### PR TITLE
Add clothing detail view with interactions and filtering

### DIFF
--- a/app-android/app/src/main/kotlin/com/closet/navigation/ClosetNavGraph.kt
+++ b/app-android/app/src/main/kotlin/com/closet/navigation/ClosetNavGraph.kt
@@ -9,6 +9,7 @@ import androidx.navigation.compose.rememberNavController
 import com.closet.features.wardrobe.ClosetDestination
 import com.closet.features.wardrobe.ClosetScreen
 import com.closet.features.wardrobe.ClothingDetailDestination
+import com.closet.features.wardrobe.ClothingDetailScreen
 
 @Composable
 fun ClosetNavGraph(
@@ -29,7 +30,9 @@ fun ClosetNavGraph(
         }
         
         composable<ClothingDetailDestination> { 
-            // TODO: Implement ClothingDetailScreen
+            ClothingDetailScreen(
+                onBackClick = { navController.popBackStack() }
+            )
         }
     }
 }

--- a/app-android/core/data/src/main/kotlin/com/closet/core/data/dao/ClothingDao.kt
+++ b/app-android/core/data/src/main/kotlin/com/closet/core/data/dao/ClothingDao.kt
@@ -19,7 +19,7 @@ interface ClothingDao {
      */
     @Query("""
         SELECT
-            ci.id, ci.name, ci.brand, ci.image_path, ci.purchase_price, ci.status, ci.is_favorite,
+            ci.id, ci.name, ci.brand, ci.image_path, ci.purchase_price, ci.status, ci.is_favorite, ci.wash_status,
             c.name  AS category_name,
             sc.name AS subcategory_name,
             (
@@ -42,7 +42,7 @@ interface ClothingDao {
      */
     @Query("""
         SELECT
-            ci.id, ci.name, ci.brand, ci.image_path, ci.purchase_price, ci.status, ci.is_favorite,
+            ci.id, ci.name, ci.brand, ci.image_path, ci.purchase_price, ci.status, ci.is_favorite, ci.wash_status,
             c.name  AS category_name,
             sc.name AS subcategory_name,
             (

--- a/app-android/core/data/src/main/kotlin/com/closet/core/data/dao/ClothingDao.kt
+++ b/app-android/core/data/src/main/kotlin/com/closet/core/data/dao/ClothingDao.kt
@@ -85,16 +85,16 @@ interface ClothingDao {
      * @param id The ID of the clothing item.
      * @param washStatus The new wash status label.
      */
-    @Query("UPDATE clothing_items SET wash_status = :washStatus, updated_at = datetime('now') WHERE id = :id")
-    suspend fun updateWashStatus(id: Long, washStatus: String)
+    @Query("UPDATE clothing_items SET wash_status = :washStatus, updated_at = :updatedAt WHERE id = :id")
+    suspend fun updateWashStatus(id: Long, washStatus: String, updatedAt: String)
 
     /**
      * Updates the favorite status and modification timestamp for a specific clothing item.
      * @param id The ID of the clothing item.
      * @param isFavorite 1 if favorite, 0 otherwise.
      */
-    @Query("UPDATE clothing_items SET is_favorite = :isFavorite, updated_at = datetime('now') WHERE id = :id")
-    suspend fun updateFavoriteStatus(id: Long, isFavorite: Int)
+    @Query("UPDATE clothing_items SET is_favorite = :isFavorite, updated_at = :updatedAt WHERE id = :id")
+    suspend fun updateFavoriteStatus(id: Long, isFavorite: Int, updatedAt: String)
 
     // --- Junction Table Helpers (Atomically replace associations) ---
 

--- a/app-android/core/data/src/main/kotlin/com/closet/core/data/dao/ClothingDao.kt
+++ b/app-android/core/data/src/main/kotlin/com/closet/core/data/dao/ClothingDao.kt
@@ -88,6 +88,14 @@ interface ClothingDao {
     @Query("UPDATE clothing_items SET wash_status = :washStatus, updated_at = datetime('now') WHERE id = :id")
     suspend fun updateWashStatus(id: Long, washStatus: String)
 
+    /**
+     * Updates the favorite status and modification timestamp for a specific clothing item.
+     * @param id The ID of the clothing item.
+     * @param isFavorite 1 if favorite, 0 otherwise.
+     */
+    @Query("UPDATE clothing_items SET is_favorite = :isFavorite, updated_at = datetime('now') WHERE id = :id")
+    suspend fun updateFavoriteStatus(id: Long, isFavorite: Int)
+
     // --- Junction Table Helpers (Atomically replace associations) ---
 
     /**

--- a/app-android/core/data/src/main/kotlin/com/closet/core/data/model/ClothingItemEntity.kt
+++ b/app-android/core/data/src/main/kotlin/com/closet/core/data/model/ClothingItemEntity.kt
@@ -109,13 +109,14 @@ data class ClothingItemWithMeta(
     val purchasePrice: Double?,
     val status: ClothingStatus,
     @ColumnInfo(name = "is_favorite")
-    val isFavorite: Int
+    val isFavorite: Int,
+    @ColumnInfo(name = "wash_status")
+    val washStatus: WashStatus
 ) {
     /** 
      * Computed at runtime for parity with "built well" rules.
      * purchase_price / wear_count
      */
-    @Suppress("unused")
     val costPerWear: Double?
         get() = if (wearCount > 0) (purchasePrice ?: 0.0) / wearCount else purchasePrice
 }

--- a/app-android/core/data/src/main/kotlin/com/closet/core/data/repository/ClothingRepository.kt
+++ b/app-android/core/data/src/main/kotlin/com/closet/core/data/repository/ClothingRepository.kt
@@ -106,6 +106,21 @@ class ClothingRepository @Inject constructor(
         DataResult.Error(AppError.DatabaseError.QueryError(e))
     }
 
+    /**
+     * Toggles the favorite status for a specific clothing item.
+     * @param id The ID of the item.
+     * @param isFavorite Whether the item should be marked as favorite.
+     * @return A [DataResult] indicating success or failure.
+     */
+    suspend fun updateFavoriteStatus(id: Long, isFavorite: Boolean): DataResult<Unit> = try {
+        clothingDao.updateFavoriteStatus(id, if (isFavorite) 1 else 0)
+        DataResult.Success(Unit)
+    } catch (e: Exception) {
+        if (e is CancellationException) throw e
+        Timber.e(e, "Error updating favorite status for item: $id")
+        DataResult.Error(AppError.DatabaseError.QueryError(e))
+    }
+
     // --- Junction Table Management ---
     // Atomic updates using withTransaction to ensure data integrity.
 
@@ -152,7 +167,7 @@ class ClothingRepository @Inject constructor(
     /**
      * Atomically replaces pattern associations for an item.
      * @param itemId The ID of the clothing item.
-     * @param patternIds The list of new pattern IDs.
+     * @param patternIds El list of new pattern IDs.
      */
     suspend fun updateItemPatterns(itemId: Long, patternIds: List<Long>): DataResult<Unit> = wrapInTransaction {
         clothingDao.deleteItemPatterns(itemId)

--- a/app-android/core/data/src/main/kotlin/com/closet/core/data/repository/ClothingRepository.kt
+++ b/app-android/core/data/src/main/kotlin/com/closet/core/data/repository/ClothingRepository.kt
@@ -2,6 +2,7 @@ package com.closet.core.data.repository
 
 import androidx.room.withTransaction
 import com.closet.core.data.ClothingDatabase
+import com.closet.core.data.Converters
 import com.closet.core.data.dao.ClothingDao
 import com.closet.core.data.model.*
 import com.closet.core.data.util.AppError
@@ -11,6 +12,7 @@ import timber.log.Timber
 import javax.inject.Inject
 import javax.inject.Singleton
 import kotlinx.coroutines.CancellationException
+import java.time.Instant
 
 /**
  * Repository providing access to clothing items.
@@ -22,6 +24,8 @@ class ClothingRepository @Inject constructor(
     private val database: ClothingDatabase,
     private val clothingDao: ClothingDao
 ) {
+    private val converters = Converters()
+
     /**
      * Retrieves all clothing items as a stream.
      * @return A [Flow] emitting a list of [ClothingItemWithMeta].
@@ -98,7 +102,8 @@ class ClothingRepository @Inject constructor(
      * @return A [DataResult] indicating success or failure.
      */
     suspend fun updateWashStatus(id: Long, washStatus: WashStatus): DataResult<Unit> = try {
-        clothingDao.updateWashStatus(id, washStatus.label)
+        val updatedAt = converters.dateToTimestamp(Instant.now()) ?: ""
+        clothingDao.updateWashStatus(id, washStatus.label, updatedAt)
         DataResult.Success(Unit)
     } catch (e: Exception) {
         if (e is CancellationException) throw e
@@ -113,7 +118,8 @@ class ClothingRepository @Inject constructor(
      * @return A [DataResult] indicating success or failure.
      */
     suspend fun updateFavoriteStatus(id: Long, isFavorite: Boolean): DataResult<Unit> = try {
-        clothingDao.updateFavoriteStatus(id, if (isFavorite) 1 else 0)
+        val updatedAt = converters.dateToTimestamp(Instant.now()) ?: ""
+        clothingDao.updateFavoriteStatus(id, if (isFavorite) 1 else 0, updatedAt)
         DataResult.Success(Unit)
     } catch (e: Exception) {
         if (e is CancellationException) throw e
@@ -167,7 +173,7 @@ class ClothingRepository @Inject constructor(
     /**
      * Atomically replaces pattern associations for an item.
      * @param itemId The ID of the clothing item.
-     * @param patternIds El list of new pattern IDs.
+     * @param patternIds The list of new pattern IDs.
      */
     suspend fun updateItemPatterns(itemId: Long, patternIds: List<Long>): DataResult<Unit> = wrapInTransaction {
         clothingDao.deleteItemPatterns(itemId)

--- a/app-android/features/wardrobe/build.gradle.kts
+++ b/app-android/features/wardrobe/build.gradle.kts
@@ -41,6 +41,7 @@ dependencies {
     implementation(libs.androidx.ui)
     implementation(libs.androidx.material3)
     implementation(libs.androidx.ui.tooling.preview)
+    implementation(libs.androidx.compose.material.icons.extended)
     debugImplementation(libs.androidx.ui.tooling)
 
     // Navigation

--- a/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/ClosetScreen.kt
+++ b/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/ClosetScreen.kt
@@ -64,14 +64,18 @@ internal fun ClosetContent(
     modifier: Modifier = Modifier
 ) {
     Scaffold(
-        modifier = modifier,
+        modifier = modifier.fillMaxSize(),
         topBar = {
             CenterAlignedTopAppBar(
                 title = { Text(stringResource(R.string.wardrobe_my_closet)) }
             )
         }
     ) { padding ->
-        Column(modifier = Modifier.padding(padding)) {
+        Column(
+            modifier = Modifier
+                .padding(padding)
+                .fillMaxSize()
+        ) {
             CategoryFilterRow(
                 categories = categories,
                 selectedCategoryId = selectedCategoryId,
@@ -79,11 +83,12 @@ internal fun ClosetContent(
             )
             
             if (items.isEmpty()) {
-                EmptyClosetMessage()
+                EmptyClosetMessage(modifier = Modifier.weight(1f))
             } else {
                 ClosetGrid(
                     items = items,
-                    onItemClick = onItemClick
+                    onItemClick = onItemClick,
+                    modifier = Modifier.weight(1f)
                 )
             }
         }
@@ -105,7 +110,7 @@ private fun CategoryFilterRow(
         contentPadding = PaddingValues(horizontal = 16.dp, vertical = 8.dp),
         horizontalArrangement = Arrangement.spacedBy(8.dp)
     ) {
-        item {
+        item(key = "all") {
             FilterChip(
                 selected = selectedCategoryId == null,
                 onClick = { onCategorySelect(null) },

--- a/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/ClosetScreen.kt
+++ b/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/ClosetScreen.kt
@@ -1,9 +1,11 @@
 package com.closet.features.wardrobe
 
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
@@ -13,6 +15,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.closet.core.data.model.CategoryEntity
 import com.closet.core.data.model.ClothingItemWithMeta
 import com.closet.core.data.model.ClothingStatus
 import com.closet.core.data.model.WashStatus
@@ -34,9 +37,14 @@ fun ClosetScreen(
     viewModel: ClosetViewModel = hiltViewModel()
 ) {
     val items by viewModel.items.collectAsStateWithLifecycle()
+    val categories by viewModel.categories.collectAsStateWithLifecycle()
+    val selectedCategoryId by viewModel.selectedCategoryId.collectAsStateWithLifecycle()
 
     ClosetContent(
         items = items,
+        categories = categories,
+        selectedCategoryId = selectedCategoryId,
+        onCategorySelect = viewModel::selectCategory,
         onItemClick = onItemClick,
         modifier = modifier
     )
@@ -49,6 +57,9 @@ fun ClosetScreen(
 @Composable
 internal fun ClosetContent(
     items: List<ClothingItemWithMeta>,
+    categories: List<CategoryEntity>,
+    selectedCategoryId: Long?,
+    onCategorySelect: (Long?) -> Unit,
     onItemClick: (Long) -> Unit,
     modifier: Modifier = Modifier
 ) {
@@ -60,13 +71,52 @@ internal fun ClosetContent(
             )
         }
     ) { padding ->
-        if (items.isEmpty()) {
-            EmptyClosetMessage(modifier = Modifier.padding(padding))
-        } else {
-            ClosetGrid(
-                items = items,
-                onItemClick = onItemClick,
-                modifier = Modifier.padding(padding)
+        Column(modifier = Modifier.padding(padding)) {
+            CategoryFilterRow(
+                categories = categories,
+                selectedCategoryId = selectedCategoryId,
+                onCategorySelect = onCategorySelect
+            )
+            
+            if (items.isEmpty()) {
+                EmptyClosetMessage()
+            } else {
+                ClosetGrid(
+                    items = items,
+                    onItemClick = onItemClick
+                )
+            }
+        }
+    }
+}
+
+/**
+ * A horizontal row of filter chips for categories.
+ */
+@Composable
+private fun CategoryFilterRow(
+    categories: List<CategoryEntity>,
+    selectedCategoryId: Long?,
+    onCategorySelect: (Long?) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    LazyRow(
+        modifier = modifier.fillMaxWidth(),
+        contentPadding = PaddingValues(horizontal = 16.dp, vertical = 8.dp),
+        horizontalArrangement = Arrangement.spacedBy(8.dp)
+    ) {
+        item {
+            FilterChip(
+                selected = selectedCategoryId == null,
+                onClick = { onCategorySelect(null) },
+                label = { Text(stringResource(R.string.wardrobe_all_items)) }
+            )
+        }
+        items(categories, key = { it.id }) { category ->
+            FilterChip(
+                selected = selectedCategoryId == category.id,
+                onClick = { onCategorySelect(category.id) },
+                label = { Text(category.name) }
             )
         }
     }
@@ -153,21 +203,15 @@ private fun ClosetScreenPreview() {
                         status = ClothingStatus.Active,
                         isFavorite = 0,
                         washStatus = WashStatus.Dirty
-                    ),
-                    ClothingItemWithMeta(
-                        id = 3,
-                        name = "Black Chinos",
-                        brand = "Everlane",
-                        categoryName = "Pants",
-                        subcategoryName = "Chinos",
-                        imagePath = null,
-                        wearCount = 20,
-                        purchasePrice = 68.00,
-                        status = ClothingStatus.Active,
-                        isFavorite = 1,
-                        washStatus = WashStatus.Clean
                     )
                 ),
+                categories = listOf(
+                    CategoryEntity(id = 1, name = "Tops", sortOrder = 1),
+                    CategoryEntity(id = 2, name = "Pants", sortOrder = 2),
+                    CategoryEntity(id = 3, name = "Outerwear", sortOrder = 3)
+                ),
+                selectedCategoryId = null,
+                onCategorySelect = {},
                 onItemClick = {}
             )
         }
@@ -181,6 +225,9 @@ private fun ClosetScreenEmptyPreview() {
         Surface {
             ClosetContent(
                 items = emptyList(),
+                categories = emptyList(),
+                selectedCategoryId = null,
+                onCategorySelect = {},
                 onItemClick = {}
             )
         }

--- a/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/ClosetScreen.kt
+++ b/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/ClosetScreen.kt
@@ -9,11 +9,15 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.closet.core.data.model.ClothingItemWithMeta
+import com.closet.core.data.model.ClothingStatus
+import com.closet.core.data.model.WashStatus
 import com.closet.core.ui.components.ClothingItemCard
+import com.closet.core.ui.theme.ClosetTheme
 
 /**
  * The main screen for browsing the wardrobe (Closet).
@@ -23,7 +27,6 @@ import com.closet.core.ui.components.ClothingItemCard
  * @param onItemClick Callback invoked when a clothing item is tapped, passing its ID.
  * @param viewModel The [ClosetViewModel] providing state for this screen.
  */
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun ClosetScreen(
     modifier: Modifier = Modifier,
@@ -32,6 +35,23 @@ fun ClosetScreen(
 ) {
     val items by viewModel.items.collectAsStateWithLifecycle()
 
+    ClosetContent(
+        items = items,
+        onItemClick = onItemClick,
+        modifier = modifier
+    )
+}
+
+/**
+ * Content of the Closet screen, decoupled from ViewModel for previews.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+internal fun ClosetContent(
+    items: List<ClothingItemWithMeta>,
+    onItemClick: (Long) -> Unit,
+    modifier: Modifier = Modifier
+) {
     Scaffold(
         modifier = modifier,
         topBar = {
@@ -97,5 +117,72 @@ private fun EmptyClosetMessage(modifier: Modifier = Modifier) {
         contentAlignment = androidx.compose.ui.Alignment.Center
     ) {
         Text(stringResource(R.string.wardrobe_empty_closet))
+    }
+}
+
+@Preview(showBackground = true, name = "Items - Light")
+@Preview(showBackground = true, uiMode = android.content.res.Configuration.UI_MODE_NIGHT_YES, name = "Items - Dark")
+@Composable
+private fun ClosetScreenPreview() {
+    ClosetTheme {
+        Surface {
+            ClosetContent(
+                items = listOf(
+                    ClothingItemWithMeta(
+                        id = 1,
+                        name = "Vintage Denim Jacket",
+                        brand = "Levi's",
+                        categoryName = "Outerwear",
+                        subcategoryName = "Jackets",
+                        imagePath = null,
+                        wearCount = 12,
+                        purchasePrice = 89.99,
+                        status = ClothingStatus.Active,
+                        isFavorite = 1,
+                        washStatus = WashStatus.Clean
+                    ),
+                    ClothingItemWithMeta(
+                        id = 2,
+                        name = "White Linen Shirt",
+                        brand = "Uniqlo",
+                        categoryName = "Tops",
+                        subcategoryName = "Shirts",
+                        imagePath = null,
+                        wearCount = 5,
+                        purchasePrice = 29.90,
+                        status = ClothingStatus.Active,
+                        isFavorite = 0,
+                        washStatus = WashStatus.Dirty
+                    ),
+                    ClothingItemWithMeta(
+                        id = 3,
+                        name = "Black Chinos",
+                        brand = "Everlane",
+                        categoryName = "Pants",
+                        subcategoryName = "Chinos",
+                        imagePath = null,
+                        wearCount = 20,
+                        purchasePrice = 68.00,
+                        status = ClothingStatus.Active,
+                        isFavorite = 1,
+                        washStatus = WashStatus.Clean
+                    )
+                ),
+                onItemClick = {}
+            )
+        }
+    }
+}
+
+@Preview(showBackground = true, name = "Empty State")
+@Composable
+private fun ClosetScreenEmptyPreview() {
+    ClosetTheme {
+        Surface {
+            ClosetContent(
+                items = emptyList(),
+                onItemClick = {}
+            )
+        }
     }
 }

--- a/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/ClosetViewModel.kt
+++ b/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/ClosetViewModel.kt
@@ -7,9 +7,7 @@ import com.closet.core.data.model.ClothingItemWithMeta
 import com.closet.core.data.repository.ClothingRepository
 import com.closet.core.data.repository.LookupRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.flow.SharingStarted
-import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.flow.*
 import javax.inject.Inject
 
 /**
@@ -27,17 +25,39 @@ class ClosetViewModel @Inject constructor(
         private const val SHARED_SUBSCRIPTION_TIMEOUT_MS = 5000L
     }
 
+    private val _selectedCategoryId = MutableStateFlow<Long?>(null)
+    val selectedCategoryId: StateFlow<Long?> = _selectedCategoryId.asStateFlow()
+
     /**
      * The list of clothing items to display in the grid.
      * Items are provided with metadata like category names and wear counts.
      * Parity: Mirrored order (newest first) and includes wear_count.
+     * Logic: Filters items based on the selected category if one is set.
      */
-    val items: StateFlow<List<ClothingItemWithMeta>> = clothingRepository.getAllItems()
-        .stateIn(
-            scope = viewModelScope,
-            started = SharingStarted.WhileSubscribed(SHARED_SUBSCRIPTION_TIMEOUT_MS),
-            initialValue = emptyList()
-        )
+    val items: StateFlow<List<ClothingItemWithMeta>> = combine(
+        clothingRepository.getAllItems(),
+        _selectedCategoryId
+    ) { allItems, selectedId ->
+        if (selectedId == null) {
+            allItems
+        } else {
+            // Note: In a larger DB, we'd move this filter to the DAO/Repository.
+            // For Closet's local-first scale, in-memory filtering is performant.
+            // We match by categoryName since ClothingItemWithMeta doesn't expose categoryId directly yet,
+            // but for robustness we should ideally use IDs if we update the model.
+            // Checking the category name from the entity list:
+            val selectedCategoryName = categories.value.find { it.id == selectedId }?.name
+            if (selectedCategoryName != null) {
+                allItems.filter { it.categoryName == selectedCategoryName }
+            } else {
+                allItems
+            }
+        }
+    }.stateIn(
+        scope = viewModelScope,
+        started = SharingStarted.WhileSubscribed(SHARED_SUBSCRIPTION_TIMEOUT_MS),
+        initialValue = emptyList()
+    )
 
     /**
      * Available categories for filtering items in the main grid.
@@ -48,4 +68,12 @@ class ClosetViewModel @Inject constructor(
             started = SharingStarted.WhileSubscribed(SHARED_SUBSCRIPTION_TIMEOUT_MS),
             initialValue = emptyList()
         )
+
+    /**
+     * Updates the currently selected category filter.
+     * @param categoryId The ID of the category to filter by, or null to clear filter.
+     */
+    fun selectCategory(categoryId: Long?) {
+        _selectedCategoryId.value = categoryId
+    }
 }

--- a/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/ClosetViewModel.kt
+++ b/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/ClosetViewModel.kt
@@ -7,7 +7,12 @@ import com.closet.core.data.model.ClothingItemWithMeta
 import com.closet.core.data.repository.ClothingRepository
 import com.closet.core.data.repository.LookupRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.flow.*
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.stateIn
 import javax.inject.Inject
 
 /**

--- a/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/ClosetViewModel.kt
+++ b/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/ClosetViewModel.kt
@@ -29,24 +29,30 @@ class ClosetViewModel @Inject constructor(
     val selectedCategoryId: StateFlow<Long?> = _selectedCategoryId.asStateFlow()
 
     /**
+     * Available categories for filtering items in the main grid.
+     */
+    val categories: StateFlow<List<CategoryEntity>> = lookupRepository.getCategories()
+        .stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.WhileSubscribed(SHARED_SUBSCRIPTION_TIMEOUT_MS),
+            initialValue = emptyList()
+        )
+
+    /**
      * The list of clothing items to display in the grid.
      * Items are provided with metadata like category names and wear counts.
-     * Parity: Mirrored order (newest first) and includes wear_count.
      * Logic: Filters items based on the selected category if one is set.
+     * Refined: Includes categories flow in combine to trigger recomputation on category updates.
      */
     val items: StateFlow<List<ClothingItemWithMeta>> = combine(
         clothingRepository.getAllItems(),
-        _selectedCategoryId
-    ) { allItems, selectedId ->
+        _selectedCategoryId,
+        categories
+    ) { allItems, selectedId, categoriesList ->
         if (selectedId == null) {
             allItems
         } else {
-            // Note: In a larger DB, we'd move this filter to the DAO/Repository.
-            // For Closet's local-first scale, in-memory filtering is performant.
-            // We match by categoryName since ClothingItemWithMeta doesn't expose categoryId directly yet,
-            // but for robustness we should ideally use IDs if we update the model.
-            // Checking the category name from the entity list:
-            val selectedCategoryName = categories.value.find { it.id == selectedId }?.name
+            val selectedCategoryName = categoriesList.find { it.id == selectedId }?.name
             if (selectedCategoryName != null) {
                 allItems.filter { it.categoryName == selectedCategoryName }
             } else {
@@ -58,16 +64,6 @@ class ClosetViewModel @Inject constructor(
         started = SharingStarted.WhileSubscribed(SHARED_SUBSCRIPTION_TIMEOUT_MS),
         initialValue = emptyList()
     )
-
-    /**
-     * Available categories for filtering items in the main grid.
-     */
-    val categories: StateFlow<List<CategoryEntity>> = lookupRepository.getCategories()
-        .stateIn(
-            scope = viewModelScope,
-            started = SharingStarted.WhileSubscribed(SHARED_SUBSCRIPTION_TIMEOUT_MS),
-            initialValue = emptyList()
-        )
 
     /**
      * Updates the currently selected category filter.

--- a/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/ClothingDetailScreen.kt
+++ b/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/ClothingDetailScreen.kt
@@ -1,6 +1,9 @@
 package com.closet.features.wardrobe
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material3.*
@@ -8,10 +11,13 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import coil.compose.AsyncImage
 import com.closet.core.data.model.ClothingItemWithMeta
 
 /**
@@ -98,7 +104,6 @@ private fun ErrorContent(
 
 /**
  * Displays the successful content of the clothing item details.
- * TODO: Implement detailed item view in the next step.
  */
 @Composable
 private fun ClothingDetailContent(
@@ -108,9 +113,49 @@ private fun ClothingDetailContent(
     Column(
         modifier = modifier
             .fillMaxSize()
-            .padding(16.dp)
+            .verticalScroll(rememberScrollState())
     ) {
-        Text(text = "Details for: ${item.name}", style = MaterialTheme.typography.headlineMedium)
-        // More details will be added here in Step 2.2
+        // Hero Image Section
+        Surface(
+            modifier = Modifier
+                .fillMaxWidth()
+                .aspectRatio(1f),
+            color = MaterialTheme.colorScheme.surfaceVariant,
+            shape = MaterialTheme.shapes.medium
+        ) {
+            AsyncImage(
+                model = item.imagePath,
+                contentDescription = item.name,
+                modifier = Modifier
+                    .fillMaxSize()
+                    .clip(MaterialTheme.shapes.medium),
+                contentScale = ContentScale.Crop
+            )
+        }
+
+        Spacer(modifier = Modifier.height(24.dp))
+
+        // Header Info Section
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp)
+        ) {
+            Text(
+                text = item.name,
+                style = MaterialTheme.typography.headlineMedium,
+                color = MaterialTheme.colorScheme.onBackground
+            )
+            
+            item.brand?.let {
+                Text(
+                    text = it,
+                    style = MaterialTheme.typography.titleMedium,
+                    color = MaterialTheme.colorScheme.secondary
+                )
+            }
+        }
+        
+        // Additional sections will follow (Tags, Stats, etc.)
     }
 }

--- a/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/ClothingDetailScreen.kt
+++ b/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/ClothingDetailScreen.kt
@@ -1,6 +1,5 @@
 package com.closet.features.wardrobe
 
-import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
@@ -114,6 +113,7 @@ private fun ClothingDetailContent(
         modifier = modifier
             .fillMaxSize()
             .verticalScroll(rememberScrollState())
+            .padding(16.dp)
     ) {
         // Hero Image Section
         Surface(
@@ -136,11 +136,7 @@ private fun ClothingDetailContent(
         Spacer(modifier = Modifier.height(24.dp))
 
         // Header Info Section
-        Column(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(horizontal = 16.dp)
-        ) {
+        Column(modifier = Modifier.fillMaxWidth()) {
             Text(
                 text = item.name,
                 style = MaterialTheme.typography.headlineMedium,
@@ -155,7 +151,90 @@ private fun ClothingDetailContent(
                 )
             }
         }
-        
-        // Additional sections will follow (Tags, Stats, etc.)
+
+        Spacer(modifier = Modifier.height(24.dp))
+
+        // Details Group Card
+        DetailGroup(
+            category = item.categoryName,
+            subcategory = item.subcategoryName
+        )
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        // Appearance Group (Chips)
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            SuggestionChip(
+                onClick = { /* Status change handled in next phase */ },
+                label = { Text(item.status.label) }
+            )
+            
+            // Note: WashStatus is not in ClothingItemWithMeta, we'll need to update it
+            // For now, using Status as a placeholder for the look.
+            AssistChip(
+                onClick = { /* Toggle wash handled in next phase */ },
+                label = { Text("Clean") }, // Placeholder label
+                leadingIcon = {
+                    // We can add an icon here later if desired
+                }
+            )
+        }
+    }
+}
+
+/**
+ * Card displaying primary metadata like Category and Subcategory.
+ */
+@Composable
+private fun DetailGroup(
+    category: String?,
+    subcategory: String?,
+    modifier: Modifier = Modifier
+) {
+    Card(
+        modifier = modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surfaceVariant
+        )
+    ) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            DetailRow(label = "Category", value = category ?: "Uncategorized")
+            if (subcategory != null) {
+                HorizontalDivider(
+                    modifier = Modifier.padding(vertical = 8.dp),
+                    thickness = 0.5.dp,
+                    color = MaterialTheme.colorScheme.outlineVariant
+                )
+                DetailRow(label = "Subcategory", value = subcategory)
+            }
+        }
+    }
+}
+
+/**
+ * A single row within a detail group.
+ */
+@Composable
+private fun DetailRow(
+    label: String,
+    value: String
+) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceBetween
+    ) {
+        Text(
+            text = label,
+            style = MaterialTheme.typography.labelLarge,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+        Text(
+            text = value,
+            style = MaterialTheme.typography.bodyLarge,
+            color = MaterialTheme.colorScheme.onSurface
+        )
     }
 }

--- a/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/ClothingDetailScreen.kt
+++ b/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/ClothingDetailScreen.kt
@@ -46,8 +46,8 @@ fun ClothingDetailScreen(
     if (showDeleteDialog) {
         AlertDialog(
             onDismissRequest = { showDeleteDialog = false },
-            title = { Text("Delete Item") },
-            text = { Text("Are you sure you want to delete this item? This action cannot be undone.") },
+            title = { Text(stringResource(R.string.wardrobe_delete_item_title)) },
+            text = { Text(stringResource(R.string.wardrobe_delete_item_confirmation)) },
             confirmButton = {
                 TextButton(
                     onClick = {
@@ -56,12 +56,12 @@ fun ClothingDetailScreen(
                     },
                     colors = ButtonDefaults.textButtonColors(contentColor = MaterialTheme.colorScheme.error)
                 ) {
-                    Text("Delete")
+                    Text(stringResource(R.string.wardrobe_delete))
                 }
             },
             dismissButton = {
                 TextButton(onClick = { showDeleteDialog = false }) {
-                    Text("Cancel")
+                    Text(stringResource(R.string.wardrobe_cancel))
                 }
             }
         )
@@ -82,7 +82,7 @@ fun ClothingDetailScreen(
                     IconButton(onClick = onBackClick) {
                         Icon(
                             imageVector = Icons.AutoMirrored.Filled.ArrowBack,
-                            contentDescription = "Back"
+                            contentDescription = stringResource(R.string.wardrobe_back)
                         )
                     }
                 },
@@ -92,15 +92,21 @@ fun ClothingDetailScreen(
                         IconButton(onClick = { viewModel.toggleFavorite() }) {
                             Icon(
                                 imageVector = if (state.item.isFavorite == 1) Icons.Default.Favorite else Icons.Default.FavoriteBorder,
-                                contentDescription = "Favorite",
+                                contentDescription = stringResource(R.string.wardrobe_favorite),
                                 tint = if (state.item.isFavorite == 1) Color.Red else LocalContentColor.current
                             )
                         }
                         IconButton(onClick = { /* Placeholder for Edit */ }) {
-                            Icon(imageVector = Icons.Default.Edit, contentDescription = "Edit")
+                            Icon(
+                                imageVector = Icons.Default.Edit,
+                                contentDescription = stringResource(R.string.wardrobe_edit)
+                            )
                         }
                         IconButton(onClick = { showDeleteDialog = true }) {
-                            Icon(imageVector = Icons.Default.Delete, contentDescription = "Delete")
+                            Icon(
+                                imageVector = Icons.Default.Delete,
+                                contentDescription = stringResource(R.string.wardrobe_delete)
+                            )
                         }
                     }
                 }
@@ -266,7 +272,7 @@ private fun StatsGroup(
         ) {
             Column(horizontalAlignment = Alignment.CenterHorizontally) {
                 Text(
-                    text = "Usage",
+                    text = stringResource(R.string.wardrobe_usage),
                     style = MaterialTheme.typography.labelMedium,
                     color = MaterialTheme.colorScheme.onSecondaryContainer
                 )
@@ -289,7 +295,7 @@ private fun StatsGroup(
 
             Column(horizontalAlignment = Alignment.CenterHorizontally) {
                 Text(
-                    text = "Cost per wear",
+                    text = stringResource(R.string.wardrobe_cost_per_wear),
                     style = MaterialTheme.typography.labelMedium,
                     color = MaterialTheme.colorScheme.onSecondaryContainer
                 )
@@ -319,14 +325,20 @@ private fun DetailGroup(
         )
     ) {
         Column(modifier = Modifier.padding(16.dp)) {
-            DetailRow(label = "Category", value = category ?: "Uncategorized")
+            DetailRow(
+                label = stringResource(R.string.wardrobe_category),
+                value = category ?: stringResource(R.string.wardrobe_uncategorized)
+            )
             if (subcategory != null) {
                 HorizontalDivider(
                     modifier = Modifier.padding(vertical = 8.dp),
                     thickness = 0.5.dp,
                     color = MaterialTheme.colorScheme.outlineVariant
                 )
-                DetailRow(label = "Subcategory", value = subcategory)
+                DetailRow(
+                    label = stringResource(R.string.wardrobe_subcategory),
+                    value = subcategory
+                )
             }
         }
     }

--- a/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/ClothingDetailScreen.kt
+++ b/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/ClothingDetailScreen.kt
@@ -1,0 +1,116 @@
+package com.closet.features.wardrobe
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.*
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.closet.core.data.model.ClothingItemWithMeta
+
+/**
+ * Screen for viewing the details of a specific clothing item.
+ *
+ * @param onBackClick Callback to navigate back to the previous screen.
+ * @param modifier The [Modifier] to be applied to the screen.
+ * @param viewModel The [ClothingDetailViewModel] providing state for this screen.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ClothingDetailScreen(
+    onBackClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    viewModel: ClothingDetailViewModel = hiltViewModel()
+) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+
+    Scaffold(
+        modifier = modifier,
+        topBar = {
+            TopAppBar(
+                title = {
+                    val title = when (val state = uiState) {
+                        is ClothingDetailUiState.Success -> state.item.name
+                        else -> ""
+                    }
+                    Text(title)
+                },
+                navigationIcon = {
+                    IconButton(onClick = onBackClick) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = "Back"
+                        )
+                    }
+                }
+            )
+        }
+    ) { padding ->
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding)
+        ) {
+            when (val state = uiState) {
+                is ClothingDetailUiState.Loading -> {
+                    CircularProgressIndicator(modifier = Modifier.align(Alignment.Center))
+                }
+                is ClothingDetailUiState.Error -> {
+                    val context = LocalContext.current
+                    ErrorContent(
+                        userMessage = context.getString(state.userMessage.resId, *state.userMessage.args),
+                        modifier = Modifier.align(Alignment.Center)
+                    )
+                }
+                is ClothingDetailUiState.Success -> {
+                    ClothingDetailContent(item = state.item)
+                }
+            }
+        }
+    }
+}
+
+/**
+ * Displays an error message when the item detail fails to load.
+ */
+@Composable
+private fun ErrorContent(
+    userMessage: String,
+    modifier: Modifier = Modifier
+) {
+    Column(
+        modifier = modifier.padding(16.dp),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Text(
+            text = userMessage,
+            style = MaterialTheme.typography.bodyLarge,
+            color = MaterialTheme.colorScheme.error
+        )
+    }
+}
+
+/**
+ * Displays the successful content of the clothing item details.
+ * TODO: Implement detailed item view in the next step.
+ */
+@Composable
+private fun ClothingDetailContent(
+    item: ClothingItemWithMeta,
+    modifier: Modifier = Modifier
+) {
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .padding(16.dp)
+    ) {
+        Text(text = "Details for: ${item.name}", style = MaterialTheme.typography.headlineMedium)
+        // More details will be added here in Step 2.2
+    }
+}

--- a/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/ClothingDetailScreen.kt
+++ b/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/ClothingDetailScreen.kt
@@ -18,11 +18,15 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.pluralStringResource
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import coil.compose.AsyncImage
 import com.closet.core.data.model.ClothingItemWithMeta
+import com.closet.core.data.model.ClothingStatus
+import com.closet.core.data.model.WashStatus
+import com.closet.core.ui.theme.ClosetTheme
 import java.text.NumberFormat
 import java.util.*
 
@@ -351,5 +355,31 @@ private fun DetailRow(
             style = MaterialTheme.typography.bodyLarge,
             color = MaterialTheme.colorScheme.onSurface
         )
+    }
+}
+
+@Preview(showBackground = true, name = "Light Mode")
+@Preview(showBackground = true, uiMode = android.content.res.Configuration.UI_MODE_NIGHT_YES, name = "Dark Mode")
+@Composable
+private fun ClothingDetailContentPreview() {
+    ClosetTheme {
+        Surface {
+            ClothingDetailContent(
+                item = ClothingItemWithMeta(
+                    id = 1L,
+                    name = "Vintage Denim Jacket",
+                    brand = "Levi's",
+                    categoryName = "Outerwear",
+                    subcategoryName = "Jackets",
+                    imagePath = null,
+                    wearCount = 12,
+                    purchasePrice = 89.99,
+                    status = ClothingStatus.Active,
+                    isFavorite = 1,
+                    washStatus = WashStatus.Clean
+                ),
+                onWashStatusToggle = {}
+            )
+        }
     }
 }

--- a/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/ClothingDetailScreen.kt
+++ b/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/ClothingDetailScreen.kt
@@ -16,8 +16,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.pluralStringResource
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -117,9 +117,8 @@ fun ClothingDetailScreen(
                     CircularProgressIndicator(modifier = Modifier.align(Alignment.Center))
                 }
                 is ClothingDetailUiState.Error -> {
-                    val context = LocalContext.current
                     ErrorContent(
-                        userMessage = context.getString(state.userMessage.resId, *state.userMessage.args),
+                        userMessage = stringResource(state.userMessage.resId, *state.userMessage.args),
                         modifier = Modifier.align(Alignment.Center)
                     )
                 }

--- a/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/ClothingDetailScreen.kt
+++ b/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/ClothingDetailScreen.kt
@@ -5,12 +5,16 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material.icons.filled.Favorite
+import androidx.compose.material.icons.filled.FavoriteBorder
 import androidx.compose.material3.*
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
+import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.pluralStringResource
@@ -24,10 +28,6 @@ import java.util.*
 
 /**
  * Screen for viewing the details of a specific clothing item.
- *
- * @param onBackClick Callback to navigate back to the previous screen.
- * @param modifier The [Modifier] to be applied to the screen.
- * @param viewModel The [ClothingDetailViewModel] providing state for this screen.
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -37,6 +37,31 @@ fun ClothingDetailScreen(
     viewModel: ClothingDetailViewModel = hiltViewModel()
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    var showDeleteDialog by remember { mutableStateOf(false) }
+
+    if (showDeleteDialog) {
+        AlertDialog(
+            onDismissRequest = { showDeleteDialog = false },
+            title = { Text("Delete Item") },
+            text = { Text("Are you sure you want to delete this item? This action cannot be undone.") },
+            confirmButton = {
+                TextButton(
+                    onClick = {
+                        viewModel.deleteItem(onDeleted = onBackClick)
+                        showDeleteDialog = false
+                    },
+                    colors = ButtonDefaults.textButtonColors(contentColor = MaterialTheme.colorScheme.error)
+                ) {
+                    Text("Delete")
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { showDeleteDialog = false }) {
+                    Text("Cancel")
+                }
+            }
+        )
+    }
 
     Scaffold(
         modifier = modifier,
@@ -55,6 +80,24 @@ fun ClothingDetailScreen(
                             imageVector = Icons.AutoMirrored.Filled.ArrowBack,
                             contentDescription = "Back"
                         )
+                    }
+                },
+                actions = {
+                    val state = uiState
+                    if (state is ClothingDetailUiState.Success) {
+                        IconButton(onClick = { viewModel.toggleFavorite() }) {
+                            Icon(
+                                imageVector = if (state.item.isFavorite == 1) Icons.Default.Favorite else Icons.Default.FavoriteBorder,
+                                contentDescription = "Favorite",
+                                tint = if (state.item.isFavorite == 1) Color.Red else LocalContentColor.current
+                            )
+                        }
+                        IconButton(onClick = { /* Placeholder for Edit */ }) {
+                            Icon(imageVector = Icons.Default.Edit, contentDescription = "Edit")
+                        }
+                        IconButton(onClick = { showDeleteDialog = true }) {
+                            Icon(imageVector = Icons.Default.Delete, contentDescription = "Delete")
+                        }
                     }
                 }
             )
@@ -77,7 +120,10 @@ fun ClothingDetailScreen(
                     )
                 }
                 is ClothingDetailUiState.Success -> {
-                    ClothingDetailContent(item = state.item)
+                    ClothingDetailContent(
+                        item = state.item,
+                        onWashStatusToggle = { viewModel.toggleWashStatus() }
+                    )
                 }
             }
         }
@@ -110,6 +156,7 @@ private fun ErrorContent(
 @Composable
 private fun ClothingDetailContent(
     item: ClothingItemWithMeta,
+    onWashStatusToggle: () -> Unit,
     modifier: Modifier = Modifier
 ) {
     Column(
@@ -157,7 +204,7 @@ private fun ClothingDetailContent(
 
         Spacer(modifier = Modifier.height(24.dp))
 
-        // Stats Group Card (Wear Count and Cost Per Wear)
+        // Stats Group Card
         StatsGroup(
             wearCount = item.wearCount,
             costPerWear = item.costPerWear
@@ -165,7 +212,7 @@ private fun ClothingDetailContent(
 
         Spacer(modifier = Modifier.height(16.dp))
 
-        // Details Group Card (Category and Subcategory)
+        // Details Group Card
         DetailGroup(
             category = item.categoryName,
             subcategory = item.subcategoryName
@@ -184,7 +231,7 @@ private fun ClothingDetailContent(
             )
             
             AssistChip(
-                onClick = { /* Toggle wash handled in next phase */ },
+                onClick = onWashStatusToggle,
                 label = { Text(item.washStatus.label) }
             )
         }

--- a/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/ClothingDetailScreen.kt
+++ b/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/ClothingDetailScreen.kt
@@ -13,11 +13,14 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import coil.compose.AsyncImage
 import com.closet.core.data.model.ClothingItemWithMeta
+import java.text.NumberFormat
+import java.util.*
 
 /**
  * Screen for viewing the details of a specific clothing item.
@@ -154,7 +157,15 @@ private fun ClothingDetailContent(
 
         Spacer(modifier = Modifier.height(24.dp))
 
-        // Details Group Card
+        // Stats Group Card (Wear Count and Cost Per Wear)
+        StatsGroup(
+            wearCount = item.wearCount,
+            costPerWear = item.costPerWear
+        )
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        // Details Group Card (Category and Subcategory)
         DetailGroup(
             category = item.categoryName,
             subcategory = item.subcategoryName
@@ -172,15 +183,72 @@ private fun ClothingDetailContent(
                 label = { Text(item.status.label) }
             )
             
-            // Note: WashStatus is not in ClothingItemWithMeta, we'll need to update it
-            // For now, using Status as a placeholder for the look.
             AssistChip(
                 onClick = { /* Toggle wash handled in next phase */ },
-                label = { Text("Clean") }, // Placeholder label
-                leadingIcon = {
-                    // We can add an icon here later if desired
-                }
+                label = { Text(item.washStatus.label) }
             )
+        }
+    }
+}
+
+/**
+ * Card displaying usage statistics like wear count and cost per wear.
+ */
+@Composable
+private fun StatsGroup(
+    wearCount: Int,
+    costPerWear: Double?,
+    modifier: Modifier = Modifier
+) {
+    val currencyFormatter = NumberFormat.getCurrencyInstance(Locale.getDefault())
+
+    Card(
+        modifier = modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.secondaryContainer
+        )
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
+            horizontalArrangement = Arrangement.SpaceBetween
+        ) {
+            Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                Text(
+                    text = "Usage",
+                    style = MaterialTheme.typography.labelMedium,
+                    color = MaterialTheme.colorScheme.onSecondaryContainer
+                )
+                Text(
+                    text = pluralStringResource(
+                        R.plurals.wardrobe_worn_times,
+                        wearCount,
+                        wearCount
+                    ),
+                    style = MaterialTheme.typography.bodyLarge,
+                    color = MaterialTheme.colorScheme.onSecondaryContainer
+                )
+            }
+
+            VerticalDivider(
+                modifier = Modifier.height(40.dp),
+                thickness = 1.dp,
+                color = MaterialTheme.colorScheme.onSecondaryContainer.copy(alpha = 0.2f)
+            )
+
+            Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                Text(
+                    text = "Cost per wear",
+                    style = MaterialTheme.typography.labelMedium,
+                    color = MaterialTheme.colorScheme.onSecondaryContainer
+                )
+                Text(
+                    text = if (costPerWear != null) currencyFormatter.format(costPerWear) else "—",
+                    style = MaterialTheme.typography.bodyLarge,
+                    color = MaterialTheme.colorScheme.onSecondaryContainer
+                )
+            }
         }
     }
 }

--- a/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/ClothingDetailScreen.kt
+++ b/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/ClothingDetailScreen.kt
@@ -1,6 +1,18 @@
 package com.closet.features.wardrobe
 
-import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.Alignment
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.AspectRatio
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
@@ -9,13 +21,38 @@ import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material.icons.filled.Favorite
 import androidx.compose.material.icons.filled.FavoriteBorder
-import androidx.compose.material3.*
-import androidx.compose.runtime.*
-import androidx.compose.ui.Alignment
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.AssistChip
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.LocalContentColor
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.SuggestionChip
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.VerticalDivider
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
@@ -27,8 +64,9 @@ import com.closet.core.data.model.ClothingItemWithMeta
 import com.closet.core.data.model.ClothingStatus
 import com.closet.core.data.model.WashStatus
 import com.closet.core.ui.theme.ClosetTheme
+import kotlinx.coroutines.flow.collectLatest
 import java.text.NumberFormat
-import java.util.*
+import java.util.Locale
 
 /**
  * Screen for viewing the details of a specific clothing item.
@@ -42,6 +80,16 @@ fun ClothingDetailScreen(
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     var showDeleteDialog by remember { mutableStateOf(false) }
+    val snackbarHostState = remember { SnackbarHostState() }
+    val context = LocalContext.current
+
+    LaunchedEffect(Unit) {
+        viewModel.actionError.collectLatest { userMessage ->
+            snackbarHostState.showSnackbar(
+                message = context.getString(userMessage.resId, *userMessage.args)
+            )
+        }
+    }
 
     if (showDeleteDialog) {
         AlertDialog(
@@ -51,8 +99,10 @@ fun ClothingDetailScreen(
             confirmButton = {
                 TextButton(
                     onClick = {
-                        viewModel.deleteItem(onDeleted = onBackClick)
-                        showDeleteDialog = false
+                        viewModel.deleteItem(onDeleted = {
+                            showDeleteDialog = false
+                            onBackClick()
+                        })
                     },
                     colors = ButtonDefaults.textButtonColors(contentColor = MaterialTheme.colorScheme.error)
                 ) {
@@ -111,7 +161,8 @@ fun ClothingDetailScreen(
                     }
                 }
             )
-        }
+        },
+        snackbarHost = { SnackbarHost(snackbarHostState) }
     ) { padding ->
         Box(
             modifier = Modifier
@@ -256,7 +307,7 @@ private fun StatsGroup(
     costPerWear: Double?,
     modifier: Modifier = Modifier
 ) {
-    val currencyFormatter = NumberFormat.getCurrencyInstance(Locale.getDefault())
+    val currencyFormatter = remember { NumberFormat.getCurrencyInstance(Locale.getDefault()) }
 
     Card(
         modifier = modifier.fillMaxWidth(),

--- a/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/ClothingDetailScreen.kt
+++ b/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/ClothingDetailScreen.kt
@@ -1,8 +1,6 @@
 package com.closet.features.wardrobe
 
-import androidx.compose.foundation.layout.Alignment
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.AspectRatio
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
@@ -48,6 +46,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color

--- a/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/ClothingDetailViewModel.kt
+++ b/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/ClothingDetailViewModel.kt
@@ -5,8 +5,10 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import androidx.navigation.toRoute
 import com.closet.core.data.model.ClothingItemWithMeta
+import com.closet.core.data.model.WashStatus
 import com.closet.core.data.repository.ClothingRepository
 import com.closet.core.data.util.AppError
+import com.closet.core.data.util.DataResult
 import com.closet.core.data.util.fold
 import com.closet.core.ui.util.UserMessage
 import com.closet.core.ui.util.asUserMessage
@@ -19,7 +21,7 @@ import javax.inject.Inject
 
 /**
  * ViewModel for the Clothing Detail screen.
- * Handles fetching a specific clothing item by its ID and managing the UI state.
+ * Handles fetching a specific clothing item by its ID and managing the UI state and actions.
  *
  * @param savedStateHandle Handle to saved state, used to retrieve navigation arguments.
  * @param clothingRepository Repository for accessing clothing item data.
@@ -48,7 +50,7 @@ class ClothingDetailViewModel @Inject constructor(
      * Fetches the clothing item from the repository and updates the UI state.
      * Uses the type-safe [DataResult] to handle success and various error states.
      */
-    private fun loadItem() {
+    fun loadItem() {
         viewModelScope.launch {
             _uiState.value = ClothingDetailUiState.Loading
 
@@ -63,6 +65,68 @@ class ClothingDetailViewModel @Inject constructor(
                 }
             )
         }
+    }
+
+    /**
+     * Toggles the favorite status of the current item.
+     */
+    fun toggleFavorite() {
+        val currentState = _uiState.value
+        if (currentState is ClothingDetailUiState.Success) {
+            viewModelScope.launch {
+                val newFavorite = currentState.item.isFavorite == 0
+                clothingRepository.updateFavoriteStatus(itemId, newFavorite).fold(
+                    onLoading = {},
+                    onSuccess = { loadItem() }, // Refresh item to show updated state
+                    onError = { handleActionError(it) }
+                )
+            }
+        }
+    }
+
+    /**
+     * Toggles the wash status of the current item between Clean and Dirty.
+     */
+    fun toggleWashStatus() {
+        val currentState = _uiState.value
+        if (currentState is ClothingDetailUiState.Success) {
+            viewModelScope.launch {
+                val newStatus = if (currentState.item.washStatus == WashStatus.Clean) {
+                    WashStatus.Dirty
+                } else {
+                    WashStatus.Clean
+                }
+                clothingRepository.updateWashStatus(itemId, newStatus).fold(
+                    onLoading = {},
+                    onSuccess = { loadItem() },
+                    onError = { handleActionError(it) }
+                )
+            }
+        }
+    }
+
+    /**
+     * Deletes the current clothing item and invokes the callback on success.
+     * @param onDeleted Callback to navigate back or show a message.
+     */
+    fun deleteItem(onDeleted: () -> Unit) {
+        viewModelScope.launch {
+            clothingRepository.deleteItem(itemId).fold(
+                onLoading = {},
+                onSuccess = { onDeleted() },
+                onError = { handleActionError(it) }
+            )
+        }
+    }
+
+    /**
+     * Maps action errors to the UI state to surface them to the user.
+     */
+    private fun handleActionError(throwable: Throwable) {
+        val error = throwable as? AppError ?: AppError.Unexpected(throwable)
+        // We could use a separate state for transient action errors (like a Snackbar),
+        // but for now, we'll update the main UI state.
+        _uiState.value = ClothingDetailUiState.Error(error.asUserMessage())
     }
 }
 

--- a/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/ClothingDetailViewModel.kt
+++ b/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/ClothingDetailViewModel.kt
@@ -13,6 +13,7 @@ import com.closet.core.data.util.fold
 import com.closet.core.ui.util.UserMessage
 import com.closet.core.ui.util.asUserMessage
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
@@ -45,7 +46,11 @@ class ClothingDetailViewModel @Inject constructor(
     /** The current UI state of the detail screen. */
     val uiState: StateFlow<ClothingDetailUiState> = _uiState.asStateFlow()
 
-    private val _actionError = MutableSharedFlow<UserMessage>()
+    private val _actionError = MutableSharedFlow<UserMessage>(
+        replay = 0,
+        extraBufferCapacity = 1,
+        onBufferOverflow = BufferOverflow.DROP_OLDEST
+    )
     /** Transient error messages for actions like toggle or delete. */
     val actionError: SharedFlow<UserMessage> = _actionError.asSharedFlow()
 
@@ -78,9 +83,9 @@ class ClothingDetailViewModel @Inject constructor(
      * Toggles the favorite status of the current item.
      */
     fun toggleFavorite() {
-        val currentState = _uiState.value
-        if (currentState is ClothingDetailUiState.Success) {
-            viewModelScope.launch {
+        viewModelScope.launch {
+            val currentState = _uiState.value
+            if (currentState is ClothingDetailUiState.Success) {
                 val newFavorite = currentState.item.isFavorite == 0
                 clothingRepository.updateFavoriteStatus(itemId, newFavorite).fold(
                     onLoading = {},
@@ -95,9 +100,9 @@ class ClothingDetailViewModel @Inject constructor(
      * Toggles the wash status of the current item between Clean and Dirty.
      */
     fun toggleWashStatus() {
-        val currentState = _uiState.value
-        if (currentState is ClothingDetailUiState.Success) {
-            viewModelScope.launch {
+        viewModelScope.launch {
+            val currentState = _uiState.value
+            if (currentState is ClothingDetailUiState.Success) {
                 val newStatus = if (currentState.item.washStatus == WashStatus.Clean) {
                     WashStatus.Dirty
                 } else {

--- a/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/ClothingDetailViewModel.kt
+++ b/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/ClothingDetailViewModel.kt
@@ -13,8 +13,11 @@ import com.closet.core.data.util.fold
 import com.closet.core.ui.util.UserMessage
 import com.closet.core.ui.util.asUserMessage
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -41,6 +44,10 @@ class ClothingDetailViewModel @Inject constructor(
 
     /** The current UI state of the detail screen. */
     val uiState: StateFlow<ClothingDetailUiState> = _uiState.asStateFlow()
+
+    private val _actionError = MutableSharedFlow<UserMessage>()
+    /** Transient error messages for actions like toggle or delete. */
+    val actionError: SharedFlow<UserMessage> = _actionError.asSharedFlow()
 
     init {
         loadItem()
@@ -120,13 +127,13 @@ class ClothingDetailViewModel @Inject constructor(
     }
 
     /**
-     * Maps action errors to the UI state to surface them to the user.
+     * Maps action errors to a transient event flow rather than replacing the whole UI state.
      */
     private fun handleActionError(throwable: Throwable) {
         val error = throwable as? AppError ?: AppError.Unexpected(throwable)
-        // We could use a separate state for transient action errors (like a Snackbar),
-        // but for now, we'll update the main UI state.
-        _uiState.value = ClothingDetailUiState.Error(error.asUserMessage())
+        viewModelScope.launch {
+            _actionError.emit(error.asUserMessage())
+        }
     }
 }
 

--- a/app-android/features/wardrobe/src/main/res/values/strings.xml
+++ b/app-android/features/wardrobe/src/main/res/values/strings.xml
@@ -7,4 +7,18 @@
     </plurals>
     <string name="wardrobe_empty_closet">Your closet is empty. Add some clothes!</string>
     <string name="wardrobe_all_items">All</string>
+
+    <!-- Clothing Detail -->
+    <string name="wardrobe_back">Back</string>
+    <string name="wardrobe_favorite">Favorite</string>
+    <string name="wardrobe_edit">Edit</string>
+    <string name="wardrobe_delete">Delete</string>
+    <string name="wardrobe_usage">Usage</string>
+    <string name="wardrobe_cost_per_wear">Cost per wear</string>
+    <string name="wardrobe_delete_item_title">Delete Item</string>
+    <string name="wardrobe_delete_item_confirmation">Are you sure you want to delete this item? This action cannot be undone.</string>
+    <string name="wardrobe_cancel">Cancel</string>
+    <string name="wardrobe_category">Category</string>
+    <string name="wardrobe_subcategory">Subcategory</string>
+    <string name="wardrobe_uncategorized">Uncategorized</string>
 </resources>

--- a/app-android/features/wardrobe/src/main/res/values/strings.xml
+++ b/app-android/features/wardrobe/src/main/res/values/strings.xml
@@ -6,4 +6,5 @@
         <item quantity="other">Worn %d times</item>
     </plurals>
     <string name="wardrobe_empty_closet">Your closet is empty. Add some clothes!</string>
+    <string name="wardrobe_all_items">All</string>
 </resources>

--- a/app-android/gradle/libs.versions.toml
+++ b/app-android/gradle/libs.versions.toml
@@ -50,6 +50,7 @@ androidx-test-ext-junit = { group = "androidx.test.ext", name = "junit", version
 androidx-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "androidxEspresso" }
 google-material = { group = "com.google.android.material", name = "material", version.ref = "material" }
 timber = { group = "com.jakewharton.timber", name = "timber", version.ref = "timber" }
+androidx-compose-material-icons-extended = { group = "androidx.compose.material", name = "material-icons-extended" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Full clothing detail screen with hero image, stats, appearance, delete confirmation.
  * Toggle favorite and wash status from the detail screen; delete navigates back on completion.
  * Category filter row with "All" option and two-column wardrobe grid.

* **Behavior**
  * Back navigation wired from detail screen to return to previous view.
  * Favorite and wash status changes are persisted immediately.

* **Chores**
  * Added extended Compose icons and new localized wardrobe strings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->