### PR TITLE
Add PatternIcon component and integrate into ItemForm patterns picker

### DIFF
--- a/hangr/assets/patterns/abstract.svg
+++ b/hangr/assets/patterns/abstract.svg
@@ -1,0 +1,5 @@
+<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M3 7 Q8 2 13 7 Q18 12 22 8"/>
+  <path d="M2 12 Q7 17 12 12 Q17 7 22 13"/>
+  <path d="M3 17 Q9 22 14 17 Q19 12 22 18"/>
+</svg>

--- a/hangr/assets/patterns/animal-print.svg
+++ b/hangr/assets/patterns/animal-print.svg
@@ -1,0 +1,10 @@
+<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" fill="currentColor">
+  <ellipse cx="6"  cy="5"  rx="2.5" ry="1.8" transform="rotate(-20 6 5)"/>
+  <ellipse cx="15" cy="4"  rx="2"   ry="1.5" transform="rotate(15 15 4)"/>
+  <ellipse cx="20" cy="9"  rx="1.8" ry="2.5" transform="rotate(-10 20 9)"/>
+  <ellipse cx="4"  cy="13" rx="1.5" ry="2.2" transform="rotate(20 4 13)"/>
+  <ellipse cx="11" cy="11" rx="2.5" ry="1.8" transform="rotate(-30 11 11)"/>
+  <ellipse cx="18" cy="16" rx="2"   ry="1.5" transform="rotate(10 18 16)"/>
+  <ellipse cx="7"  cy="19" rx="2.2" ry="1.6" transform="rotate(-15 7 19)"/>
+  <ellipse cx="15" cy="20" rx="1.8" ry="2.2" transform="rotate(25 15 20)"/>
+</svg>

--- a/hangr/assets/patterns/camouflage.svg
+++ b/hangr/assets/patterns/camouflage.svg
@@ -1,0 +1,11 @@
+<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" fill="currentColor">
+  <path d="M2 2 L8 2 L10 5 L7 8 L2 7 Z" opacity="1"/>
+  <path d="M10 2 L16 2 L18 6 L13 7 L10 4 Z" opacity="0.5"/>
+  <path d="M17 3 L22 2 L22 8 L18 9 L16 6 Z" opacity="0.75"/>
+  <path d="M2 9 L6 9 L9 13 L5 15 L2 13 Z" opacity="0.6"/>
+  <path d="M8 10 L14 9 L16 13 L11 15 L8 13 Z" opacity="1"/>
+  <path d="M17 10 L22 10 L22 16 L18 16 L16 13 Z" opacity="0.5"/>
+  <path d="M2 15 L7 15 L8 19 L4 22 L2 20 Z" opacity="0.75"/>
+  <path d="M9 16 L15 15 L16 19 L12 22 L9 21 Z" opacity="0.5"/>
+  <path d="M17 17 L22 17 L22 22 L18 22 L16 20 Z" opacity="1"/>
+</svg>

--- a/hangr/assets/patterns/checkered.svg
+++ b/hangr/assets/patterns/checkered.svg
@@ -1,0 +1,24 @@
+<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" fill="currentColor">
+  <!-- Row 1 -->
+  <rect x="2"  y="2"  width="5" height="5"/>
+  <rect x="9"  y="2"  width="5" height="5"/>
+  <rect x="16" y="2"  width="6" height="5"/>
+  <!-- Row 2 -->
+  <rect x="7"  y="9"  width="5" height="5" opacity="0.35"/>
+  <rect x="14" y="9"  width="8" height="5" opacity="0.35"/>
+  <rect x="2"  y="9"  width="3" height="5" opacity="0.35"/>
+  <!-- Row 1 cols -->
+  <rect x="2"  y="2"  width="5" height="5"/>
+  <rect x="9"  y="2"  width="5" height="5"/>
+  <rect x="16" y="2"  width="6" height="5"/>
+  <!-- Even rows (offset) -->
+  <rect x="7"  y="7"  width="5" height="5"/>
+  <rect x="14" y="7"  width="8" height="5"/>
+  <!-- Odd rows -->
+  <rect x="2"  y="14" width="5" height="5"/>
+  <rect x="9"  y="14" width="5" height="5"/>
+  <rect x="16" y="14" width="6" height="5"/>
+  <!-- Even rows -->
+  <rect x="7"  y="19" width="5" height="3"/>
+  <rect x="14" y="19" width="8" height="3"/>
+</svg>

--- a/hangr/assets/patterns/color-block.svg
+++ b/hangr/assets/patterns/color-block.svg
@@ -1,0 +1,8 @@
+<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" fill="currentColor">
+  <!-- Top block -->
+  <rect x="2" y="2" width="20" height="8" rx="2" ry="2"/>
+  <!-- Bottom-left block -->
+  <path d="M2 12 H11 V22 H4 Q2 22 2 20 Z"/>
+  <!-- Bottom-right block -->
+  <path d="M13 12 H22 V20 Q22 22 20 22 H13 Z" opacity="0.5"/>
+</svg>

--- a/hangr/assets/patterns/floral.svg
+++ b/hangr/assets/patterns/floral.svg
@@ -1,0 +1,14 @@
+<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+  <!-- Center -->
+  <circle cx="12" cy="12" r="2"/>
+  <!-- Petals -->
+  <ellipse cx="12" cy="6"  rx="2" ry="3.5" />
+  <ellipse cx="12" cy="18" rx="2" ry="3.5" />
+  <ellipse cx="6"  cy="12" rx="3.5" ry="2" />
+  <ellipse cx="18" cy="12" rx="3.5" ry="2" />
+  <!-- Diagonal petals -->
+  <ellipse cx="7.5"  cy="7.5"  rx="2" ry="3.5" transform="rotate(-45 7.5 7.5)"/>
+  <ellipse cx="16.5" cy="7.5"  rx="2" ry="3.5" transform="rotate(45 16.5 7.5)"/>
+  <ellipse cx="7.5"  cy="16.5" rx="2" ry="3.5" transform="rotate(45 7.5 16.5)"/>
+  <ellipse cx="16.5" cy="16.5" rx="2" ry="3.5" transform="rotate(-45 16.5 16.5)"/>
+</svg>

--- a/hangr/assets/patterns/geometric.svg
+++ b/hangr/assets/patterns/geometric.svg
@@ -1,0 +1,15 @@
+<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+  <!-- Top row hexagons (simplified as triangles tessellated) -->
+  <polygon points="12,2 20,7 20,17 12,22 4,17 4,7"/>
+  <line x1="12" y1="2"  x2="4"  y2="7"/>
+  <line x1="12" y1="2"  x2="20" y2="7"/>
+  <line x1="4"  y1="7"  x2="20" y2="7"/>
+  <line x1="4"  y1="17" x2="20" y2="17"/>
+  <line x1="4"  y1="7"  x2="4"  y2="17"/>
+  <line x1="20" y1="7"  x2="20" y2="17"/>
+  <line x1="12" y1="2"  x2="12" y2="22"/>
+  <line x1="4"  y1="7"  x2="12" y2="12"/>
+  <line x1="20" y1="7"  x2="12" y2="12"/>
+  <line x1="4"  y1="17" x2="12" y2="12"/>
+  <line x1="20" y1="17" x2="12" y2="12"/>
+</svg>

--- a/hangr/assets/patterns/graphic.svg
+++ b/hangr/assets/patterns/graphic.svg
@@ -1,0 +1,4 @@
+<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" fill="currentColor">
+  <!-- Bold lightning bolt -->
+  <polygon points="13,2 7,13 11,13 11,22 17,11 13,11"/>
+</svg>

--- a/hangr/assets/patterns/houndstooth.svg
+++ b/hangr/assets/patterns/houndstooth.svg
@@ -1,0 +1,18 @@
+<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" fill="currentColor">
+  <!-- Top-left tile -->
+  <polygon points="0,0  6,0  12,6  9,6  6,3  6,6  3,6  6,9  6,12  0,6"/>
+  <polygon points="12,0  12,3  9,0"/>
+  <polygon points="0,12  3,12  0,9"/>
+  <!-- Top-right tile -->
+  <polygon points="12,0  18,0  24,6  21,6  18,3  18,6  15,6  18,9  18,12  12,6"/>
+  <polygon points="24,0  24,3  21,0"/>
+  <polygon points="12,12  15,12  12,9"/>
+  <!-- Bottom-left tile -->
+  <polygon points="0,12  6,12  12,18  9,18  6,15  6,18  3,18  6,21  6,24  0,18"/>
+  <polygon points="12,12  12,15  9,12"/>
+  <polygon points="0,24  3,24  0,21"/>
+  <!-- Bottom-right tile -->
+  <polygon points="12,12  18,12  24,18  21,18  18,15  18,18  15,18  18,21  18,24  12,18"/>
+  <polygon points="24,12  24,15  21,12"/>
+  <polygon points="12,24  15,24  12,21"/>
+</svg>

--- a/hangr/assets/patterns/ombre.svg
+++ b/hangr/assets/patterns/ombre.svg
@@ -1,0 +1,7 @@
+<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" fill="currentColor">
+  <rect x="2" y="2"  width="20" height="4" rx="1" opacity="0.15"/>
+  <rect x="2" y="6"  width="20" height="4" opacity="0.3"/>
+  <rect x="2" y="10" width="20" height="4" opacity="0.55"/>
+  <rect x="2" y="14" width="20" height="4" opacity="0.75"/>
+  <rect x="2" y="18" width="20" height="4" rx="1" opacity="1"/>
+</svg>

--- a/hangr/assets/patterns/other.svg
+++ b/hangr/assets/patterns/other.svg
@@ -1,0 +1,5 @@
+<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+  <circle cx="12" cy="12" r="10"/>
+  <path d="M12 17 L12 17" stroke-width="2"/>
+  <path d="M12 7 C12 7 15 8 15 11 C15 13.5 13 14 12 15"/>
+</svg>

--- a/hangr/assets/patterns/paisley.svg
+++ b/hangr/assets/patterns/paisley.svg
@@ -1,0 +1,8 @@
+<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+  <!-- Teardrop body -->
+  <path d="M12 20 C6 20 4 14 7 9 C9 5 13 3 15 5 C18 8 16 14 12 20 Z"/>
+  <!-- Inner curl -->
+  <path d="M12 17 C9 16 8 13 10 10 C11 8 13 7 14 9 C15 11 13 15 12 17"/>
+  <!-- Dot at tip -->
+  <circle cx="15" cy="5.5" r="1" fill="currentColor"/>
+</svg>

--- a/hangr/assets/patterns/plaid-tartan.svg
+++ b/hangr/assets/patterns/plaid-tartan.svg
@@ -1,0 +1,13 @@
+<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round">
+  <!-- Vertical lines -->
+  <line x1="6"  y1="2" x2="6"  y2="22"/>
+  <line x1="12" y1="2" x2="12" y2="22"/>
+  <line x1="18" y1="2" x2="18" y2="22"/>
+  <!-- Horizontal lines -->
+  <line x1="2" y1="6"  x2="22" y2="6"/>
+  <line x1="2" y1="12" x2="22" y2="12"/>
+  <line x1="2" y1="18" x2="22" y2="18"/>
+  <!-- Thicker accent lines -->
+  <line x1="12" y1="2" x2="12" y2="22" stroke-width="3" opacity="0.4"/>
+  <line x1="2"  y1="12" x2="22" y2="12" stroke-width="3" opacity="0.4"/>
+</svg>

--- a/hangr/assets/patterns/polka-dot.svg
+++ b/hangr/assets/patterns/polka-dot.svg
@@ -1,0 +1,11 @@
+<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" fill="currentColor">
+  <circle cx="5"  cy="5"  r="2"/>
+  <circle cx="12" cy="5"  r="2"/>
+  <circle cx="19" cy="5"  r="2"/>
+  <circle cx="5"  cy="12" r="2"/>
+  <circle cx="12" cy="12" r="2"/>
+  <circle cx="19" cy="12" r="2"/>
+  <circle cx="5"  cy="19" r="2"/>
+  <circle cx="12" cy="19" r="2"/>
+  <circle cx="19" cy="19" r="2"/>
+</svg>

--- a/hangr/assets/patterns/solid.svg
+++ b/hangr/assets/patterns/solid.svg
@@ -1,0 +1,3 @@
+<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" fill="currentColor">
+  <rect x="2" y="2" width="20" height="20" rx="2"/>
+</svg>

--- a/hangr/assets/patterns/striped.svg
+++ b/hangr/assets/patterns/striped.svg
@@ -1,0 +1,13 @@
+<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round">
+  <line x1="0"  y1="4"  x2="4"  y2="0"/>
+  <line x1="0"  y1="8"  x2="8"  y2="0"/>
+  <line x1="0"  y1="12" x2="12" y2="0"/>
+  <line x1="0"  y1="16" x2="16" y2="0"/>
+  <line x1="0"  y1="20" x2="20" y2="0"/>
+  <line x1="0"  y1="24" x2="24" y2="0"/>
+  <line x1="4"  y1="24" x2="24" y2="4"/>
+  <line x1="8"  y1="24" x2="24" y2="8"/>
+  <line x1="12" y1="24" x2="24" y2="12"/>
+  <line x1="16" y1="24" x2="24" y2="16"/>
+  <line x1="20" y1="24" x2="24" y2="20"/>
+</svg>

--- a/hangr/assets/patterns/tie-dye.svg
+++ b/hangr/assets/patterns/tie-dye.svg
@@ -1,0 +1,6 @@
+<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round">
+  <circle cx="12" cy="12" r="2"/>
+  <circle cx="12" cy="12" r="5"/>
+  <circle cx="12" cy="12" r="8"/>
+  <circle cx="12" cy="12" r="11"/>
+</svg>

--- a/hangr/components/PatternIcon.tsx
+++ b/hangr/components/PatternIcon.tsx
@@ -1,6 +1,8 @@
 import { Image, ImageStyle } from 'expo-image';
 import { StyleProp } from 'react-native';
 
+import { Palette } from '@/constants/tokens';
+
 // ---------------------------------------------------------------------------
 // Static map of every pattern SVG bundled in assets/patterns/.
 // Key = pattern name lowercased, spaces/slashes replaced with hyphens
@@ -48,7 +50,7 @@ type Props = {
 // Component
 // ---------------------------------------------------------------------------
 
-export function PatternIcon({ name, size = 24, color = '#FFFFFF', style }: Props) {
+export function PatternIcon({ name, size = 24, color = Palette.white, style }: Props) {
   const source = PATTERN_MAP[patternKey(name)];
   if (!source) return null;
 

--- a/hangr/components/PatternIcon.tsx
+++ b/hangr/components/PatternIcon.tsx
@@ -31,7 +31,7 @@ const PATTERN_MAP: Record<string, ReturnType<typeof require>> = {
 
 /** Derive the map key from a pattern display name (e.g. "Plaid/Tartan" → "plaid-tartan"). */
 export function patternKey(name: string): string {
-  return name.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/-+$/, '');
+  return name.trim().toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '');
 }
 
 // ---------------------------------------------------------------------------

--- a/hangr/components/PatternIcon.tsx
+++ b/hangr/components/PatternIcon.tsx
@@ -1,0 +1,62 @@
+import { Image, ImageStyle } from 'expo-image';
+import { StyleProp } from 'react-native';
+
+// ---------------------------------------------------------------------------
+// Static map of every pattern SVG bundled in assets/patterns/.
+// Key = pattern name lowercased, spaces/slashes replaced with hyphens
+// (matches the filename without .svg).
+// ---------------------------------------------------------------------------
+
+const PATTERN_MAP: Record<string, ReturnType<typeof require>> = {
+  'solid':        require('@/assets/patterns/solid.svg'),
+  'striped':      require('@/assets/patterns/striped.svg'),
+  'plaid-tartan': require('@/assets/patterns/plaid-tartan.svg'),
+  'checkered':    require('@/assets/patterns/checkered.svg'),
+  'floral':       require('@/assets/patterns/floral.svg'),
+  'geometric':    require('@/assets/patterns/geometric.svg'),
+  'animal-print': require('@/assets/patterns/animal-print.svg'),
+  'abstract':     require('@/assets/patterns/abstract.svg'),
+  'tie-dye':      require('@/assets/patterns/tie-dye.svg'),
+  'camouflage':   require('@/assets/patterns/camouflage.svg'),
+  'paisley':      require('@/assets/patterns/paisley.svg'),
+  'polka-dot':    require('@/assets/patterns/polka-dot.svg'),
+  'houndstooth':  require('@/assets/patterns/houndstooth.svg'),
+  'graphic':      require('@/assets/patterns/graphic.svg'),
+  'color-block':  require('@/assets/patterns/color-block.svg'),
+  'ombre':        require('@/assets/patterns/ombre.svg'),
+  'other':        require('@/assets/patterns/other.svg'),
+};
+
+/** Derive the map key from a pattern display name (e.g. "Plaid/Tartan" → "plaid-tartan"). */
+export function patternKey(name: string): string {
+  return name.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/-+$/, '');
+}
+
+// ---------------------------------------------------------------------------
+// Props
+// ---------------------------------------------------------------------------
+
+type Props = {
+  /** Pattern display name as stored in the DB (e.g. "Plaid/Tartan"). */
+  name: string;
+  size?: number;
+  color?: string;
+  style?: StyleProp<ImageStyle>;
+};
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export function PatternIcon({ name, size = 24, color = '#FFFFFF', style }: Props) {
+  const source = PATTERN_MAP[patternKey(name)];
+  if (!source) return null;
+
+  return (
+    <Image
+      source={source}
+      style={[{ width: size, height: size, tintColor: color }, style]}
+      contentFit="contain"
+    />
+  );
+}

--- a/hangr/components/clothing/ItemForm.tsx
+++ b/hangr/components/clothing/ItemForm.tsx
@@ -31,6 +31,7 @@ import {
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import { FontSize, FontWeight, Palette, Radius, Spacing } from '@/constants/tokens';
+import { PatternIcon } from '@/components/PatternIcon';
 import { PhosphorIcon } from '@/components/PhosphorIcon';
 import { useAccent } from '@/context/AccentContext';
 import { useSettings } from '@/context/SettingsContext';
@@ -784,6 +785,9 @@ export function ItemForm({ initialValues = EMPTY_FORM, onSubmit, submitLabel, su
         items={patterns}
         selectedIds={values.patternIds}
         onToggle={(id) => toggleMulti('patternIds', id)}
+        renderDot={(pattern) => (
+          <PatternIcon name={pattern.name} size={16} color={Palette.textSecondary} />
+        )}
       />
       <PickerSheet
         visible={openSheet === 'seasons'}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pattern previews now display as SVG icons in the patterns picker, showing a small patterned icon next to each option to make selection faster and more intuitive.
  * The icons appear alongside existing color indicators, scale consistently with other picker items, and respect the app’s current color styling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->