### PR TITLE
Add brand normalization with database migration

### DIFF
--- a/app-android/app/src/main/kotlin/com/closet/MainActivity.kt
+++ b/app-android/app/src/main/kotlin/com/closet/MainActivity.kt
@@ -14,6 +14,13 @@ import com.closet.core.ui.theme.ClosetTheme
 import com.closet.navigation.ClosetNavGraph
 import dagger.hilt.android.AndroidEntryPoint
 
+/**
+ * Single-activity entry point for the app.
+ *
+ * Enables edge-to-edge display and hosts [ClosetNavGraph] inside a [ClosetTheme]-wrapped
+ * [androidx.compose.material3.Scaffold]. Hilt dependency injection is provided via
+ * [@AndroidEntryPoint][dagger.hilt.android.AndroidEntryPoint].
+ */
 @AndroidEntryPoint
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {

--- a/app-android/app/src/main/kotlin/com/closet/navigation/ClosetNavGraph.kt
+++ b/app-android/app/src/main/kotlin/com/closet/navigation/ClosetNavGraph.kt
@@ -44,13 +44,21 @@ fun ClosetNavGraph(
 
         composable<AddClothingDestination> {
             ClothingFormScreen(
-                onBackClick = { navController.popBackStack() }
+                onBackClick = { navController.popBackStack() },
+                onManageBrands = { navController.navigate(BrandManagementDestination) }
             )
         }
 
         composable<EditClothingDestination> {
             ClothingFormScreen(
-                onBackClick = { navController.popBackStack() }
+                onBackClick = { navController.popBackStack() },
+                onManageBrands = { navController.navigate(BrandManagementDestination) }
+            )
+        }
+
+        composable<BrandManagementDestination> {
+            BrandManagementScreen(
+                onBack = { navController.popBackStack() }
             )
         }
 

--- a/app-android/app/src/main/kotlin/com/closet/navigation/ClosetNavGraph.kt
+++ b/app-android/app/src/main/kotlin/com/closet/navigation/ClosetNavGraph.kt
@@ -12,6 +12,15 @@ import com.closet.features.outfits.outfitBuilderScreen
 import com.closet.features.outfits.wardrobePickerScreen
 import com.closet.features.outfits.OutfitsRoute
 
+/**
+ * Root [NavHost] for the app, wiring all feature destinations into a single navigation graph.
+ *
+ * Start destination is [ClosetDestination] (the main closet screen). Wardrobe routes are
+ * registered inline; outfits routes are registered via feature-module extension functions.
+ *
+ * @param modifier Modifier applied to the [NavHost].
+ * @param navController The [NavHostController] managing back-stack state.
+ */
 @Composable
 fun ClosetNavGraph(
     modifier: Modifier = Modifier,

--- a/app-android/architecture-roadmap.md
+++ b/app-android/architecture-roadmap.md
@@ -1,0 +1,61 @@
+# Architecture Roadmap
+
+Findings from codebase audit. Items ordered by priority.
+
+---
+
+## Phase 1 — God Files (Immediate)
+
+### `ClothingFormScreen.kt` (916 lines)
+- [x] Extract `CategoryDropdown` and `SubcategoryDropdown` into a generic `DropdownSelector<T>` composable — they are nearly identical
+- [x] Extract `ColorSelectionGrid`, `DatePickerField`, `BrandAutocompleteField`, and other private composables into `FormComponents.kt`
+- [x] Move all `@Preview` functions and mock data into `FormPreviews.kt`
+- [x] Ensure `ClothingFormScreen.kt` contains only the top-level screen composable and `ClothingFormTopBar`/`ClothingFormContent`
+
+### `ClothingDetailScreen.kt` (731 lines)
+- [ ] Replace the 5 copy-pasted `MultiSelectSheet` blocks (seasons, occasions, colors, materials, patterns) with a data-driven loop or single generic helper composable
+- [ ] Extract `ClothingAttributes` and `AttributeSection`/`AttributeChip` into `ClothingDetailComponents.kt`
+- [ ] Move `@Preview` functions into `ClothingDetailPreviews.kt`
+
+### `BrandManagementScreen.kt` (405 lines)
+- [ ] Extract dialog/edit state into a sealed class (`BrandDialogState`) instead of separate boolean flags
+- [ ] Extract dialog composables (`AddBrandRow`, `EditBrandRow`) into `BrandComponents.kt`
+
+---
+
+## Phase 2 — ViewModel State (Short-term)
+
+### `ClothingFormViewModel.kt` (468 lines, 13 `MutableStateFlow`s)
+- [ ] Consolidate 13 individual `MutableStateFlow` field properties into a single `ClothingFormUiState` data class exposed as one `StateFlow` — update via `copy()`
+- [ ] Extract the `isDirty` computation (currently ~20 lines of field comparisons) into a standalone function
+- [ ] Audit `loadItemForEditing` — it uses `.first()` blocking calls; replace with structured `collectLatest` or proper error handling
+
+### `ClothingDetailViewModel.kt`
+- [ ] Combine the 6 separate `StateFlow`s (categories, seasons, occasions, etc.) into a single `UiState` `StateFlow` to eliminate synchronization risk
+
+---
+
+## Phase 3 — Shared Utilities (Short-term)
+
+- [ ] Create a shared `ErrorSnackbar` / error-handling composable in `core/ui/components/` — currently duplicated across 4 screens
+- [ ] Extract `wear_count` SQL subquery in `ClothingDao.kt` to a named Kotlin constant — currently copy-pasted in `getAllClothingItems` and `getClothingItemById`
+- [ ] Confirm `resolveImagePath` usage is consistent across `ClosetScreen`, `ClothingDetailScreen`, `WardrobePickerScreen` — extract to a shared util in `core/ui/` if not already
+
+---
+
+## Phase 4 — Database & Migrations (Medium-term)
+
+- [ ] Move inline `MIGRATION_1_2`, `MIGRATION_3_4` objects out of `ClothingDatabase.kt` into a `migrations/` package (e.g. `Migration1To2.kt`) — standard multi-module convention
+- [ ] Extract column-existence raw query in migrations into a reusable helper (e.g. `columnExists(db, table, column): Boolean`)
+- [ ] Evaluate whether `DatabaseSeeder` hard-coded seed entries should be loaded from a bundled JSON/CSV resource file to reduce maintenance burden on code changes
+
+---
+
+## Architectural Strengths — Do Not Change
+
+- Module dependency graph: `app → features → core/ui → core/data` — no violations, keep it this way
+- `DataResult<T>` + `AppError` sealed class hierarchy — well-designed, use as the template
+- `ClosetScreen.kt` — use as the reference implementation for all screen structure
+- Hilt `@Singleton` scoping in `DataModule` — correct, do not scatter providers
+- Room migrations with backfill logic — correct pattern, just needs cleanup
+- Relative image path storage + reconstruction at display time — matches spec, do not change

--- a/app-android/architecture-roadmap.md
+++ b/app-android/architecture-roadmap.md
@@ -31,7 +31,7 @@ Findings from codebase audit. Items ordered by priority.
 - [x] Audit `loadItemForEditing` — it uses `.first()` blocking calls; replace with structured `collectLatest` or proper error handling
 
 ### `ClothingDetailViewModel.kt`
-- [ ] Combine the 6 separate `StateFlow`s (categories, seasons, occasions, etc.) into a single `UiState` `StateFlow` to eliminate synchronization risk
+- [x] Combine the 6 separate `StateFlow`s (categories, seasons, occasions, etc.) into a single `UiState` `StateFlow` to eliminate synchronization risk
 
 ---
 

--- a/app-android/architecture-roadmap.md
+++ b/app-android/architecture-roadmap.md
@@ -18,8 +18,8 @@ Findings from codebase audit. Items ordered by priority.
 - [x] Move `@Preview` functions into `ClothingDetailPreviews.kt`
 
 ### `BrandManagementScreen.kt` (405 lines)
-- [ ] Extract dialog/edit state into a sealed class (`BrandDialogState`) instead of separate boolean flags
-- [ ] Extract dialog composables (`AddBrandRow`, `EditBrandRow`) into `BrandComponents.kt`
+- [x] Extract dialog/edit state into a sealed class (`BrandDialogState`) instead of separate boolean flags
+- [x] Extract dialog composables (`AddBrandRow`, `EditBrandRow`) into `BrandComponents.kt`
 
 ---
 

--- a/app-android/architecture-roadmap.md
+++ b/app-android/architecture-roadmap.md
@@ -37,9 +37,9 @@ Findings from codebase audit. Items ordered by priority.
 
 ## Phase 3 — Shared Utilities (Short-term)
 
-- [ ] Create a shared `ErrorSnackbar` / error-handling composable in `core/ui/components/` — currently duplicated across 4 screens
-- [ ] Extract `wear_count` SQL subquery in `ClothingDao.kt` to a named Kotlin constant — currently copy-pasted in `getAllClothingItems` and `getClothingItemById`
-- [ ] Confirm `resolveImagePath` usage is consistent across `ClosetScreen`, `ClothingDetailScreen`, `WardrobePickerScreen` — extract to a shared util in `core/ui/` if not already
+- [x] Create a shared `ErrorSnackbar` / error-handling composable in `core/ui/components/` — currently duplicated across 4 screens
+- [x] Extract `wear_count` SQL subquery in `ClothingDao.kt` to a named Kotlin constant — currently copy-pasted in `getAllClothingItems` and `getClothingItemById`
+- [x] Confirm `resolveImagePath` usage is consistent across `ClosetScreen`, `ClothingDetailScreen`, `WardrobePickerScreen` — extract to a shared util in `core/ui/` if not already
 
 ---
 

--- a/app-android/architecture-roadmap.md
+++ b/app-android/architecture-roadmap.md
@@ -13,9 +13,9 @@ Findings from codebase audit. Items ordered by priority.
 - [x] Ensure `ClothingFormScreen.kt` contains only the top-level screen composable and `ClothingFormTopBar`/`ClothingFormContent`
 
 ### `ClothingDetailScreen.kt` (731 lines)
-- [ ] Replace the 5 copy-pasted `MultiSelectSheet` blocks (seasons, occasions, colors, materials, patterns) with a data-driven loop or single generic helper composable
-- [ ] Extract `ClothingAttributes` and `AttributeSection`/`AttributeChip` into `ClothingDetailComponents.kt`
-- [ ] Move `@Preview` functions into `ClothingDetailPreviews.kt`
+- [x] Replace the 5 copy-pasted `MultiSelectSheet` blocks (seasons, occasions, colors, materials, patterns) with a data-driven loop or single generic helper composable
+- [x] Extract `ClothingAttributes` and `AttributeSection`/`AttributeChip` into `ClothingDetailComponents.kt`
+- [x] Move `@Preview` functions into `ClothingDetailPreviews.kt`
 
 ### `BrandManagementScreen.kt` (405 lines)
 - [ ] Extract dialog/edit state into a sealed class (`BrandDialogState`) instead of separate boolean flags

--- a/app-android/architecture-roadmap.md
+++ b/app-android/architecture-roadmap.md
@@ -45,9 +45,9 @@ Findings from codebase audit. Items ordered by priority.
 
 ## Phase 4 — Database & Migrations (Medium-term)
 
-- [ ] Move inline `MIGRATION_1_2`, `MIGRATION_3_4` objects out of `ClothingDatabase.kt` into a `migrations/` package (e.g. `Migration1To2.kt`) — standard multi-module convention
-- [ ] Extract column-existence raw query in migrations into a reusable helper (e.g. `columnExists(db, table, column): Boolean`)
-- [ ] Evaluate whether `DatabaseSeeder` hard-coded seed entries should be loaded from a bundled JSON/CSV resource file to reduce maintenance burden on code changes
+- [x] Move inline `MIGRATION_1_2`, `MIGRATION_3_4` objects out of `ClothingDatabase.kt` into a `migrations/` package (e.g. `Migration1To2.kt`) — standard multi-module convention
+- [x] Extract column-existence raw query in migrations into a reusable helper (e.g. `columnExists(db, table, column): Boolean`)
+- [x] Evaluate whether `DatabaseSeeder` hard-coded seed entries should be loaded from a bundled JSON/CSV resource file to reduce maintenance burden on code changes — **decision: keep in Kotlin.** Data is small (~150 rows) and stable; JSON/CSV would require threading `Context` into `SupportSQLiteDatabase` callbacks, add a parser + error handling path, and lose compile-time safety for no meaningful gain.
 
 ---
 

--- a/app-android/architecture-roadmap.md
+++ b/app-android/architecture-roadmap.md
@@ -26,9 +26,9 @@ Findings from codebase audit. Items ordered by priority.
 ## Phase 2 — ViewModel State (Short-term)
 
 ### `ClothingFormViewModel.kt` (468 lines, 13 `MutableStateFlow`s)
-- [ ] Consolidate 13 individual `MutableStateFlow` field properties into a single `ClothingFormUiState` data class exposed as one `StateFlow` — update via `copy()`
-- [ ] Extract the `isDirty` computation (currently ~20 lines of field comparisons) into a standalone function
-- [ ] Audit `loadItemForEditing` — it uses `.first()` blocking calls; replace with structured `collectLatest` or proper error handling
+- [x] Consolidate 13 individual `MutableStateFlow` field properties into a single `ClothingFormUiState` data class exposed as one `StateFlow` — update via `copy()`
+- [x] Extract the `isDirty` computation (currently ~20 lines of field comparisons) into a standalone function
+- [x] Audit `loadItemForEditing` — it uses `.first()` blocking calls; replace with structured `collectLatest` or proper error handling
 
 ### `ClothingDetailViewModel.kt`
 - [ ] Combine the 6 separate `StateFlow`s (categories, seasons, occasions, etc.) into a single `UiState` `StateFlow` to eliminate synchronization risk

--- a/app-android/brand-lookup-roadmap.md
+++ b/app-android/brand-lookup-roadmap.md
@@ -1,0 +1,225 @@
+# Brand System — Implementation Roadmap
+
+## Current State Summary
+
+| Item | Status |
+|---|---|
+| `clothing_items.brand` column | **Exists** — nullable `TEXT`, free-form string |
+| `LookupRepository.getDistinctBrands()` | **Exists** — queries distinct strings from the column |
+| Brand in `ClothingFormScreen` | **Exists** — plain `OutlinedTextField` |
+| `brands` lookup table | **Does not exist** |
+| Brand management screen | **Does not exist** |
+| Autocomplete widget | **Does not exist** |
+
+The pivot: `brand` is currently denormalized free text. The feature requires normalizing it into a proper FK relationship. This touches the schema, entity, all DAOs that select brand, the repository layer, and the UI.
+
+---
+
+## Phase 1 — Schema Migration
+
+**Migration 3 → 4**
+
+1. Create `brands` table:
+   ```sql
+   CREATE TABLE brands (
+       id INTEGER PRIMARY KEY AUTOINCREMENT,
+       name TEXT NOT NULL UNIQUE
+   )
+   ```
+2. Backfill brands from existing data:
+   ```sql
+   INSERT OR IGNORE INTO brands (name)
+   SELECT DISTINCT brand FROM clothing_items
+   WHERE brand IS NOT NULL AND brand != ''
+   ```
+3. Add `brand_id` column to `clothing_items`:
+   ```sql
+   ALTER TABLE clothing_items ADD COLUMN brand_id INTEGER
+       REFERENCES brands(id) ON DELETE SET NULL
+   ```
+4. Populate `brand_id` from the backfill:
+   ```sql
+   UPDATE clothing_items
+   SET brand_id = (SELECT id FROM brands WHERE brands.name = clothing_items.brand)
+   WHERE brand IS NOT NULL AND brand != ''
+   ```
+5. SQLite cannot drop columns before API 35, so `brand` (the old text column) stays but is deprecated — stop reading it in all new queries. Add a comment in the migration noting it is vestigial.
+
+**Seed data** (called from the migration, not `seedAll`): insert 5–10 common brands (`Zara`, `H&M`, `Nike`, `Adidas`, `Levi's`, `Uniqlo`, `Gap`, `Mango`) using `INSERT OR IGNORE` so they don't overwrite backfilled data and are idempotent.
+
+**Schema export:** Room will auto-export `4.json` when `kspDebugKotlin` runs.
+
+---
+
+## Phase 2 — Data Layer
+
+### 2a. `BrandEntity`
+New file in `core/data/model/` (alongside `LookupEntities.kt` — can live inside it or as a separate file):
+```kotlin
+@Entity(tableName = "brands")
+data class BrandEntity(
+    id: Long,       // PrimaryKey autoGenerate
+    name: String    // NOT NULL UNIQUE
+)
+```
+
+Update `ClothingDatabase` entities list and bump version to 4.
+
+### 2b. `BrandDao`
+New `@Dao` interface (separate from `LookupDao` since brands are user-managed, not seed-only lookups):
+
+| Method | Query |
+|---|---|
+| `getAllBrands(): Flow<List<BrandEntity>>` | `SELECT * FROM brands ORDER BY name` |
+| `getBrandById(id): BrandEntity?` | `SELECT * WHERE id = :id` |
+| `insertBrand(brand): Long` | `INSERT INTO brands (name) VALUES (:name)` |
+| `updateBrand(brand)` | `@Update` |
+| `deleteBrand(id)` | `DELETE WHERE id = :id` |
+| `getItemCountForBrand(brandId): Int` | `SELECT COUNT(*) FROM clothing_items WHERE brand_id = :brandId` |
+
+### 2c. Update `ClothingItemEntity`
+- Add `brandId: Long?` with `ForeignKey(entity = BrandEntity::class, onDelete = SET_NULL)`
+- Keep `brand: String?` column present (legacy, no longer written to)
+- Add index on `brand_id`
+
+### 2d. Update `ClothingDao` queries
+Every `SELECT` that emits brand data should change from `ci.brand` to `brands.name` via a LEFT JOIN:
+```sql
+LEFT JOIN brands ON brands.id = ci.brand_id
+```
+Update `ClothingItemWithMeta.brand: String?` to be populated from the join. No structural changes to the data class — just the query source changes.
+
+### 2e. `BrandRepository`
+New repository (separate from `LookupRepository` since brands are user-editable):
+
+| Method | Returns | Notes |
+|---|---|---|
+| `getAllBrands()` | `Flow<List<BrandEntity>>` | For management screen and form autocomplete |
+| `insertBrand(name)` | `DataResult<Long>` | Returns new ID; wrap in `wrapInTransaction` |
+| `updateBrand(id, name)` | `DataResult<Unit>` | |
+| `deleteBrand(id)` | `DataResult<Unit>` | Repository layer does NOT check count — DAO constraint handles it |
+| `getItemCountForBrand(id)` | `DataResult<Int>` | Used by management screen before showing delete |
+
+Wrap all ops in the same `wrapInTransaction` / `DataResult` pattern as `ClothingRepository`. Provide via `@Singleton` in `DataModule`.
+
+### 2f. Update `ClothingRepository`
+- `createClothingItem` / `updateClothingItem` signatures gain `brandId: Long?` in place of `brand: String?`
+- Remove any `brand: String?` write path
+
+### 2g. Remove `LookupRepository.getDistinctBrands()`
+This method and the corresponding `LookupDao` query become dead code once `BrandRepository` exists. Delete them.
+
+---
+
+## Phase 3 — Form Autocomplete
+
+### 3a. `ClothingFormViewModel` changes
+- Replace `_brand: MutableStateFlow<String>` with `_selectedBrandId: MutableStateFlow<Long?>` and `_brandQuery: MutableStateFlow<String>` (the text the user is typing)
+- Inject `BrandRepository`; expose `allBrands: StateFlow<List<BrandEntity>>` from `BrandRepository.getAllBrands()`
+- Add `fun onBrandQueryChange(text: String)` — updates `_brandQuery`
+- Add `fun onBrandSelect(brand: BrandEntity)` — sets `_selectedBrandId`, clears the text query to the brand name
+- Add `suspend fun onAddNewBrand(name: String): Long` — calls `brandRepository.insertBrand(name)`, then calls `onBrandSelect` with the returned entity
+- On save: pass `_selectedBrandId.value` instead of brand string
+
+### 3b. `BrandAutocompleteField` composable
+New private composable in `ClothingFormScreen.kt`:
+
+```kotlin
+ExposedDropdownMenuBox(
+    expanded = expanded,
+    onExpandedChange = { expanded = it }
+) {
+    OutlinedTextField(
+        value = query,
+        onValueChange = { onQueryChange(it); expanded = true },
+        label = { Text("Brand") },
+        trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded) },
+        modifier = Modifier.menuAnchor(MenuAnchorType.PrimaryEditable)
+    )
+
+    ExposedDropdownMenu(expanded = expanded && (filteredBrands.isNotEmpty() || showAddOption)) {
+        filteredBrands.forEach { brand ->
+            DropdownMenuItem(
+                text = { Text(brand.name) },
+                onClick = { onBrandSelect(brand); expanded = false }
+            )
+        }
+        if (showAddOption) {  // query non-empty and no exact match
+            HorizontalDivider()
+            DropdownMenuItem(
+                text = { Text("Add \"$query\" as new brand") },
+                leadingIcon = { Icon(Icons.Default.Add, null) },
+                onClick = { onAddNewBrand(query); expanded = false }
+            )
+        }
+    }
+}
+```
+
+Filtering logic:
+```kotlin
+val filteredBrands = allBrands.filter { it.name.contains(query, ignoreCase = true) }
+val showAddOption = query.isNotBlank() && filteredBrands.none { it.name.equals(query, ignoreCase = true) }
+```
+
+Replace the current `OutlinedTextField` brand field with `BrandAutocompleteField`.
+
+---
+
+## Phase 4 — Brand Management Screen
+
+### 4a. New destination
+In `WardrobeNavigation.kt`:
+```kotlin
+@Serializable
+object BrandManagementDestination
+```
+
+### 4b. `BrandManagementViewModel`
+- Inject `BrandRepository`
+- `brands: StateFlow<List<BrandEntity>>` from `getAllBrands()`
+- `uiState: StateFlow<BrandManagementUiState>` — wraps loading/error/confirmation dialog state
+- `fun requestDelete(brand: BrandEntity)` — calls `getItemCountForBrand`, then:
+  - If count > 0: sets state to show blocked dialog: "X items use this brand. Reassign them before deleting."
+  - If count == 0: sets state to show confirm dialog
+- `fun confirmDelete(id: Long)` — calls `deleteBrand`, dismisses dialog
+- `fun saveBrand(id: Long?, name: String)` — insert if `id == null`, update otherwise
+
+### 4c. `BrandManagementScreen`
+- `LazyColumn` of brands, each row:
+  - Brand name (primary text)
+  - Item count (secondary text, e.g. "3 items")
+  - Edit icon → toggle row to inline editable state (`OutlinedTextField` in place)
+  - Delete icon → calls `requestDelete`
+- Confirm/blocked `AlertDialog` driven by `uiState`
+- FAB or top-bar action to add a new brand (inline text field + confirm)
+
+Prefer inline edit (toggle the row to an editable state) over a separate edit screen to avoid extra navigation boilerplate.
+
+### 4d. Access point
+Add a settings/manage icon next to the brand field in `ClothingFormScreen` that navigates to `BrandManagementDestination`. Register the route in `ClosetNavGraph.kt` alongside the existing wardrobe routes.
+
+---
+
+## Phase 5 — Detail Screen Verification
+
+`ClothingDetailScreen` reads `uiState.item.brand` (the string). After migration this is populated via the LEFT JOIN in `ClothingDao` — no structural change needed in the screen. Verify the DAO query and ViewModel still populate the field correctly after the join change.
+
+---
+
+## Execution Order
+
+```
+Phase 1  →  Phase 2a–2g  →  Phase 3a–3b  →  Phase 4a–4d  →  Phase 5
+```
+
+Phases 1 and 2 must be sequential (schema before entity). Phases 3 and 4 can be developed in parallel once Phase 2 is complete. Phase 5 is a verification step, not new work.
+
+---
+
+## Risk Notes
+
+- **Migration backfill:** The `UPDATE clothing_items SET brand_id = ...` step depends on exact string matching. Case differences in existing data (e.g. "Nike" vs "nike") will not backfill correctly. Accept this — free-text data has no canonical casing guarantee. Users can reassign from the management screen.
+- **`brand` column retention:** Leaving the old column avoids a costly table recreation. Mark it clearly as deprecated in the migration and never write to it in new code.
+- **Unique constraint on `brands.name`:** `insertBrand` will fail if the user tries to add a brand that already exists case-sensitively. The `showAddOption` logic must filter with `ignoreCase = true` to avoid surfacing "Add as new brand" when a case-insensitive match already exists.
+- **`ExposedDropdownMenuBox` with editable anchor:** Requires `MenuAnchorType.PrimaryEditable` (Material3 1.3+). Verify `libs.versions.toml` has a compatible `material3` version before starting Phase 3.

--- a/app-android/core/data/schemas/com.closet.core.data.ClothingDatabase/4.json
+++ b/app-android/core/data/schemas/com.closet.core.data.ClothingDatabase/4.json
@@ -1,0 +1,1133 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 4,
+    "identityHash": "327e69bd6afde50e6be113374fa122f1",
+    "entities": [
+      {
+        "tableName": "clothing_items",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `brand` TEXT, `brand_id` INTEGER, `category_id` INTEGER, `subcategory_id` INTEGER, `size_value_id` INTEGER, `waist` REAL, `inseam` REAL, `purchase_price` REAL, `purchase_date` TEXT, `purchase_location` TEXT, `image_path` TEXT, `notes` TEXT, `status` TEXT NOT NULL DEFAULT 'Active', `wash_status` TEXT NOT NULL DEFAULT 'Clean', `is_favorite` INTEGER NOT NULL, `created_at` TEXT NOT NULL, `updated_at` TEXT NOT NULL, FOREIGN KEY(`category_id`) REFERENCES `categories`(`id`) ON UPDATE NO ACTION ON DELETE SET NULL , FOREIGN KEY(`subcategory_id`) REFERENCES `subcategories`(`id`) ON UPDATE NO ACTION ON DELETE SET NULL , FOREIGN KEY(`size_value_id`) REFERENCES `size_values`(`id`) ON UPDATE NO ACTION ON DELETE SET NULL , FOREIGN KEY(`brand_id`) REFERENCES `brands`(`id`) ON UPDATE NO ACTION ON DELETE SET NULL )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "brand",
+            "columnName": "brand",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "brandId",
+            "columnName": "brand_id",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "categoryId",
+            "columnName": "category_id",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "subcategoryId",
+            "columnName": "subcategory_id",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "sizeValueId",
+            "columnName": "size_value_id",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "waist",
+            "columnName": "waist",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "inseam",
+            "columnName": "inseam",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "purchasePrice",
+            "columnName": "purchase_price",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "purchaseDate",
+            "columnName": "purchase_date",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "purchaseLocation",
+            "columnName": "purchase_location",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "imagePath",
+            "columnName": "image_path",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "notes",
+            "columnName": "notes",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'Active'"
+          },
+          {
+            "fieldPath": "washStatus",
+            "columnName": "wash_status",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'Clean'"
+          },
+          {
+            "fieldPath": "isFavorite",
+            "columnName": "is_favorite",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_clothing_items_category_id",
+            "unique": false,
+            "columnNames": [
+              "category_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_clothing_items_category_id` ON `${TABLE_NAME}` (`category_id`)"
+          },
+          {
+            "name": "index_clothing_items_subcategory_id",
+            "unique": false,
+            "columnNames": [
+              "subcategory_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_clothing_items_subcategory_id` ON `${TABLE_NAME}` (`subcategory_id`)"
+          },
+          {
+            "name": "index_clothing_items_size_value_id",
+            "unique": false,
+            "columnNames": [
+              "size_value_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_clothing_items_size_value_id` ON `${TABLE_NAME}` (`size_value_id`)"
+          },
+          {
+            "name": "index_clothing_items_brand_id",
+            "unique": false,
+            "columnNames": [
+              "brand_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_clothing_items_brand_id` ON `${TABLE_NAME}` (`brand_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "categories",
+            "onDelete": "SET NULL",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "category_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "subcategories",
+            "onDelete": "SET NULL",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "subcategory_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "size_values",
+            "onDelete": "SET NULL",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "size_value_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "brands",
+            "onDelete": "SET NULL",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "brand_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "brands",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_brands_name",
+            "unique": true,
+            "columnNames": [
+              "name"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_brands_name` ON `${TABLE_NAME}` (`name`)"
+          }
+        ]
+      },
+      {
+        "tableName": "categories",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `icon` TEXT, `sort_order` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "icon",
+            "columnName": "icon",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sortOrder",
+            "columnName": "sort_order",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "subcategories",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `category_id` INTEGER NOT NULL, `name` TEXT NOT NULL, `sort_order` INTEGER NOT NULL, FOREIGN KEY(`category_id`) REFERENCES `categories`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "categoryId",
+            "columnName": "category_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sortOrder",
+            "columnName": "sort_order",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_subcategories_category_id",
+            "unique": false,
+            "columnNames": [
+              "category_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_subcategories_category_id` ON `${TABLE_NAME}` (`category_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "categories",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "category_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "seasons",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `icon` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "icon",
+            "columnName": "icon",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "occasions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `icon` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "icon",
+            "columnName": "icon",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "colors",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `hex` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hex",
+            "columnName": "hex",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "materials",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "patterns",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "size_systems",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "size_values",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `size_system_id` INTEGER NOT NULL, `value` TEXT NOT NULL, `sort_order` INTEGER NOT NULL, FOREIGN KEY(`size_system_id`) REFERENCES `size_systems`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sizeSystemId",
+            "columnName": "size_system_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "value",
+            "columnName": "value",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sortOrder",
+            "columnName": "sort_order",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_size_values_size_system_id",
+            "unique": false,
+            "columnNames": [
+              "size_system_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_size_values_size_system_id` ON `${TABLE_NAME}` (`size_system_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "size_systems",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "size_system_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "outfits",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT, `notes` TEXT, `created_at` TEXT NOT NULL, `updated_at` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "notes",
+            "columnName": "notes",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "outfit_items",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`outfit_id` INTEGER NOT NULL, `clothing_item_id` INTEGER NOT NULL, `pos_x` REAL, `pos_y` REAL, `scale` REAL, `z_index` INTEGER, PRIMARY KEY(`outfit_id`, `clothing_item_id`), FOREIGN KEY(`outfit_id`) REFERENCES `outfits`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`clothing_item_id`) REFERENCES `clothing_items`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "outfitId",
+            "columnName": "outfit_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "clothingItemId",
+            "columnName": "clothing_item_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "posX",
+            "columnName": "pos_x",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "posY",
+            "columnName": "pos_y",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "scale",
+            "columnName": "scale",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "zIndex",
+            "columnName": "z_index",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "outfit_id",
+            "clothing_item_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_outfit_items_clothing_item_id",
+            "unique": false,
+            "columnNames": [
+              "clothing_item_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_outfit_items_clothing_item_id` ON `${TABLE_NAME}` (`clothing_item_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "outfits",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "outfit_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "clothing_items",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "clothing_item_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "outfit_logs",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `outfit_id` INTEGER, `date` TEXT NOT NULL, `is_ootd` INTEGER NOT NULL, `notes` TEXT, `temperature_low` REAL, `temperature_high` REAL, `weather_condition` TEXT, `created_at` TEXT NOT NULL, FOREIGN KEY(`outfit_id`) REFERENCES `outfits`(`id`) ON UPDATE NO ACTION ON DELETE SET NULL )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "outfitId",
+            "columnName": "outfit_id",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "date",
+            "columnName": "date",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isOotd",
+            "columnName": "is_ootd",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "notes",
+            "columnName": "notes",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "temperatureLow",
+            "columnName": "temperature_low",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "temperatureHigh",
+            "columnName": "temperature_high",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "weatherCondition",
+            "columnName": "weather_condition",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_outfit_logs_outfit_id",
+            "unique": false,
+            "columnNames": [
+              "outfit_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_outfit_logs_outfit_id` ON `${TABLE_NAME}` (`outfit_id`)"
+          },
+          {
+            "name": "index_outfit_logs_date",
+            "unique": false,
+            "columnNames": [
+              "date"
+            ],
+            "orders": [
+              "ASC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_outfit_logs_date` ON `${TABLE_NAME}` (`date` ASC)"
+          },
+          {
+            "name": "index_outfit_logs_outfit_id_date",
+            "unique": true,
+            "columnNames": [
+              "outfit_id",
+              "date"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_outfit_logs_outfit_id_date` ON `${TABLE_NAME}` (`outfit_id`, `date`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "outfits",
+            "onDelete": "SET NULL",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "outfit_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "clothing_item_colors",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`clothing_item_id` INTEGER NOT NULL, `color_id` INTEGER NOT NULL, PRIMARY KEY(`clothing_item_id`, `color_id`), FOREIGN KEY(`clothing_item_id`) REFERENCES `clothing_items`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`color_id`) REFERENCES `colors`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "clothingItemId",
+            "columnName": "clothing_item_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "colorId",
+            "columnName": "color_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "clothing_item_id",
+            "color_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_clothing_item_colors_color_id",
+            "unique": false,
+            "columnNames": [
+              "color_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_clothing_item_colors_color_id` ON `${TABLE_NAME}` (`color_id`)"
+          },
+          {
+            "name": "index_clothing_item_colors_clothing_item_id",
+            "unique": false,
+            "columnNames": [
+              "clothing_item_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_clothing_item_colors_clothing_item_id` ON `${TABLE_NAME}` (`clothing_item_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "clothing_items",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "clothing_item_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "colors",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "color_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "clothing_item_materials",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`clothing_item_id` INTEGER NOT NULL, `material_id` INTEGER NOT NULL, PRIMARY KEY(`clothing_item_id`, `material_id`), FOREIGN KEY(`clothing_item_id`) REFERENCES `clothing_items`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`material_id`) REFERENCES `materials`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "clothingItemId",
+            "columnName": "clothing_item_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "materialId",
+            "columnName": "material_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "clothing_item_id",
+            "material_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_clothing_item_materials_material_id",
+            "unique": false,
+            "columnNames": [
+              "material_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_clothing_item_materials_material_id` ON `${TABLE_NAME}` (`material_id`)"
+          },
+          {
+            "name": "index_clothing_item_materials_clothing_item_id",
+            "unique": false,
+            "columnNames": [
+              "clothing_item_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_clothing_item_materials_clothing_item_id` ON `${TABLE_NAME}` (`clothing_item_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "clothing_items",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "clothing_item_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "materials",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "material_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "clothing_item_seasons",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`clothing_item_id` INTEGER NOT NULL, `season_id` INTEGER NOT NULL, PRIMARY KEY(`clothing_item_id`, `season_id`), FOREIGN KEY(`clothing_item_id`) REFERENCES `clothing_items`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`season_id`) REFERENCES `seasons`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "clothingItemId",
+            "columnName": "clothing_item_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "seasonId",
+            "columnName": "season_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "clothing_item_id",
+            "season_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_clothing_item_seasons_season_id",
+            "unique": false,
+            "columnNames": [
+              "season_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_clothing_item_seasons_season_id` ON `${TABLE_NAME}` (`season_id`)"
+          },
+          {
+            "name": "index_clothing_item_seasons_clothing_item_id",
+            "unique": false,
+            "columnNames": [
+              "clothing_item_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_clothing_item_seasons_clothing_item_id` ON `${TABLE_NAME}` (`clothing_item_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "clothing_items",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "clothing_item_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "seasons",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "season_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "clothing_item_occasions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`clothing_item_id` INTEGER NOT NULL, `occasion_id` INTEGER NOT NULL, PRIMARY KEY(`clothing_item_id`, `occasion_id`), FOREIGN KEY(`clothing_item_id`) REFERENCES `clothing_items`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`occasion_id`) REFERENCES `occasions`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "clothingItemId",
+            "columnName": "clothing_item_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "occasionId",
+            "columnName": "occasion_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "clothing_item_id",
+            "occasion_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_clothing_item_occasions_occasion_id",
+            "unique": false,
+            "columnNames": [
+              "occasion_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_clothing_item_occasions_occasion_id` ON `${TABLE_NAME}` (`occasion_id`)"
+          },
+          {
+            "name": "index_clothing_item_occasions_clothing_item_id",
+            "unique": false,
+            "columnNames": [
+              "clothing_item_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_clothing_item_occasions_clothing_item_id` ON `${TABLE_NAME}` (`clothing_item_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "clothing_items",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "clothing_item_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "occasions",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "occasion_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "clothing_item_patterns",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`clothing_item_id` INTEGER NOT NULL, `pattern_id` INTEGER NOT NULL, PRIMARY KEY(`clothing_item_id`, `pattern_id`), FOREIGN KEY(`clothing_item_id`) REFERENCES `clothing_items`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`pattern_id`) REFERENCES `patterns`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "clothingItemId",
+            "columnName": "clothing_item_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "patternId",
+            "columnName": "pattern_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "clothing_item_id",
+            "pattern_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_clothing_item_patterns_pattern_id",
+            "unique": false,
+            "columnNames": [
+              "pattern_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_clothing_item_patterns_pattern_id` ON `${TABLE_NAME}` (`pattern_id`)"
+          },
+          {
+            "name": "index_clothing_item_patterns_clothing_item_id",
+            "unique": false,
+            "columnNames": [
+              "clothing_item_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_clothing_item_patterns_clothing_item_id` ON `${TABLE_NAME}` (`clothing_item_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "clothing_items",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "clothing_item_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "patterns",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "pattern_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '327e69bd6afde50e6be113374fa122f1')"
+    ]
+  }
+}

--- a/app-android/core/data/src/main/kotlin/com/closet/core/data/ClothingDatabase.kt
+++ b/app-android/core/data/src/main/kotlin/com/closet/core/data/ClothingDatabase.kt
@@ -10,6 +10,7 @@ import com.closet.core.data.dao.*
 import com.closet.core.data.migrations.MIGRATION_1_2
 import com.closet.core.data.migrations.MIGRATION_2_3
 import com.closet.core.data.migrations.MIGRATION_3_4
+import com.closet.core.data.migrations.MIGRATION_4_5
 import com.closet.core.data.model.*
 
 /**
@@ -39,7 +40,7 @@ import com.closet.core.data.model.*
         ClothingItemOccasionEntity::class,
         ClothingItemPatternEntity::class
     ],
-    version = 4,
+    version = 5,
     exportSchema = true
 )
 @TypeConverters(Converters::class)
@@ -74,7 +75,7 @@ abstract class ClothingDatabase : RoomDatabase() {
                     ClothingDatabase::class.java,
                     DATABASE_NAME
                 )
-                .addMigrations(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4)
+                .addMigrations(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5)
                 .addCallback(object : Callback() {
                     override fun onCreate(db: SupportSQLiteDatabase) {
                         super.onCreate(db)

--- a/app-android/core/data/src/main/kotlin/com/closet/core/data/ClothingDatabase.kt
+++ b/app-android/core/data/src/main/kotlin/com/closet/core/data/ClothingDatabase.kt
@@ -44,6 +44,8 @@ import com.closet.core.data.model.*
 abstract class ClothingDatabase : RoomDatabase() {
     /** @return [ClothingDao] for clothing item operations. */
     abstract fun clothingDao(): ClothingDao
+    /** @return [BrandDao] for brand management. */
+    abstract fun brandDao(): BrandDao
     /** @return [LookupDao] for lookup table queries. */
     abstract fun lookupDao(): LookupDao
     /** @return [OutfitDao] for outfit management. */

--- a/app-android/core/data/src/main/kotlin/com/closet/core/data/ClothingDatabase.kt
+++ b/app-android/core/data/src/main/kotlin/com/closet/core/data/ClothingDatabase.kt
@@ -18,6 +18,7 @@ import com.closet.core.data.model.*
 @Database(
     entities = [
         ClothingItemEntity::class,
+        BrandEntity::class,
         CategoryEntity::class,
         SubcategoryEntity::class,
         SeasonEntity::class,
@@ -36,7 +37,7 @@ import com.closet.core.data.model.*
         ClothingItemOccasionEntity::class,
         ClothingItemPatternEntity::class
     ],
-    version = 3,
+    version = 4,
     exportSchema = true
 )
 @TypeConverters(Converters::class)
@@ -92,6 +93,56 @@ abstract class ClothingDatabase : RoomDatabase() {
         }
 
         /**
+         * Migration 3→4: introduce the brands lookup table and migrate the free-text brand column
+         * to a proper FK relationship.
+         *
+         * Steps:
+         *   1. Create brands table with unique index on name.
+         *   2. Backfill brands from distinct values in clothing_items.brand (user data first).
+         *   3. Add brand_id FK column to clothing_items.
+         *   4. Populate brand_id by matching the backfilled names.
+         *   5. Seed common brands (INSERT OR IGNORE — backfilled rows are not overwritten).
+         *
+         * Note: The old `brand` TEXT column is kept in place. SQLite cannot drop columns before
+         * API 35, and a table recreation is not worth the risk here. The column is no longer
+         * written to by new code; reads go through the brand_id join.
+         */
+        private val MIGRATION_3_4 = object : Migration(3, 4) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                // 1. Create brands table
+                db.execSQL(
+                    "CREATE TABLE IF NOT EXISTS `brands` (" +
+                    "`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, " +
+                    "`name` TEXT NOT NULL)"
+                )
+                db.execSQL(
+                    "CREATE UNIQUE INDEX IF NOT EXISTS `index_brands_name` ON `brands` (`name`)"
+                )
+
+                // 2. Backfill brands from existing free-text data
+                db.execSQL(
+                    "INSERT OR IGNORE INTO brands (name) " +
+                    "SELECT DISTINCT brand FROM clothing_items " +
+                    "WHERE brand IS NOT NULL AND brand != ''"
+                )
+
+                // 3. Add brand_id FK column
+                db.execSQL("ALTER TABLE clothing_items ADD COLUMN brand_id INTEGER REFERENCES brands(id) ON DELETE SET NULL")
+                db.execSQL("CREATE INDEX IF NOT EXISTS `index_clothing_items_brand_id` ON `clothing_items` (`brand_id`)")
+
+                // 4. Populate brand_id from backfilled rows (exact string match; case differences are accepted)
+                db.execSQL(
+                    "UPDATE clothing_items " +
+                    "SET brand_id = (SELECT id FROM brands WHERE brands.name = clothing_items.brand) " +
+                    "WHERE brand IS NOT NULL AND brand != ''"
+                )
+
+                // 5. Seed common starter brands (user backfill takes priority via INSERT OR IGNORE above)
+                DatabaseSeeder.seedBrands(db)
+            }
+        }
+
+        /**
          * Migration 2→3: enforce one wear-log per outfit per day.
          * The unique index mirrors the OutfitLogEntity annotation added in the same change;
          * the app-level check in LogRepository.wearOutfitToday is the primary guard,
@@ -118,7 +169,7 @@ abstract class ClothingDatabase : RoomDatabase() {
                     ClothingDatabase::class.java,
                     DATABASE_NAME
                 )
-                .addMigrations(MIGRATION_1_2, MIGRATION_2_3)
+                .addMigrations(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4)
                 .addCallback(object : Callback() {
                     override fun onCreate(db: SupportSQLiteDatabase) {
                         super.onCreate(db)

--- a/app-android/core/data/src/main/kotlin/com/closet/core/data/ClothingDatabase.kt
+++ b/app-android/core/data/src/main/kotlin/com/closet/core/data/ClothingDatabase.kt
@@ -141,6 +141,10 @@ abstract class ClothingDatabase : RoomDatabase() {
 
                 // 5. Seed common starter brands (user backfill takes priority via INSERT OR IGNORE above)
                 DatabaseSeeder.seedBrands(db)
+
+                // 6. Ensure the one-OOTD-per-day partial index exists on upgraded databases.
+                //    Fresh installs get this via the onCreate callback; migrations must add it explicitly.
+                db.execSQL("CREATE UNIQUE INDEX IF NOT EXISTS one_ootd_per_day ON outfit_logs(date) WHERE is_ootd = 1")
             }
         }
 

--- a/app-android/core/data/src/main/kotlin/com/closet/core/data/ClothingDatabase.kt
+++ b/app-android/core/data/src/main/kotlin/com/closet/core/data/ClothingDatabase.kt
@@ -5,9 +5,11 @@ import androidx.room.Database
 import androidx.room.Room
 import androidx.room.RoomDatabase
 import androidx.room.TypeConverters
-import androidx.room.migration.Migration
 import androidx.sqlite.db.SupportSQLiteDatabase
 import com.closet.core.data.dao.*
+import com.closet.core.data.migrations.MIGRATION_1_2
+import com.closet.core.data.migrations.MIGRATION_2_3
+import com.closet.core.data.migrations.MIGRATION_3_4
 import com.closet.core.data.model.*
 
 /**
@@ -60,109 +62,6 @@ abstract class ClothingDatabase : RoomDatabase() {
 
         @Volatile
         private var INSTANCE: ClothingDatabase? = null
-
-        /**
-         * Migration from version 1 to 2: Add layout columns to outfit_items and populate colors.
-         * Note: Columns are checked before adding to avoid errors if they already exist in some v1 versions.
-         */
-        private val MIGRATION_1_2 = object : Migration(1, 2) {
-            override fun migrate(db: SupportSQLiteDatabase) {
-                val cursor = db.query("PRAGMA table_info(outfit_items)")
-                val existingColumns = mutableSetOf<String>()
-                while (cursor.moveToNext()) {
-                    val nameIndex = cursor.getColumnIndex("name")
-                    if (nameIndex != -1) {
-                        existingColumns.add(cursor.getString(nameIndex))
-                    }
-                }
-                cursor.close()
-
-                if (!existingColumns.contains("pos_x")) {
-                    db.execSQL("ALTER TABLE outfit_items ADD COLUMN pos_x REAL")
-                }
-                if (!existingColumns.contains("pos_y")) {
-                    db.execSQL("ALTER TABLE outfit_items ADD COLUMN pos_y REAL")
-                }
-                if (!existingColumns.contains("scale")) {
-                    db.execSQL("ALTER TABLE outfit_items ADD COLUMN scale REAL")
-                }
-                if (!existingColumns.contains("z_index")) {
-                    db.execSQL("ALTER TABLE outfit_items ADD COLUMN z_index INTEGER")
-                }
-
-                DatabaseSeeder.seedColors(db)
-            }
-        }
-
-        /**
-         * Migration 3→4: introduce the brands lookup table and migrate the free-text brand column
-         * to a proper FK relationship.
-         *
-         * Steps:
-         *   1. Create brands table with unique index on name.
-         *   2. Backfill brands from distinct values in clothing_items.brand (user data first).
-         *   3. Add brand_id FK column to clothing_items.
-         *   4. Populate brand_id by matching the backfilled names.
-         *   5. Seed common brands (INSERT OR IGNORE — backfilled rows are not overwritten).
-         *
-         * Note: The old `brand` TEXT column is kept in place. SQLite cannot drop columns before
-         * API 35, and a table recreation is not worth the risk here. The column is no longer
-         * written to by new code; reads go through the brand_id join.
-         */
-        private val MIGRATION_3_4 = object : Migration(3, 4) {
-            override fun migrate(db: SupportSQLiteDatabase) {
-                // 1. Create brands table
-                db.execSQL(
-                    "CREATE TABLE IF NOT EXISTS `brands` (" +
-                    "`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, " +
-                    "`name` TEXT NOT NULL)"
-                )
-                db.execSQL(
-                    "CREATE UNIQUE INDEX IF NOT EXISTS `index_brands_name` ON `brands` (`name`)"
-                )
-
-                // 2. Backfill brands from existing free-text data
-                db.execSQL(
-                    "INSERT OR IGNORE INTO brands (name) " +
-                    "SELECT DISTINCT brand FROM clothing_items " +
-                    "WHERE brand IS NOT NULL AND brand != ''"
-                )
-
-                // 3. Add brand_id FK column
-                db.execSQL("ALTER TABLE clothing_items ADD COLUMN brand_id INTEGER REFERENCES brands(id) ON DELETE SET NULL")
-                db.execSQL("CREATE INDEX IF NOT EXISTS `index_clothing_items_brand_id` ON `clothing_items` (`brand_id`)")
-
-                // 4. Populate brand_id from backfilled rows (exact string match; case differences are accepted)
-                db.execSQL(
-                    "UPDATE clothing_items " +
-                    "SET brand_id = (SELECT id FROM brands WHERE brands.name = clothing_items.brand) " +
-                    "WHERE brand IS NOT NULL AND brand != ''"
-                )
-
-                // 5. Seed common starter brands (user backfill takes priority via INSERT OR IGNORE above)
-                DatabaseSeeder.seedBrands(db)
-
-                // 6. Ensure the one-OOTD-per-day partial index exists on upgraded databases.
-                //    Fresh installs get this via the onCreate callback; migrations must add it explicitly.
-                db.execSQL("CREATE UNIQUE INDEX IF NOT EXISTS one_ootd_per_day ON outfit_logs(date) WHERE is_ootd = 1")
-            }
-        }
-
-        /**
-         * Migration 2→3: enforce one wear-log per outfit per day.
-         * The unique index mirrors the OutfitLogEntity annotation added in the same change;
-         * the app-level check in LogRepository.wearOutfitToday is the primary guard,
-         * but the index acts as a hard safety net at the schema level.
-         * Note: SQLite treats NULL as distinct, so rows with outfit_id = NULL are unaffected.
-         */
-        private val MIGRATION_2_3 = object : Migration(2, 3) {
-            override fun migrate(db: SupportSQLiteDatabase) {
-                db.execSQL(
-                    "CREATE UNIQUE INDEX IF NOT EXISTS `index_outfit_logs_outfit_id_date` " +
-                    "ON `outfit_logs` (`outfit_id`, `date`)"
-                )
-            }
-        }
 
         /**
          * Returns a singleton instance of the database.

--- a/app-android/core/data/src/main/kotlin/com/closet/core/data/Converters.kt
+++ b/app-android/core/data/src/main/kotlin/com/closet/core/data/Converters.kt
@@ -6,42 +6,57 @@ import com.closet.core.data.model.WashStatus
 import com.closet.core.data.model.WeatherCondition
 import java.time.Instant
 
+/**
+ * Room [TypeConverter]s for domain types that cannot be stored natively in SQLite.
+ *
+ * Registered via `@TypeConverters(Converters::class)` on [com.closet.core.data.ClothingDatabase].
+ * Converts [Instant] ↔ ISO-8601 string and the three status enums ↔ their string labels.
+ */
 class Converters {
+
+    /** Parses an ISO-8601 timestamp string to [Instant], or returns null for a null input. */
     @TypeConverter
     fun fromTimestamp(value: String?): Instant? {
         return value?.let { Instant.parse(it) }
     }
 
+    /** Serializes an [Instant] to its ISO-8601 string representation for storage. */
     @TypeConverter
     fun dateToTimestamp(date: Instant?): String? {
         return date?.toString()
     }
 
+    /** Serializes [ClothingStatus] to its string label for storage. */
     @TypeConverter
     fun fromClothingStatus(status: ClothingStatus): String {
         return status.label
     }
 
+    /** Deserializes a stored label string back to a [ClothingStatus] value. */
     @TypeConverter
     fun toClothingStatus(value: String): ClothingStatus {
         return ClothingStatus.fromString(value)
     }
 
+    /** Serializes [WashStatus] to its string label for storage. */
     @TypeConverter
     fun fromWashStatus(status: WashStatus): String {
         return status.label
     }
 
+    /** Deserializes a stored label string back to a [WashStatus] value. */
     @TypeConverter
     fun toWashStatus(value: String): WashStatus {
         return WashStatus.fromString(value)
     }
 
+    /** Serializes a nullable [WeatherCondition] to its string label, or null. */
     @TypeConverter
     fun fromWeatherCondition(condition: WeatherCondition?): String? {
         return condition?.label
     }
 
+    /** Deserializes a nullable label string back to a [WeatherCondition] value. */
     @TypeConverter
     fun toWeatherCondition(value: String?): WeatherCondition? {
         return WeatherCondition.fromString(value)

--- a/app-android/core/data/src/main/kotlin/com/closet/core/data/DatabaseSeeder.kt
+++ b/app-android/core/data/src/main/kotlin/com/closet/core/data/DatabaseSeeder.kt
@@ -3,11 +3,19 @@ package com.closet.core.data
 import androidx.sqlite.db.SupportSQLiteDatabase
 
 /**
- * Mirror of seed files in hangr/db/seeds.
- * Canonical values sourced from closet-migrations skills and reference.md.
+ * Seeds all static lookup tables (categories, subcategories, seasons, occasions, colors,
+ * materials, patterns, size systems) on first database creation.
+ *
+ * Mirror of seed files in hangr/db/seeds. Canonical values sourced from the
+ * closet-migrations skill. All inserts use `INSERT OR IGNORE` so seeds are idempotent
+ * and safe to re-run without duplicating rows.
  */
 object DatabaseSeeder {
 
+    /**
+     * Runs all seed functions inside a single transaction.
+     * Called by [com.closet.core.data.ClothingDatabase] from [androidx.room.RoomDatabase.Callback.onCreate].
+     */
     fun seedAll(db: SupportSQLiteDatabase) {
         db.beginTransaction()
         try {
@@ -25,6 +33,7 @@ object DatabaseSeeder {
         }
     }
 
+    /** Seeds the 10 top-level clothing categories with stable IDs (1–10). */
     private fun seedCategories(db: SupportSQLiteDatabase) {
         val categories = listOf(
             Triple("Tops", "t-shirt", 1),
@@ -46,6 +55,7 @@ object DatabaseSeeder {
         }
     }
 
+    /** Seeds subcategories mapped to their parent category IDs (1–10). */
     private fun seedSubcategories(db: SupportSQLiteDatabase) {
         val mapping = mapOf(
             1L to listOf("T-Shirt", "Tank Top", "Blouse", "Shirt", "Polo", "Sweater", "Hoodie", "Sweatshirt", "Cardigan", "Bodysuit"),
@@ -69,6 +79,7 @@ object DatabaseSeeder {
         }
     }
 
+    /** Seeds the 5 seasons (Spring, Summer, Fall, Winter, All Season) with Phosphor icons. */
     private fun seedSeasons(db: SupportSQLiteDatabase) {
         val seasons = listOf(
             "Spring" to "flower",
@@ -85,6 +96,7 @@ object DatabaseSeeder {
         }
     }
 
+    /** Seeds the 9 occasion types (Casual, Work/Business, Formal, etc.) with Phosphor icons. */
     private fun seedOccasions(db: SupportSQLiteDatabase) {
         val occasions = listOf(
             "Casual" to "coffee",
@@ -105,6 +117,10 @@ object DatabaseSeeder {
         }
     }
 
+    /**
+     * Seeds 18 named colors with hex codes.
+     * Public so it can be called independently in migrations that backfill color data.
+     */
     fun seedColors(db: SupportSQLiteDatabase) {
         val colors = listOf(
             "Black" to "#000000",
@@ -134,6 +150,7 @@ object DatabaseSeeder {
         }
     }
 
+    /** Seeds 23 fabric/material types including natural fibers, synthetics, and "Other". */
     private fun seedMaterials(db: SupportSQLiteDatabase) {
         val materials = listOf(
             "Cotton", "Polyester", "Wool", "Linen", "Silk", "Denim", "Leather",
@@ -146,6 +163,7 @@ object DatabaseSeeder {
         }
     }
 
+    /** Seeds 17 visual patterns (Solid, Striped, Floral, etc.) including "Other". */
     private fun seedPatterns(db: SupportSQLiteDatabase) {
         val patterns = listOf(
             "Solid", "Striped", "Plaid/Tartan", "Checkered", "Floral", "Geometric",
@@ -168,6 +186,10 @@ object DatabaseSeeder {
         }
     }
 
+    /**
+     * Seeds 4 size systems (Letter, Women's Numeric, Shoes (US Men's), One Size) with
+     * their associated size values. System IDs are hardcoded starting at 1.
+     */
     private fun seedSizeSystems(db: SupportSQLiteDatabase) {
         val systems = mapOf(
             "Letter" to listOf("XS", "S", "M", "L", "XL", "XXL", "XXXL"),

--- a/app-android/core/data/src/main/kotlin/com/closet/core/data/DatabaseSeeder.kt
+++ b/app-android/core/data/src/main/kotlin/com/closet/core/data/DatabaseSeeder.kt
@@ -157,6 +157,17 @@ object DatabaseSeeder {
         }
     }
 
+    /**
+     * Seeds a starter set of common brands. Called only from MIGRATION_3_4 — not from seedAll.
+     * Uses INSERT OR IGNORE so user-backfilled data from the migration takes priority.
+     */
+    internal fun seedBrands(db: SupportSQLiteDatabase) {
+        val brands = listOf("Adidas", "Gap", "H&M", "Levi's", "Mango", "Nike", "Uniqlo", "Zara")
+        brands.forEach { name ->
+            db.execSQL("INSERT OR IGNORE INTO brands (name) VALUES (?)", arrayOf<Any>(name))
+        }
+    }
+
     private fun seedSizeSystems(db: SupportSQLiteDatabase) {
         val systems = mapOf(
             "Letter" to listOf("XS", "S", "M", "L", "XL", "XXL", "XXXL"),

--- a/app-android/core/data/src/main/kotlin/com/closet/core/data/dao/BrandDao.kt
+++ b/app-android/core/data/src/main/kotlin/com/closet/core/data/dao/BrandDao.kt
@@ -6,24 +6,41 @@ import androidx.room.Update
 import com.closet.core.data.model.BrandEntity
 import kotlinx.coroutines.flow.Flow
 
+/**
+ * DAO for brand lookup data. All write operations use raw SQL to avoid Room
+ * auto-generating a full entity insert for the name-only table.
+ */
 @Dao
 interface BrandDao {
 
+    /** Returns all brands ordered alphabetically as a live [Flow]. */
     @Query("SELECT * FROM brands ORDER BY name")
     fun getAllBrands(): Flow<List<BrandEntity>>
 
+    /** Returns the brand with the given [id], or null if not found. */
     @Query("SELECT * FROM brands WHERE id = :id")
     suspend fun getBrandById(id: Long): BrandEntity?
 
+    /**
+     * Inserts a new brand with the given [name].
+     * @return The row ID of the newly inserted brand.
+     * @throws android.database.sqlite.SQLiteConstraintException if a brand with [name] already exists.
+     */
     @Query("INSERT INTO brands (name) VALUES (:name)")
     suspend fun insertBrand(name: String): Long
 
+    /** Updates the brand record (name change). */
     @Update
     suspend fun updateBrand(brand: BrandEntity)
 
+    /**
+     * Deletes the brand only if no clothing items reference it.
+     * @return The number of rows deleted (0 if the brand is still in use, 1 on success).
+     */
     @Query("DELETE FROM brands WHERE id = :id AND NOT EXISTS (SELECT 1 FROM clothing_items WHERE brand_id = :id)")
     suspend fun deleteBrandIfUnused(id: Long): Int
 
+    /** Returns the number of clothing items currently assigned to [brandId]. */
     @Query("SELECT COUNT(*) FROM clothing_items WHERE brand_id = :brandId")
     suspend fun getItemCountForBrand(brandId: Long): Int
 }

--- a/app-android/core/data/src/main/kotlin/com/closet/core/data/dao/BrandDao.kt
+++ b/app-android/core/data/src/main/kotlin/com/closet/core/data/dao/BrandDao.kt
@@ -1,0 +1,29 @@
+package com.closet.core.data.dao
+
+import androidx.room.Dao
+import androidx.room.Query
+import androidx.room.Update
+import com.closet.core.data.model.BrandEntity
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface BrandDao {
+
+    @Query("SELECT * FROM brands ORDER BY name")
+    fun getAllBrands(): Flow<List<BrandEntity>>
+
+    @Query("SELECT * FROM brands WHERE id = :id")
+    suspend fun getBrandById(id: Long): BrandEntity?
+
+    @Query("INSERT INTO brands (name) VALUES (:name)")
+    suspend fun insertBrand(name: String): Long
+
+    @Update
+    suspend fun updateBrand(brand: BrandEntity)
+
+    @Query("DELETE FROM brands WHERE id = :id")
+    suspend fun deleteBrand(id: Long)
+
+    @Query("SELECT COUNT(*) FROM clothing_items WHERE brand_id = :brandId")
+    suspend fun getItemCountForBrand(brandId: Long): Int
+}

--- a/app-android/core/data/src/main/kotlin/com/closet/core/data/dao/BrandDao.kt
+++ b/app-android/core/data/src/main/kotlin/com/closet/core/data/dao/BrandDao.kt
@@ -22,16 +22,19 @@ interface BrandDao {
     suspend fun getBrandById(id: Long): BrandEntity?
 
     /**
-     * Inserts a new brand with the given [name].
+     * Inserts a new brand with the given [name] and its lowercase [normalizedName].
      * @return The row ID of the newly inserted brand.
-     * @throws android.database.sqlite.SQLiteConstraintException if a brand with [name] already exists.
+     * @throws android.database.sqlite.SQLiteConstraintException if a brand with [normalizedName] already exists.
      */
-    @Query("INSERT INTO brands (name) VALUES (:name)")
-    suspend fun insertBrand(name: String): Long
+    @Query("INSERT INTO brands (name, normalized_name) VALUES (:name, :normalizedName)")
+    suspend fun insertBrand(name: String, normalizedName: String): Long
 
-    /** Updates the brand record (name change). */
+    /**
+     * Updates the brand record (name change).
+     * @return The number of rows updated (0 if the brand ID was not found).
+     */
     @Update
-    suspend fun updateBrand(brand: BrandEntity)
+    suspend fun updateBrand(brand: BrandEntity): Int
 
     /**
      * Deletes the brand only if no clothing items reference it.

--- a/app-android/core/data/src/main/kotlin/com/closet/core/data/dao/BrandDao.kt
+++ b/app-android/core/data/src/main/kotlin/com/closet/core/data/dao/BrandDao.kt
@@ -21,8 +21,8 @@ interface BrandDao {
     @Update
     suspend fun updateBrand(brand: BrandEntity)
 
-    @Query("DELETE FROM brands WHERE id = :id")
-    suspend fun deleteBrand(id: Long)
+    @Query("DELETE FROM brands WHERE id = :id AND NOT EXISTS (SELECT 1 FROM clothing_items WHERE brand_id = :id)")
+    suspend fun deleteBrandIfUnused(id: Long): Int
 
     @Query("SELECT COUNT(*) FROM clothing_items WHERE brand_id = :brandId")
     suspend fun getItemCountForBrand(brandId: Long): Int

--- a/app-android/core/data/src/main/kotlin/com/closet/core/data/dao/ClothingDao.kt
+++ b/app-android/core/data/src/main/kotlin/com/closet/core/data/dao/ClothingDao.kt
@@ -19,7 +19,7 @@ interface ClothingDao {
      */
     @Query("""
         SELECT
-            ci.id, ci.name, ci.brand, ci.image_path, ci.purchase_price, ci.status, ci.is_favorite, ci.wash_status,
+            ci.id, ci.name, b.name AS brand, ci.image_path, ci.purchase_price, ci.status, ci.is_favorite, ci.wash_status,
             c.name  AS category_name,
             sc.name AS subcategory_name,
             (
@@ -31,6 +31,7 @@ interface ClothingDao {
         FROM clothing_items ci
         LEFT JOIN categories    c  ON ci.category_id    = c.id
         LEFT JOIN subcategories sc ON ci.subcategory_id = sc.id
+        LEFT JOIN brands        b  ON ci.brand_id       = b.id
         ORDER BY ci.created_at DESC
     """)
     fun getAllClothingItems(): Flow<List<ClothingItemWithMeta>>
@@ -42,7 +43,7 @@ interface ClothingDao {
      */
     @Query("""
         SELECT
-            ci.id, ci.name, ci.brand, ci.image_path, ci.purchase_price, ci.status, ci.is_favorite, ci.wash_status,
+            ci.id, ci.name, b.name AS brand, ci.image_path, ci.purchase_price, ci.status, ci.is_favorite, ci.wash_status,
             c.name  AS category_name,
             sc.name AS subcategory_name,
             (
@@ -54,6 +55,7 @@ interface ClothingDao {
         FROM clothing_items ci
         LEFT JOIN categories    c  ON ci.category_id    = c.id
         LEFT JOIN subcategories sc ON ci.subcategory_id = sc.id
+        LEFT JOIN brands        b  ON ci.brand_id       = b.id
         WHERE ci.id = :id
     """)
     suspend fun getClothingItemById(id: Long): ClothingItemWithMeta?

--- a/app-android/core/data/src/main/kotlin/com/closet/core/data/dao/ClothingDao.kt
+++ b/app-android/core/data/src/main/kotlin/com/closet/core/data/dao/ClothingDao.kt
@@ -5,6 +5,17 @@ import com.closet.core.data.model.*
 import kotlinx.coroutines.flow.Flow
 
 /**
+ * Correlated subquery that counts distinct outfit log entries for a clothing item.
+ * Requires the `ci` alias to be in scope (clothing_items). Alias `wear_count` is included.
+ */
+private const val WEAR_COUNT_SUBQUERY = """(
+        SELECT COUNT(DISTINCT ol.id)
+        FROM outfit_logs ol
+        JOIN outfit_items oi ON ol.outfit_id = oi.outfit_id
+        WHERE oi.clothing_item_id = ci.id
+    ) AS wear_count"""
+
+/**
  * Data Access Object for clothing items and their associated metadata.
  * Provides methods for querying, inserting, updating, and deleting items.
  * Parity: This is the native equivalent of queries.ts from the Expo project.
@@ -22,12 +33,7 @@ interface ClothingDao {
             ci.id, ci.name, b.name AS brand, ci.image_path, ci.purchase_price, ci.status, ci.is_favorite, ci.wash_status,
             c.name  AS category_name,
             sc.name AS subcategory_name,
-            (
-                SELECT COUNT(DISTINCT ol.id)
-                FROM outfit_logs ol
-                JOIN outfit_items oi ON ol.outfit_id = oi.outfit_id
-                WHERE oi.clothing_item_id = ci.id
-            ) AS wear_count
+            """ + WEAR_COUNT_SUBQUERY + """
         FROM clothing_items ci
         LEFT JOIN categories    c  ON ci.category_id    = c.id
         LEFT JOIN subcategories sc ON ci.subcategory_id = sc.id
@@ -46,12 +52,7 @@ interface ClothingDao {
             ci.id, ci.name, b.name AS brand, ci.image_path, ci.purchase_price, ci.status, ci.is_favorite, ci.wash_status,
             c.name  AS category_name,
             sc.name AS subcategory_name,
-            (
-                SELECT COUNT(DISTINCT ol.id)
-                FROM outfit_logs ol
-                JOIN outfit_items oi ON ol.outfit_id = oi.outfit_id
-                WHERE oi.clothing_item_id = ci.id
-            ) AS wear_count
+            """ + WEAR_COUNT_SUBQUERY + """
         FROM clothing_items ci
         LEFT JOIN categories    c  ON ci.category_id    = c.id
         LEFT JOIN subcategories sc ON ci.subcategory_id = sc.id
@@ -65,14 +66,7 @@ interface ClothingDao {
      * @return A [Flow] emitting a list of [ClothingItemDetail].
      */
     @Transaction
-    @Query("""
-        SELECT ci.*,
-            (
-                SELECT COUNT(DISTINCT ol.id)
-                FROM outfit_logs ol
-                JOIN outfit_items oi ON ol.outfit_id = oi.outfit_id
-                WHERE oi.clothing_item_id = ci.id
-            ) AS wear_count
+    @Query("SELECT ci.*, " + WEAR_COUNT_SUBQUERY + """
         FROM clothing_items ci
         ORDER BY ci.created_at DESC
     """)
@@ -84,14 +78,7 @@ interface ClothingDao {
      * @return A [Flow] emitting the [ClothingItemDetail] if found.
      */
     @Transaction
-    @Query("""
-        SELECT ci.*,
-            (
-                SELECT COUNT(DISTINCT ol.id)
-                FROM outfit_logs ol
-                JOIN outfit_items oi ON ol.outfit_id = oi.outfit_id
-                WHERE oi.clothing_item_id = ci.id
-            ) AS wear_count
+    @Query("SELECT ci.*, " + WEAR_COUNT_SUBQUERY + """
         FROM clothing_items ci
         WHERE ci.id = :id
     """)

--- a/app-android/core/data/src/main/kotlin/com/closet/core/data/dao/LookupDao.kt
+++ b/app-android/core/data/src/main/kotlin/com/closet/core/data/dao/LookupDao.kt
@@ -77,10 +77,4 @@ interface LookupDao {
     @Query("SELECT * FROM size_values WHERE size_system_id = :systemId ORDER BY sort_order")
     fun getSizeValues(systemId: Long): Flow<List<SizeValueEntity>>
 
-    /**
-     * Retrieves a distinct list of all brands currently in the wardrobe.
-     * @return A list of brand names.
-     */
-    @Query("SELECT DISTINCT brand FROM clothing_items WHERE brand IS NOT NULL AND brand != '' ORDER BY brand")
-    suspend fun getDistinctBrands(): List<String>
 }

--- a/app-android/core/data/src/main/kotlin/com/closet/core/data/di/DataModule.kt
+++ b/app-android/core/data/src/main/kotlin/com/closet/core/data/di/DataModule.kt
@@ -39,4 +39,8 @@ object DataModule {
     @Provides
     @Singleton
     fun provideStatsDao(db: ClothingDatabase): StatsDao = db.statsDao()
+
+    @Provides
+    @Singleton
+    fun provideBrandDao(db: ClothingDatabase): BrandDao = db.brandDao()
 }

--- a/app-android/core/data/src/main/kotlin/com/closet/core/data/di/DataModule.kt
+++ b/app-android/core/data/src/main/kotlin/com/closet/core/data/di/DataModule.kt
@@ -10,36 +10,49 @@ import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
 import javax.inject.Singleton
 
+/**
+ * Hilt module that provides the Room database and all DAO singletons.
+ *
+ * Installed in [dagger.hilt.components.SingletonComponent] so every DAO and
+ * repository shares a single [ClothingDatabase] instance for the app's lifetime.
+ */
 @Module
 @InstallIn(SingletonComponent::class)
 object DataModule {
 
+    /** Provides the single [ClothingDatabase] instance for the application. */
     @Provides
     @Singleton
     fun provideDatabase(@ApplicationContext context: Context): ClothingDatabase {
         return ClothingDatabase.getDatabase(context)
     }
 
+    /** Provides the [ClothingDao] singleton from the shared database instance. */
     @Provides
     @Singleton
     fun provideClothingDao(db: ClothingDatabase): ClothingDao = db.clothingDao()
 
+    /** Provides the [LookupDao] singleton from the shared database instance. */
     @Provides
     @Singleton
     fun provideLookupDao(db: ClothingDatabase): LookupDao = db.lookupDao()
 
+    /** Provides the [OutfitDao] singleton from the shared database instance. */
     @Provides
     @Singleton
     fun provideOutfitDao(db: ClothingDatabase): OutfitDao = db.outfitDao()
 
+    /** Provides the [LogDao] singleton from the shared database instance. */
     @Provides
     @Singleton
     fun provideLogDao(db: ClothingDatabase): LogDao = db.logDao()
 
+    /** Provides the [StatsDao] singleton from the shared database instance. */
     @Provides
     @Singleton
     fun provideStatsDao(db: ClothingDatabase): StatsDao = db.statsDao()
 
+    /** Provides the [BrandDao] singleton from the shared database instance. */
     @Provides
     @Singleton
     fun provideBrandDao(db: ClothingDatabase): BrandDao = db.brandDao()

--- a/app-android/core/data/src/main/kotlin/com/closet/core/data/migrations/Migration1To2.kt
+++ b/app-android/core/data/src/main/kotlin/com/closet/core/data/migrations/Migration1To2.kt
@@ -1,0 +1,28 @@
+package com.closet.core.data.migrations
+
+import androidx.room.migration.Migration
+import androidx.sqlite.db.SupportSQLiteDatabase
+import com.closet.core.data.DatabaseSeeder
+
+/**
+ * Migration 1→2: Add layout columns to outfit_items and populate colors.
+ * Columns are checked before adding to avoid errors if they already exist in some v1 versions.
+ */
+val MIGRATION_1_2 = object : Migration(1, 2) {
+    override fun migrate(db: SupportSQLiteDatabase) {
+        if (!columnExists(db, "outfit_items", "pos_x")) {
+            db.execSQL("ALTER TABLE outfit_items ADD COLUMN pos_x REAL")
+        }
+        if (!columnExists(db, "outfit_items", "pos_y")) {
+            db.execSQL("ALTER TABLE outfit_items ADD COLUMN pos_y REAL")
+        }
+        if (!columnExists(db, "outfit_items", "scale")) {
+            db.execSQL("ALTER TABLE outfit_items ADD COLUMN scale REAL")
+        }
+        if (!columnExists(db, "outfit_items", "z_index")) {
+            db.execSQL("ALTER TABLE outfit_items ADD COLUMN z_index INTEGER")
+        }
+
+        DatabaseSeeder.seedColors(db)
+    }
+}

--- a/app-android/core/data/src/main/kotlin/com/closet/core/data/migrations/Migration2To3.kt
+++ b/app-android/core/data/src/main/kotlin/com/closet/core/data/migrations/Migration2To3.kt
@@ -1,0 +1,20 @@
+package com.closet.core.data.migrations
+
+import androidx.room.migration.Migration
+import androidx.sqlite.db.SupportSQLiteDatabase
+
+/**
+ * Migration 2→3: Enforce one wear-log per outfit per day.
+ * The unique index mirrors the OutfitLogEntity annotation added in the same change;
+ * the app-level check in LogRepository.wearOutfitToday is the primary guard,
+ * but the index acts as a hard safety net at the schema level.
+ * Note: SQLite treats NULL as distinct, so rows with outfit_id = NULL are unaffected.
+ */
+val MIGRATION_2_3 = object : Migration(2, 3) {
+    override fun migrate(db: SupportSQLiteDatabase) {
+        db.execSQL(
+            "CREATE UNIQUE INDEX IF NOT EXISTS `index_outfit_logs_outfit_id_date` " +
+            "ON `outfit_logs` (`outfit_id`, `date`)"
+        )
+    }
+}

--- a/app-android/core/data/src/main/kotlin/com/closet/core/data/migrations/Migration3To4.kt
+++ b/app-android/core/data/src/main/kotlin/com/closet/core/data/migrations/Migration3To4.kt
@@ -1,0 +1,59 @@
+package com.closet.core.data.migrations
+
+import androidx.room.migration.Migration
+import androidx.sqlite.db.SupportSQLiteDatabase
+import com.closet.core.data.DatabaseSeeder
+
+/**
+ * Migration 3→4: Introduce the brands lookup table and migrate the free-text brand column
+ * to a proper FK relationship.
+ *
+ * Steps:
+ *   1. Create brands table with unique index on name.
+ *   2. Backfill brands from distinct values in clothing_items.brand (user data first).
+ *   3. Add brand_id FK column to clothing_items.
+ *   4. Populate brand_id by matching the backfilled names.
+ *   5. Seed common brands (INSERT OR IGNORE — backfilled rows are not overwritten).
+ *
+ * Note: The old `brand` TEXT column is kept in place. SQLite cannot drop columns before
+ * API 35, and a table recreation is not worth the risk here. The column is no longer
+ * written to by new code; reads go through the brand_id join.
+ */
+val MIGRATION_3_4 = object : Migration(3, 4) {
+    override fun migrate(db: SupportSQLiteDatabase) {
+        // 1. Create brands table
+        db.execSQL(
+            "CREATE TABLE IF NOT EXISTS `brands` (" +
+            "`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, " +
+            "`name` TEXT NOT NULL)"
+        )
+        db.execSQL(
+            "CREATE UNIQUE INDEX IF NOT EXISTS `index_brands_name` ON `brands` (`name`)"
+        )
+
+        // 2. Backfill brands from existing free-text data
+        db.execSQL(
+            "INSERT OR IGNORE INTO brands (name) " +
+            "SELECT DISTINCT brand FROM clothing_items " +
+            "WHERE brand IS NOT NULL AND brand != ''"
+        )
+
+        // 3. Add brand_id FK column
+        db.execSQL("ALTER TABLE clothing_items ADD COLUMN brand_id INTEGER REFERENCES brands(id) ON DELETE SET NULL")
+        db.execSQL("CREATE INDEX IF NOT EXISTS `index_clothing_items_brand_id` ON `clothing_items` (`brand_id`)")
+
+        // 4. Populate brand_id from backfilled rows (exact string match; case differences are accepted)
+        db.execSQL(
+            "UPDATE clothing_items " +
+            "SET brand_id = (SELECT id FROM brands WHERE brands.name = clothing_items.brand) " +
+            "WHERE brand IS NOT NULL AND brand != ''"
+        )
+
+        // 5. Seed common starter brands (user backfill takes priority via INSERT OR IGNORE above)
+        DatabaseSeeder.seedBrands(db)
+
+        // 6. Ensure the one-OOTD-per-day partial index exists on upgraded databases.
+        //    Fresh installs get this via the onCreate callback; migrations must add it explicitly.
+        db.execSQL("CREATE UNIQUE INDEX IF NOT EXISTS one_ootd_per_day ON outfit_logs(date) WHERE is_ootd = 1")
+    }
+}

--- a/app-android/core/data/src/main/kotlin/com/closet/core/data/migrations/Migration3To4.kt
+++ b/app-android/core/data/src/main/kotlin/com/closet/core/data/migrations/Migration3To4.kt
@@ -31,22 +31,24 @@ val MIGRATION_3_4 = object : Migration(3, 4) {
             "CREATE UNIQUE INDEX IF NOT EXISTS `index_brands_name` ON `brands` (`name`)"
         )
 
-        // 2. Backfill brands from existing free-text data
+        // 2. Backfill brands from existing free-text data (trim to avoid inserting whitespace-only values)
         db.execSQL(
             "INSERT OR IGNORE INTO brands (name) " +
-            "SELECT DISTINCT brand FROM clothing_items " +
-            "WHERE brand IS NOT NULL AND brand != ''"
+            "SELECT DISTINCT TRIM(brand) FROM clothing_items " +
+            "WHERE TRIM(brand) IS NOT NULL AND TRIM(brand) != ''"
         )
 
-        // 3. Add brand_id FK column
-        db.execSQL("ALTER TABLE clothing_items ADD COLUMN brand_id INTEGER REFERENCES brands(id) ON DELETE SET NULL")
+        // 3. Add brand_id FK column (guard against schemas that already have the column)
+        if (!columnExists(db, "clothing_items", "brand_id")) {
+            db.execSQL("ALTER TABLE clothing_items ADD COLUMN brand_id INTEGER REFERENCES brands(id) ON DELETE SET NULL")
+        }
         db.execSQL("CREATE INDEX IF NOT EXISTS `index_clothing_items_brand_id` ON `clothing_items` (`brand_id`)")
 
-        // 4. Populate brand_id from backfilled rows (exact string match; case differences are accepted)
+        // 4. Populate brand_id from backfilled rows (match on trimmed value)
         db.execSQL(
             "UPDATE clothing_items " +
-            "SET brand_id = (SELECT id FROM brands WHERE brands.name = clothing_items.brand) " +
-            "WHERE brand IS NOT NULL AND brand != ''"
+            "SET brand_id = (SELECT id FROM brands WHERE brands.name = TRIM(clothing_items.brand)) " +
+            "WHERE TRIM(brand) IS NOT NULL AND TRIM(brand) != ''"
         )
 
         // 5. Seed common starter brands (user backfill takes priority via INSERT OR IGNORE above)

--- a/app-android/core/data/src/main/kotlin/com/closet/core/data/migrations/Migration4To5.kt
+++ b/app-android/core/data/src/main/kotlin/com/closet/core/data/migrations/Migration4To5.kt
@@ -1,0 +1,28 @@
+package com.closet.core.data.migrations
+
+import androidx.room.migration.Migration
+import androidx.sqlite.db.SupportSQLiteDatabase
+
+/**
+ * Migration 4→5: Add case-insensitive uniqueness to brands via a normalized_name column.
+ *
+ * Steps:
+ *   1. Add normalized_name column (NOT NULL, backfilled from LOWER(name)).
+ *   2. Create a unique index on normalized_name.
+ *   3. Drop the old case-sensitive unique index on name.
+ */
+val MIGRATION_4_5 = object : Migration(4, 5) {
+    override fun migrate(db: SupportSQLiteDatabase) {
+        // 1. Add normalized_name column with a temporary default; backfill immediately.
+        db.execSQL("ALTER TABLE brands ADD COLUMN normalized_name TEXT NOT NULL DEFAULT ''")
+        db.execSQL("UPDATE brands SET normalized_name = LOWER(name)")
+
+        // 2. Create unique index on normalized_name.
+        db.execSQL(
+            "CREATE UNIQUE INDEX IF NOT EXISTS `index_brands_normalized_name` ON `brands` (`normalized_name`)"
+        )
+
+        // 3. Drop the old case-sensitive unique index on name.
+        db.execSQL("DROP INDEX IF EXISTS `index_brands_name`")
+    }
+}

--- a/app-android/core/data/src/main/kotlin/com/closet/core/data/migrations/MigrationHelpers.kt
+++ b/app-android/core/data/src/main/kotlin/com/closet/core/data/migrations/MigrationHelpers.kt
@@ -1,0 +1,19 @@
+package com.closet.core.data.migrations
+
+import androidx.sqlite.db.SupportSQLiteDatabase
+
+/**
+ * Returns true if [column] exists in [table], false otherwise.
+ * Uses PRAGMA table_info — safe for use inside migrations.
+ */
+fun columnExists(db: SupportSQLiteDatabase, table: String, column: String): Boolean {
+    val cursor = db.query("PRAGMA table_info($table)")
+    cursor.use {
+        val nameIndex = it.getColumnIndex("name")
+        if (nameIndex == -1) return false
+        while (it.moveToNext()) {
+            if (it.getString(nameIndex) == column) return true
+        }
+    }
+    return false
+}

--- a/app-android/core/data/src/main/kotlin/com/closet/core/data/model/ClothingItemEntity.kt
+++ b/app-android/core/data/src/main/kotlin/com/closet/core/data/model/ClothingItemEntity.kt
@@ -27,12 +27,19 @@ import java.time.Instant
             parentColumns = ["id"],
             childColumns = ["size_value_id"],
             onDelete = ForeignKey.SET_NULL
+        ),
+        ForeignKey(
+            entity = BrandEntity::class,
+            parentColumns = ["id"],
+            childColumns = ["brand_id"],
+            onDelete = ForeignKey.SET_NULL
         )
     ],
     indices = [
         Index(value = ["category_id"]),
         Index(value = ["subcategory_id"]),
-        Index(value = ["size_value_id"])
+        Index(value = ["size_value_id"]),
+        Index(value = ["brand_id"])
     ]
 )
 data class ClothingItemEntity(
@@ -40,7 +47,12 @@ data class ClothingItemEntity(
     val id: Long = 0,
     
     val name: String,
+
+    /** Deprecated: free-text brand column kept for migration backfill. Read brand via [brandId] join instead. */
     val brand: String? = null,
+
+    @ColumnInfo(name = "brand_id")
+    val brandId: Long? = null,
     
     @ColumnInfo(name = "category_id")
     val categoryId: Long? = null,

--- a/app-android/core/data/src/main/kotlin/com/closet/core/data/model/ClothingItemEntity.kt
+++ b/app-android/core/data/src/main/kotlin/com/closet/core/data/model/ClothingItemEntity.kt
@@ -200,7 +200,10 @@ data class ClothingItemDetail(
             entityColumn = "pattern_id"
         )
     )
-    val patterns: List<PatternEntity>
+    val patterns: List<PatternEntity>,
+
+    @Relation(parentColumn = "brand_id", entityColumn = "id")
+    val brand: BrandEntity?
 ) {
     val costPerWear: Double?
         get() = if (wearCount > 0) (item.purchasePrice ?: 0.0) / wearCount else item.purchasePrice

--- a/app-android/core/data/src/main/kotlin/com/closet/core/data/model/ClothingItemEntity.kt
+++ b/app-android/core/data/src/main/kotlin/com/closet/core/data/model/ClothingItemEntity.kt
@@ -48,7 +48,7 @@ data class ClothingItemEntity(
     
     val name: String,
 
-    /** Deprecated: free-text brand column kept for migration backfill. Read brand via [brandId] join instead. */
+    @Deprecated("Replaced by brandId FK. Do not write to this field. Retained for schema compatibility — SQLite cannot drop columns before API 35.")
     val brand: String? = null,
 
     @ColumnInfo(name = "brand_id")

--- a/app-android/core/data/src/main/kotlin/com/closet/core/data/model/JunctionEntities.kt
+++ b/app-android/core/data/src/main/kotlin/com/closet/core/data/model/JunctionEntities.kt
@@ -5,6 +5,10 @@ import androidx.room.Entity
 import androidx.room.ForeignKey
 import androidx.room.Index
 
+/**
+ * Junction entity linking a clothing item to one or more [ColorEntity] values.
+ * Cascade-deletes when either side is removed.
+ */
 @Entity(
     tableName = "clothing_item_colors",
     primaryKeys = ["clothing_item_id", "color_id"],
@@ -19,6 +23,10 @@ data class ClothingItemColorEntity(
     @ColumnInfo(name = "color_id") val colorId: Long
 )
 
+/**
+ * Junction entity linking a clothing item to one or more [MaterialEntity] values.
+ * Cascade-deletes when either side is removed.
+ */
 @Entity(
     tableName = "clothing_item_materials",
     primaryKeys = ["clothing_item_id", "material_id"],
@@ -33,6 +41,10 @@ data class ClothingItemMaterialEntity(
     @ColumnInfo(name = "material_id") val materialId: Long
 )
 
+/**
+ * Junction entity linking a clothing item to one or more [SeasonEntity] values.
+ * Cascade-deletes when either side is removed.
+ */
 @Entity(
     tableName = "clothing_item_seasons",
     primaryKeys = ["clothing_item_id", "season_id"],
@@ -47,6 +59,10 @@ data class ClothingItemSeasonEntity(
     @ColumnInfo(name = "season_id") val seasonId: Long
 )
 
+/**
+ * Junction entity linking a clothing item to one or more [OccasionEntity] values.
+ * Cascade-deletes when either side is removed.
+ */
 @Entity(
     tableName = "clothing_item_occasions",
     primaryKeys = ["clothing_item_id", "occasion_id"],
@@ -61,6 +77,10 @@ data class ClothingItemOccasionEntity(
     @ColumnInfo(name = "occasion_id") val occasionId: Long
 )
 
+/**
+ * Junction entity linking a clothing item to one or more [PatternEntity] values.
+ * Cascade-deletes when either side is removed.
+ */
 @Entity(
     tableName = "clothing_item_patterns",
     primaryKeys = ["clothing_item_id", "pattern_id"],

--- a/app-android/core/data/src/main/kotlin/com/closet/core/data/model/LookupEntities.kt
+++ b/app-android/core/data/src/main/kotlin/com/closet/core/data/model/LookupEntities.kt
@@ -6,6 +6,7 @@ import androidx.room.ForeignKey
 import androidx.room.Index
 import androidx.room.PrimaryKey
 
+/** Clothing brand (e.g. Nike, Zara). Name must be unique. Seeded by [com.closet.core.data.DatabaseSeeder.seedBrands]. */
 @Entity(
     tableName = "brands",
     indices = [Index(value = ["name"], unique = true)]
@@ -15,6 +16,7 @@ data class BrandEntity(
     val name: String
 )
 
+/** Top-level clothing category (e.g. Tops, Bottoms). Seeded with a Phosphor icon name and display order. */
 @Entity(tableName = "categories")
 data class CategoryEntity(
     @PrimaryKey(autoGenerate = true) val id: Long = 0,
@@ -23,6 +25,7 @@ data class CategoryEntity(
     @ColumnInfo(name = "sort_order") val sortOrder: Int
 )
 
+/** Clothing subcategory (e.g. T-Shirt, Jeans) belonging to a parent [CategoryEntity]. */
 @Entity(
     tableName = "subcategories",
     foreignKeys = [
@@ -42,6 +45,7 @@ data class SubcategoryEntity(
     @ColumnInfo(name = "sort_order") val sortOrder: Int
 )
 
+/** Season lookup value (e.g. Spring, Winter). Stored with a Phosphor icon name for display. */
 @Entity(tableName = "seasons")
 data class SeasonEntity(
     @PrimaryKey(autoGenerate = true) val id: Long = 0,
@@ -49,6 +53,7 @@ data class SeasonEntity(
     val icon: String? = null
 )
 
+/** Occasion lookup value (e.g. Casual, Formal). Stored with a Phosphor icon name for display. */
 @Entity(tableName = "occasions")
 data class OccasionEntity(
     @PrimaryKey(autoGenerate = true) val id: Long = 0,
@@ -56,6 +61,7 @@ data class OccasionEntity(
     val icon: String? = null
 )
 
+/** Color lookup value (e.g. Navy, Beige) with an optional hex code for color-matching. */
 @Entity(tableName = "colors")
 data class ColorEntity(
     @PrimaryKey(autoGenerate = true) val id: Long = 0,
@@ -63,24 +69,28 @@ data class ColorEntity(
     val hex: String? = null
 )
 
+/** Fabric/material lookup value (e.g. Cotton, Wool). */
 @Entity(tableName = "materials")
 data class MaterialEntity(
     @PrimaryKey(autoGenerate = true) val id: Long = 0,
     val name: String
 )
 
+/** Visual pattern lookup value (e.g. Solid, Striped, Floral). */
 @Entity(tableName = "patterns")
 data class PatternEntity(
     @PrimaryKey(autoGenerate = true) val id: Long = 0,
     val name: String
 )
 
+/** A named sizing system (e.g. Letter, Women's Numeric, Shoes (US Men's)). */
 @Entity(tableName = "size_systems")
 data class SizeSystemEntity(
     @PrimaryKey(autoGenerate = true) val id: Long = 0,
     val name: String
 )
 
+/** A single size value (e.g. "M", "8", "10.5") within a [SizeSystemEntity]. */
 @Entity(
     tableName = "size_values",
     foreignKeys = [

--- a/app-android/core/data/src/main/kotlin/com/closet/core/data/model/LookupEntities.kt
+++ b/app-android/core/data/src/main/kotlin/com/closet/core/data/model/LookupEntities.kt
@@ -6,6 +6,15 @@ import androidx.room.ForeignKey
 import androidx.room.Index
 import androidx.room.PrimaryKey
 
+@Entity(
+    tableName = "brands",
+    indices = [Index(value = ["name"], unique = true)]
+)
+data class BrandEntity(
+    @PrimaryKey(autoGenerate = true) val id: Long = 0,
+    val name: String
+)
+
 @Entity(tableName = "categories")
 data class CategoryEntity(
     @PrimaryKey(autoGenerate = true) val id: Long = 0,

--- a/app-android/core/data/src/main/kotlin/com/closet/core/data/model/LookupEntities.kt
+++ b/app-android/core/data/src/main/kotlin/com/closet/core/data/model/LookupEntities.kt
@@ -9,11 +9,12 @@ import androidx.room.PrimaryKey
 /** Clothing brand (e.g. Nike, Zara). Name must be unique. Seeded by [com.closet.core.data.DatabaseSeeder.seedBrands]. */
 @Entity(
     tableName = "brands",
-    indices = [Index(value = ["name"], unique = true)]
+    indices = [Index(value = ["normalized_name"], unique = true)]
 )
 data class BrandEntity(
     @PrimaryKey(autoGenerate = true) val id: Long = 0,
-    val name: String
+    val name: String,
+    @ColumnInfo(name = "normalized_name") val normalizedName: String
 )
 
 /** Top-level clothing category (e.g. Tops, Bottoms). Seeded with a Phosphor icon name and display order. */

--- a/app-android/core/data/src/main/kotlin/com/closet/core/data/repository/BrandRepository.kt
+++ b/app-android/core/data/src/main/kotlin/com/closet/core/data/repository/BrandRepository.kt
@@ -78,6 +78,8 @@ class BrandRepository @Inject constructor(
      *   if the brand is still in use, otherwise [DataResult.Success].
      */
     suspend fun deleteBrand(id: Long): DataResult<Unit> = try {
+        brandDao.getBrandById(id)
+            ?: return DataResult.Error(AppError.DatabaseError.NotFound())
         val deleted = brandDao.deleteBrandIfUnused(id)
         if (deleted == 0) {
             DataResult.Error(AppError.ValidationError.InvalidInput("Brand is still assigned to one or more items and cannot be deleted."))

--- a/app-android/core/data/src/main/kotlin/com/closet/core/data/repository/BrandRepository.kt
+++ b/app-android/core/data/src/main/kotlin/com/closet/core/data/repository/BrandRepository.kt
@@ -1,0 +1,54 @@
+package com.closet.core.data.repository
+
+import com.closet.core.data.dao.BrandDao
+import com.closet.core.data.model.BrandEntity
+import com.closet.core.data.util.AppError
+import com.closet.core.data.util.DataResult
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.flow.Flow
+import timber.log.Timber
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class BrandRepository @Inject constructor(
+    private val brandDao: BrandDao
+) {
+
+    fun getAllBrands(): Flow<List<BrandEntity>> = brandDao.getAllBrands()
+
+    suspend fun insertBrand(name: String): DataResult<Long> = try {
+        val id = brandDao.insertBrand(name)
+        DataResult.Success(id)
+    } catch (e: Exception) {
+        if (e is CancellationException) throw e
+        Timber.e(e, "Error inserting brand: $name")
+        DataResult.Error(AppError.DatabaseError.QueryError(e))
+    }
+
+    suspend fun updateBrand(id: Long, name: String): DataResult<Unit> = try {
+        brandDao.updateBrand(BrandEntity(id = id, name = name))
+        DataResult.Success(Unit)
+    } catch (e: Exception) {
+        if (e is CancellationException) throw e
+        Timber.e(e, "Error updating brand id=$id")
+        DataResult.Error(AppError.DatabaseError.QueryError(e))
+    }
+
+    suspend fun deleteBrand(id: Long): DataResult<Unit> = try {
+        brandDao.deleteBrand(id)
+        DataResult.Success(Unit)
+    } catch (e: Exception) {
+        if (e is CancellationException) throw e
+        Timber.e(e, "Error deleting brand id=$id")
+        DataResult.Error(AppError.DatabaseError.QueryError(e))
+    }
+
+    suspend fun getItemCountForBrand(id: Long): DataResult<Int> = try {
+        DataResult.Success(brandDao.getItemCountForBrand(id))
+    } catch (e: Exception) {
+        if (e is CancellationException) throw e
+        Timber.e(e, "Error fetching item count for brand id=$id")
+        DataResult.Error(AppError.DatabaseError.QueryError(e))
+    }
+}

--- a/app-android/core/data/src/main/kotlin/com/closet/core/data/repository/BrandRepository.kt
+++ b/app-android/core/data/src/main/kotlin/com/closet/core/data/repository/BrandRepository.kt
@@ -11,13 +11,26 @@ import timber.log.Timber
 import javax.inject.Inject
 import javax.inject.Singleton
 
+/**
+ * Repository for brand CRUD operations.
+ *
+ * All suspend operations wrap results in [DataResult] and re-throw [kotlinx.coroutines.CancellationException]
+ * so callers never need to handle raw exceptions.
+ */
 @Singleton
 class BrandRepository @Inject constructor(
     private val brandDao: BrandDao
 ) {
 
+    /** Returns all brands ordered alphabetically as a live [DataResult] [Flow]. */
     fun getAllBrands(): Flow<DataResult<List<BrandEntity>>> = brandDao.getAllBrands().asDataResult()
 
+    /**
+     * Inserts a brand with the given [name].
+     * @return [DataResult.Success] containing the new brand's row ID, or
+     *   [DataResult.Error] with [com.closet.core.data.util.AppError.DatabaseError.ConstraintViolation]
+     *   if the name already exists.
+     */
     suspend fun insertBrand(name: String): DataResult<Long> = try {
         val id = brandDao.insertBrand(name)
         DataResult.Success(id)
@@ -27,6 +40,10 @@ class BrandRepository @Inject constructor(
         DataResult.Error(AppError.DatabaseError.QueryError(e))
     }
 
+    /**
+     * Updates the name of the brand identified by [id].
+     * @return [DataResult.Success] on success, or [DataResult.Error] on failure.
+     */
     suspend fun updateBrand(id: Long, name: String): DataResult<Unit> = try {
         brandDao.updateBrand(BrandEntity(id = id, name = name))
         DataResult.Success(Unit)
@@ -36,6 +53,11 @@ class BrandRepository @Inject constructor(
         DataResult.Error(AppError.DatabaseError.QueryError(e))
     }
 
+    /**
+     * Deletes the brand only if it has no associated clothing items.
+     * @return [DataResult.Error] with [com.closet.core.data.util.AppError.ValidationError.InvalidInput]
+     *   if the brand is still in use, otherwise [DataResult.Success].
+     */
     suspend fun deleteBrand(id: Long): DataResult<Unit> = try {
         val deleted = brandDao.deleteBrandIfUnused(id)
         if (deleted == 0) {
@@ -49,6 +71,7 @@ class BrandRepository @Inject constructor(
         DataResult.Error(AppError.DatabaseError.QueryError(e))
     }
 
+    /** Returns the number of clothing items currently assigned to the brand with [id]. */
     suspend fun getItemCountForBrand(id: Long): DataResult<Int> = try {
         DataResult.Success(brandDao.getItemCountForBrand(id))
     } catch (e: Exception) {

--- a/app-android/core/data/src/main/kotlin/com/closet/core/data/repository/BrandRepository.kt
+++ b/app-android/core/data/src/main/kotlin/com/closet/core/data/repository/BrandRepository.kt
@@ -4,9 +4,12 @@ import com.closet.core.data.dao.BrandDao
 import com.closet.core.data.model.BrandEntity
 import com.closet.core.data.util.AppError
 import com.closet.core.data.util.DataResult
-import com.closet.core.data.util.asDataResult
+import android.database.sqlite.SQLiteConstraintException
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.onStart
 import timber.log.Timber
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -23,7 +26,14 @@ class BrandRepository @Inject constructor(
 ) {
 
     /** Returns all brands ordered alphabetically as a live [DataResult] [Flow]. */
-    fun getAllBrands(): Flow<DataResult<List<BrandEntity>>> = brandDao.getAllBrands().asDataResult()
+    fun getAllBrands(): Flow<DataResult<List<BrandEntity>>> = brandDao.getAllBrands()
+        .map<List<BrandEntity>, DataResult<List<BrandEntity>>> { DataResult.Success(it) }
+        .onStart { emit(DataResult.Loading) }
+        .catch { throwable ->
+            if (throwable is CancellationException) throw throwable
+            Timber.e(throwable, "Error loading brands")
+            emit(DataResult.Error(AppError.DatabaseError.QueryError(throwable)))
+        }
 
     /**
      * Inserts a brand with the given [name].
@@ -32,10 +42,14 @@ class BrandRepository @Inject constructor(
      *   if the name already exists.
      */
     suspend fun insertBrand(name: String): DataResult<Long> = try {
-        val id = brandDao.insertBrand(name)
+        val id = brandDao.insertBrand(name, name.lowercase())
         DataResult.Success(id)
+    } catch (e: CancellationException) {
+        throw e
+    } catch (e: SQLiteConstraintException) {
+        Timber.e(e, "Constraint violation inserting brand: $name")
+        DataResult.Error(AppError.DatabaseError.ConstraintViolation(e.message ?: "A brand with that name already exists."))
     } catch (e: Exception) {
-        if (e is CancellationException) throw e
         Timber.e(e, "Error inserting brand: $name")
         DataResult.Error(AppError.DatabaseError.QueryError(e))
     }
@@ -45,10 +59,15 @@ class BrandRepository @Inject constructor(
      * @return [DataResult.Success] on success, or [DataResult.Error] on failure.
      */
     suspend fun updateBrand(id: Long, name: String): DataResult<Unit> = try {
-        brandDao.updateBrand(BrandEntity(id = id, name = name))
-        DataResult.Success(Unit)
+        val updated = brandDao.updateBrand(BrandEntity(id = id, name = name, normalizedName = name.lowercase()))
+        if (updated > 0) DataResult.Success(Unit)
+        else DataResult.Error(AppError.DatabaseError.NotFound())
+    } catch (e: CancellationException) {
+        throw e
+    } catch (e: SQLiteConstraintException) {
+        Timber.e(e, "Constraint violation updating brand id=$id")
+        DataResult.Error(AppError.DatabaseError.ConstraintViolation(e.message ?: "A brand with that name already exists."))
     } catch (e: Exception) {
-        if (e is CancellationException) throw e
         Timber.e(e, "Error updating brand id=$id")
         DataResult.Error(AppError.DatabaseError.QueryError(e))
     }

--- a/app-android/core/data/src/main/kotlin/com/closet/core/data/repository/BrandRepository.kt
+++ b/app-android/core/data/src/main/kotlin/com/closet/core/data/repository/BrandRepository.kt
@@ -4,6 +4,7 @@ import com.closet.core.data.dao.BrandDao
 import com.closet.core.data.model.BrandEntity
 import com.closet.core.data.util.AppError
 import com.closet.core.data.util.DataResult
+import com.closet.core.data.util.asDataResult
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.Flow
 import timber.log.Timber
@@ -15,7 +16,7 @@ class BrandRepository @Inject constructor(
     private val brandDao: BrandDao
 ) {
 
-    fun getAllBrands(): Flow<List<BrandEntity>> = brandDao.getAllBrands()
+    fun getAllBrands(): Flow<DataResult<List<BrandEntity>>> = brandDao.getAllBrands().asDataResult()
 
     suspend fun insertBrand(name: String): DataResult<Long> = try {
         val id = brandDao.insertBrand(name)
@@ -36,8 +37,12 @@ class BrandRepository @Inject constructor(
     }
 
     suspend fun deleteBrand(id: Long): DataResult<Unit> = try {
-        brandDao.deleteBrand(id)
-        DataResult.Success(Unit)
+        val deleted = brandDao.deleteBrandIfUnused(id)
+        if (deleted == 0) {
+            DataResult.Error(AppError.ValidationError.InvalidInput("Brand is still assigned to one or more items and cannot be deleted."))
+        } else {
+            DataResult.Success(Unit)
+        }
     } catch (e: Exception) {
         if (e is CancellationException) throw e
         Timber.e(e, "Error deleting brand id=$id")

--- a/app-android/core/data/src/main/kotlin/com/closet/core/data/repository/LookupRepository.kt
+++ b/app-android/core/data/src/main/kotlin/com/closet/core/data/repository/LookupRepository.kt
@@ -72,9 +72,4 @@ class LookupRepository @Inject constructor(
     fun getSizeValues(systemId: Long): Flow<List<SizeValueEntity>> = 
         lookupDao.getSizeValues(systemId)
 
-    /**
-     * Retrieves a distinct list of brands used in existing wardrobe items for autocomplete.
-     * @return A list of unique brand names.
-     */
-    suspend fun getDistinctBrands(): List<String> = lookupDao.getDistinctBrands()
 }

--- a/app-android/core/ui/src/main/kotlin/com/closet/core/ui/components/ErrorSnackbarHost.kt
+++ b/app-android/core/ui/src/main/kotlin/com/closet/core/ui/components/ErrorSnackbarHost.kt
@@ -1,0 +1,76 @@
+package com.closet.core.ui.components
+
+import androidx.annotation.StringRes
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.ui.platform.LocalContext
+import com.closet.core.ui.util.UserMessage
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * Collects a [Flow] of [UserMessage]s and shows each as a Snackbar.
+ *
+ * Place this alongside the [SnackbarHost] in your Scaffold:
+ * ```
+ * val snackbarHostState = remember { SnackbarHostState() }
+ * UserMessageSnackbarEffect(viewModel.actionError, snackbarHostState)
+ * Scaffold(snackbarHost = { SnackbarHost(snackbarHostState) }) { ... }
+ * ```
+ */
+@Composable
+fun UserMessageSnackbarEffect(
+    messages: Flow<UserMessage>,
+    snackbarHostState: SnackbarHostState
+) {
+    val context = LocalContext.current
+    LaunchedEffect(Unit) {
+        messages.collect { message ->
+            val text = if (message.args.isEmpty()) {
+                context.getString(message.resId)
+            } else {
+                context.getString(message.resId, *message.args)
+            }
+            snackbarHostState.showSnackbar(text)
+        }
+    }
+}
+
+/**
+ * Shows a Snackbar when [errorRes] is non-null, then calls [onErrorConsumed] to clear it.
+ *
+ * Use for ViewModels that expose a nullable `@StringRes Int?` error field.
+ */
+@Composable
+fun ResErrorSnackbarEffect(
+    @StringRes errorRes: Int?,
+    snackbarHostState: SnackbarHostState,
+    onErrorConsumed: () -> Unit
+) {
+    val context = LocalContext.current
+    LaunchedEffect(errorRes) {
+        if (errorRes != null) {
+            snackbarHostState.showSnackbar(context.getString(errorRes))
+            onErrorConsumed()
+        }
+    }
+}
+
+/**
+ * Shows a Snackbar when [errorMessage] is non-null, then calls [onErrorConsumed] to clear it.
+ *
+ * Use for ViewModels that expose a nullable [String] error field.
+ */
+@Composable
+fun StringErrorSnackbarEffect(
+    errorMessage: String?,
+    snackbarHostState: SnackbarHostState,
+    onErrorConsumed: () -> Unit
+) {
+    LaunchedEffect(errorMessage) {
+        if (errorMessage != null) {
+            snackbarHostState.showSnackbar(errorMessage)
+            onErrorConsumed()
+        }
+    }
+}

--- a/app-android/core/ui/src/main/kotlin/com/closet/core/ui/components/ErrorSnackbarHost.kt
+++ b/app-android/core/ui/src/main/kotlin/com/closet/core/ui/components/ErrorSnackbarHost.kt
@@ -24,7 +24,7 @@ fun UserMessageSnackbarEffect(
     snackbarHostState: SnackbarHostState
 ) {
     val context = LocalContext.current
-    LaunchedEffect(Unit) {
+    LaunchedEffect(messages) {
         messages.collect { message ->
             val text = if (message.args.isEmpty()) {
                 context.getString(message.resId)

--- a/app-android/features/outfits/src/main/kotlin/com/closet/features/outfits/OutfitBuilderViewModel.kt
+++ b/app-android/features/outfits/src/main/kotlin/com/closet/features/outfits/OutfitBuilderViewModel.kt
@@ -22,6 +22,14 @@ import kotlinx.coroutines.launch
 import java.io.File
 import javax.inject.Inject
 
+/**
+ * UI state for the Outfit Builder screen.
+ *
+ * @property name Optional outfit name entered by the user.
+ * @property members Clothing items currently added to the outfit, ordered by selection time.
+ * @property isSaving True while the save operation is in flight.
+ * @property canSave Derived flag — true when there is at least one member and no save is pending.
+ */
 data class OutfitBuilderUiState(
     val name: String = "",
     val members: List<OutfitMember> = emptyList(),
@@ -30,11 +38,23 @@ data class OutfitBuilderUiState(
     val canSave: Boolean get() = members.isNotEmpty() && !isSaving
 }
 
+/**
+ * One-time events emitted by [OutfitBuilderViewModel] for the screen to handle via a channel.
+ */
 sealed interface OutfitBuilderEvent {
+    /** Emitted when the outfit was saved successfully. */
     data object SaveSuccess : OutfitBuilderEvent
+    /** Emitted when the save operation failed. */
     data object SaveError : OutfitBuilderEvent
 }
 
+/**
+ * ViewModel for the Outfit Builder screen.
+ *
+ * Manages the in-progress outfit name and the ordered list of selected clothing items.
+ * Reads picker results deposited by [WardrobePickerScreen] via [SavedStateHandle]
+ * under [PICKER_RESULT_KEY], then persists the finished outfit through [OutfitRepository].
+ */
 @HiltViewModel
 class OutfitBuilderViewModel @Inject constructor(
     private val savedStateHandle: SavedStateHandle,
@@ -52,6 +72,7 @@ class OutfitBuilderViewModel @Inject constructor(
     private val _isSaving = MutableStateFlow(false)
 
     private val _events = Channel<OutfitBuilderEvent>(Channel.BUFFERED)
+    /** One-time [OutfitBuilderEvent] emissions for the screen to collect. */
     val events = _events.receiveAsFlow()
 
     // Unfiltered item list used to resolve member IDs → ClothingItemDetail.
@@ -75,6 +96,7 @@ class OutfitBuilderViewModel @Inject constructor(
         initialValue = emptyList()
     )
 
+    /** Consolidated UI state combining name, member list, and saving flag. */
     val uiState: StateFlow<OutfitBuilderUiState> = combine(
         _name, members, _isSaving
     ) { name, members, isSaving ->
@@ -98,6 +120,7 @@ class OutfitBuilderViewModel @Inject constructor(
             .launchIn(viewModelScope)
     }
 
+    /** Updates the outfit name as the user types. */
     fun updateName(value: String) {
         _name.value = value
     }
@@ -111,10 +134,17 @@ class OutfitBuilderViewModel @Inject constructor(
         _memberIds.value = current
     }
 
+    /** Removes the item with [itemId] from the outfit member list. */
     fun removeMember(itemId: Long) {
         _memberIds.value = _memberIds.value.filter { it != itemId }
     }
 
+    /**
+     * Saves the current outfit via [OutfitRepository].
+     * Uses the resolved [members] list (not raw IDs) so items deleted from the
+     * wardrobe while the builder was open are already absent. Emits [OutfitBuilderEvent]
+     * on completion.
+     */
     fun save() {
         // Derive IDs from the resolved member list, not raw _memberIds, so any item that was
         // deleted from the wardrobe while the builder was open is already absent here.
@@ -136,5 +166,6 @@ class OutfitBuilderViewModel @Inject constructor(
         }
     }
 
+    /** Resolves a stored relative image [path] to a [File], or null if [path] is null. */
     fun resolveImagePath(path: String?): File? = path?.let { storageRepository.getFile(it) }
 }

--- a/app-android/features/outfits/src/main/kotlin/com/closet/features/outfits/OutfitsNavigation.kt
+++ b/app-android/features/outfits/src/main/kotlin/com/closet/features/outfits/OutfitsNavigation.kt
@@ -6,30 +6,40 @@ import androidx.navigation.NavOptions
 import androidx.navigation.compose.composable
 import kotlinx.serialization.Serializable
 
-// SavedStateHandle key used to pass selected item IDs back from WardrobePickerScreen.
+/**
+ * [SavedStateHandle] key used to pass selected clothing item IDs back from
+ * [WardrobePickerScreen] to [OutfitBuilderViewModel] via the previous back-stack entry.
+ */
 const val PICKER_RESULT_KEY = "wardrobe_picker_item_ids"
 
+/** Top-level route for the Outfits gallery screen. */
 @Serializable
 object OutfitsRoute
 
+/** Route for the Outfit Builder screen where users compose and save an outfit. */
 @Serializable
 object OutfitBuilderDestination
 
+/** Route for the Wardrobe Picker screen used to select items while building an outfit. */
 @Serializable
 object WardrobePickerDestination
 
+/** Navigates to the Outfits gallery, applying [navOptions] for back-stack management. */
 fun NavController.navigateToOutfits(navOptions: NavOptions? = null) {
     this.navigate(OutfitsRoute, navOptions)
 }
 
+/** Navigates to the Outfit Builder screen. */
 fun NavController.navigateToOutfitBuilder() {
     this.navigate(OutfitBuilderDestination)
 }
 
+/** Navigates to the Wardrobe Picker screen from inside the Outfit Builder. */
 fun NavController.navigateToWardrobePicker() {
     this.navigate(WardrobePickerDestination)
 }
 
+/** Registers the [OutfitsRoute] composable destination in the [NavGraphBuilder]. */
 fun NavGraphBuilder.outfitsScreen(navController: NavController) {
     composable<OutfitsRoute> {
         OutfitsScreen(
@@ -38,6 +48,7 @@ fun NavGraphBuilder.outfitsScreen(navController: NavController) {
     }
 }
 
+/** Registers the [OutfitBuilderDestination] composable destination in the [NavGraphBuilder]. */
 fun NavGraphBuilder.outfitBuilderScreen(navController: NavController) {
     composable<OutfitBuilderDestination> {
         OutfitBuilderScreen(
@@ -47,6 +58,12 @@ fun NavGraphBuilder.outfitBuilderScreen(navController: NavController) {
     }
 }
 
+/**
+ * Registers the [WardrobePickerDestination] composable destination in the [NavGraphBuilder].
+ *
+ * On confirm, the selected item IDs are deposited into the previous back-stack entry's
+ * [androidx.lifecycle.SavedStateHandle] under [PICKER_RESULT_KEY] before popping.
+ */
 fun NavGraphBuilder.wardrobePickerScreen(navController: NavController) {
     composable<WardrobePickerDestination> {
         WardrobePickerScreen(

--- a/app-android/features/outfits/src/main/kotlin/com/closet/features/outfits/OutfitsViewModel.kt
+++ b/app-android/features/outfits/src/main/kotlin/com/closet/features/outfits/OutfitsViewModel.kt
@@ -19,11 +19,23 @@ import kotlinx.coroutines.launch
 import java.io.File
 import javax.inject.Inject
 
+/**
+ * One-time events emitted by [OutfitsViewModel] after a wear-log operation completes.
+ */
 sealed interface OutfitsEvent {
+    /** Emitted when the outfit was successfully logged as worn today. */
     data object WearSuccess : OutfitsEvent
+    /** Emitted when the wear-log operation failed. */
     data object WearError : OutfitsEvent
 }
 
+/**
+ * ViewModel for the Outfits gallery screen.
+ *
+ * Exposes the full list of saved outfits as a live [outfits] flow and handles
+ * the "Wear Today" action via [wearOutfit]. Only one wear operation is allowed
+ * in flight at a time; [wearingOutfitId] tracks which card shows a loading state.
+ */
 @HiltViewModel
 class OutfitsViewModel @Inject constructor(
     private val outfitRepository: OutfitRepository,
@@ -31,6 +43,7 @@ class OutfitsViewModel @Inject constructor(
     private val storageRepository: StorageRepository
 ) : ViewModel() {
 
+    /** Live list of all saved outfits with their member items. */
     val outfits: StateFlow<List<OutfitWithItems>> = outfitRepository.getAllOutfitsWithItems()
         .stateIn(
             scope = viewModelScope,
@@ -41,11 +54,14 @@ class OutfitsViewModel @Inject constructor(
     // ID of the outfit currently being logged; null when idle.
     // Drives per-card button loading/disabled state.
     private val _wearingOutfitId = MutableStateFlow<Long?>(null)
+    /** ID of the outfit currently being logged as worn; null when idle. Drives per-card loading state. */
     val wearingOutfitId: StateFlow<Long?> = _wearingOutfitId.asStateFlow()
 
     private val _events = Channel<OutfitsEvent>(Channel.BUFFERED)
+    /** One-time [OutfitsEvent] emissions for the screen to collect. */
     val events = _events.receiveAsFlow()
 
+    /** Resolves a stored relative image [path] to a [File], or null if [path] is null. */
     fun resolveImagePath(path: String?): File? = path?.let { storageRepository.getFile(it) }
 
     /**

--- a/app-android/features/outfits/src/main/kotlin/com/closet/features/outfits/WardrobePickerViewModel.kt
+++ b/app-android/features/outfits/src/main/kotlin/com/closet/features/outfits/WardrobePickerViewModel.kt
@@ -17,6 +17,17 @@ import kotlinx.coroutines.flow.stateIn
 import java.io.File
 import javax.inject.Inject
 
+/**
+ * UI state for the Wardrobe Picker screen.
+ *
+ * @property items Filtered clothing items visible in the list.
+ * @property categories All categories available as filter chips.
+ * @property seasons All seasons available as filter chips.
+ * @property selectedCategoryId Active category filter, or null for no filter.
+ * @property selectedSeasonId Active season filter, or null for no filter.
+ * @property selectedItemIds IDs of items the user has tapped to include in the outfit.
+ * @property isLoading True until the initial item list has loaded.
+ */
 data class WardrobePickerUiState(
     val items: List<ClothingItemDetail> = emptyList(),
     val categories: List<CategoryEntity> = emptyList(),
@@ -27,6 +38,13 @@ data class WardrobePickerUiState(
     val isLoading: Boolean = true
 )
 
+/**
+ * ViewModel for the Wardrobe Picker screen.
+ *
+ * Applies optional category and season filters over the full wardrobe and tracks
+ * which items the user has selected. Selections survive filter changes because
+ * [selectedMembers] draws from the unfiltered item list.
+ */
 @HiltViewModel
 class WardrobePickerViewModel @Inject constructor(
     private val clothingRepository: ClothingRepository,
@@ -52,6 +70,7 @@ class WardrobePickerViewModel @Inject constructor(
 
     private val _filters = combine(_categoryFilter, _seasonFilter) { cat, season -> cat to season }
 
+    /** Filtered UI state combining items, lookups, active filters, and selection. */
     val uiState: StateFlow<WardrobePickerUiState> = combine(
         _allItems,
         lookupRepository.getCategories(),
@@ -94,19 +113,23 @@ class WardrobePickerViewModel @Inject constructor(
         initialValue = emptyList()
     )
 
+    /** Sets the active category filter to [id], or clears it when [id] is null. */
     fun selectCategory(id: Long?) {
         _categoryFilter.value = id
     }
 
+    /** Sets the active season filter to [id], or clears it when [id] is null. */
     fun selectSeason(id: Long?) {
         _seasonFilter.value = id
     }
 
+    /** Adds the item with [id] to the selection if not present, or removes it if already selected. */
     fun toggleItem(id: Long) {
         _selectedItemIds.value = _selectedItemIds.value.toMutableSet().apply {
             if (contains(id)) remove(id) else add(id)
         }
     }
 
+    /** Resolves a stored relative image [path] to a [File], or null if [path] is null. */
     fun resolveImagePath(path: String?): File? = path?.let { storageRepository.getFile(it) }
 }

--- a/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/BrandComponents.kt
+++ b/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/BrandComponents.kt
@@ -1,0 +1,145 @@
+package com.closet.features.wardrobe
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.ListItem
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.unit.dp
+import com.closet.core.data.model.BrandEntity
+
+// ─── Editor state ─────────────────────────────────────────────────────────────
+
+internal sealed class BrandEditorState {
+    data object Idle : BrandEditorState()
+    data class Adding(val text: String = "", val saving: Boolean = false) : BrandEditorState()
+    data class Editing(val brandId: Long, val text: String, val saving: Boolean = false) : BrandEditorState()
+}
+
+// ─── BrandRow ─────────────────────────────────────────────────────────────────
+
+@Composable
+internal fun BrandRow(
+    brand: BrandEntity,
+    onEditClick: () -> Unit,
+    onDeleteClick: () -> Unit
+) {
+    ListItem(
+        headlineContent = { Text(brand.name) },
+        trailingContent = {
+            Row {
+                IconButton(onClick = onEditClick) {
+                    Icon(Icons.Default.Edit, contentDescription = stringResource(R.string.wardrobe_edit))
+                }
+                IconButton(onClick = onDeleteClick) {
+                    Icon(
+                        Icons.Default.Delete,
+                        contentDescription = stringResource(R.string.wardrobe_delete),
+                        tint = MaterialTheme.colorScheme.error
+                    )
+                }
+            }
+        }
+    )
+}
+
+// ─── AddBrandRow ──────────────────────────────────────────────────────────────
+
+@Composable
+internal fun AddBrandRow(
+    text: String,
+    onTextChange: (String) -> Unit,
+    isSaving: Boolean = false,
+    onConfirm: () -> Unit,
+    onCancel: () -> Unit
+) {
+    val focusRequester = remember { FocusRequester() }
+    LaunchedEffect(Unit) { focusRequester.requestFocus() }
+
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 8.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(8.dp)
+    ) {
+        OutlinedTextField(
+            value = text,
+            onValueChange = onTextChange,
+            modifier = Modifier
+                .weight(1f)
+                .focusRequester(focusRequester),
+            label = { Text(stringResource(R.string.brand_management_new_brand_hint)) },
+            singleLine = true,
+            keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
+            keyboardActions = KeyboardActions(onDone = { onConfirm() })
+        )
+        IconButton(onClick = onConfirm, enabled = text.isNotBlank() && !isSaving) {
+            Icon(Icons.Default.Check, contentDescription = stringResource(R.string.wardrobe_save))
+        }
+        IconButton(onClick = onCancel, enabled = !isSaving) {
+            Icon(Icons.Default.Close, contentDescription = stringResource(R.string.wardrobe_cancel))
+        }
+    }
+}
+
+// ─── EditBrandRow ─────────────────────────────────────────────────────────────
+
+@Composable
+internal fun EditBrandRow(
+    text: String,
+    onTextChange: (String) -> Unit,
+    isSaving: Boolean = false,
+    onConfirm: () -> Unit,
+    onCancel: () -> Unit
+) {
+    val focusRequester = remember { FocusRequester() }
+    LaunchedEffect(Unit) { focusRequester.requestFocus() }
+
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 8.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(8.dp)
+    ) {
+        OutlinedTextField(
+            value = text,
+            onValueChange = onTextChange,
+            modifier = Modifier
+                .weight(1f)
+                .focusRequester(focusRequester),
+            label = { Text(stringResource(R.string.brand_management_edit_hint)) },
+            singleLine = true,
+            keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
+            keyboardActions = KeyboardActions(onDone = { onConfirm() })
+        )
+        IconButton(onClick = onConfirm, enabled = text.isNotBlank() && !isSaving) {
+            Icon(Icons.Default.Check, contentDescription = stringResource(R.string.wardrobe_save))
+        }
+        IconButton(onClick = onCancel, enabled = !isSaving) {
+            Icon(Icons.Default.Close, contentDescription = stringResource(R.string.wardrobe_cancel))
+        }
+    }
+}

--- a/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/BrandComponents.kt
+++ b/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/BrandComponents.kt
@@ -64,10 +64,11 @@ internal fun BrandRow(
     )
 }
 
-// ─── AddBrandRow ──────────────────────────────────────────────────────────────
+// ─── BrandInputRow ────────────────────────────────────────────────────────────
 
 @Composable
-internal fun AddBrandRow(
+internal fun BrandInputRow(
+    label: String,
     text: String,
     onTextChange: (String) -> Unit,
     isSaving: Boolean = false,
@@ -90,50 +91,10 @@ internal fun AddBrandRow(
             modifier = Modifier
                 .weight(1f)
                 .focusRequester(focusRequester),
-            label = { Text(stringResource(R.string.brand_management_new_brand_hint)) },
+            label = { Text(label) },
             singleLine = true,
             keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
-            keyboardActions = KeyboardActions(onDone = { onConfirm() })
-        )
-        IconButton(onClick = onConfirm, enabled = text.isNotBlank() && !isSaving) {
-            Icon(Icons.Default.Check, contentDescription = stringResource(R.string.wardrobe_save))
-        }
-        IconButton(onClick = onCancel, enabled = !isSaving) {
-            Icon(Icons.Default.Close, contentDescription = stringResource(R.string.wardrobe_cancel))
-        }
-    }
-}
-
-// ─── EditBrandRow ─────────────────────────────────────────────────────────────
-
-@Composable
-internal fun EditBrandRow(
-    text: String,
-    onTextChange: (String) -> Unit,
-    isSaving: Boolean = false,
-    onConfirm: () -> Unit,
-    onCancel: () -> Unit
-) {
-    val focusRequester = remember { FocusRequester() }
-    LaunchedEffect(Unit) { focusRequester.requestFocus() }
-
-    Row(
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(horizontal = 16.dp, vertical = 8.dp),
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.spacedBy(8.dp)
-    ) {
-        OutlinedTextField(
-            value = text,
-            onValueChange = onTextChange,
-            modifier = Modifier
-                .weight(1f)
-                .focusRequester(focusRequester),
-            label = { Text(stringResource(R.string.brand_management_edit_hint)) },
-            singleLine = true,
-            keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
-            keyboardActions = KeyboardActions(onDone = { onConfirm() })
+            keyboardActions = KeyboardActions(onDone = { if (text.isNotBlank() && !isSaving) onConfirm() })
         )
         IconButton(onClick = onConfirm, enabled = text.isNotBlank() && !isSaving) {
             Icon(Icons.Default.Check, contentDescription = stringResource(R.string.wardrobe_save))

--- a/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/BrandManagementScreen.kt
+++ b/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/BrandManagementScreen.kt
@@ -4,23 +4,14 @@ import android.content.res.Configuration
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
-import androidx.compose.foundation.text.KeyboardActions
-import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Add
-import androidx.compose.material.icons.filled.Check
-import androidx.compose.material.icons.filled.Close
-import androidx.compose.material.icons.filled.Delete
-import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.focus.FocusRequester
-import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -57,17 +48,35 @@ internal fun BrandManagementContent(
     onErrorConsumed: () -> Unit
 ) {
     val snackbarHostState = remember { SnackbarHostState() }
-
-    var isAddingBrand by remember { mutableStateOf(false) }
-    var newBrandText by remember { mutableStateOf("") }
-    var editingBrandId by remember { mutableStateOf<Long?>(null) }
-    var editText by remember { mutableStateOf("") }
+    var editorState by remember { mutableStateOf<BrandEditorState>(BrandEditorState.Idle) }
 
     val errorMessage = uiState.errorMessage
     LaunchedEffect(errorMessage) {
         if (errorMessage != null) {
             snackbarHostState.showSnackbar(errorMessage)
             onErrorConsumed()
+        }
+    }
+
+    // Close the active row only when a pending save completes successfully.
+    // On error the row stays open so the user can correct the input.
+    LaunchedEffect(uiState.isLoading) {
+        val state = editorState
+        val isSaving = when (state) {
+            is BrandEditorState.Adding -> state.saving
+            is BrandEditorState.Editing -> state.saving
+            BrandEditorState.Idle -> false
+        }
+        if (isSaving && !uiState.isLoading) {
+            editorState = if (uiState.errorMessage == null) {
+                BrandEditorState.Idle
+            } else {
+                when (state) {
+                    is BrandEditorState.Adding -> state.copy(saving = false)
+                    is BrandEditorState.Editing -> state.copy(saving = false)
+                    BrandEditorState.Idle -> BrandEditorState.Idle
+                }
+            }
         }
     }
 
@@ -85,11 +94,9 @@ internal fun BrandManagementContent(
             )
         },
         floatingActionButton = {
-            if (!isAddingBrand) {
+            if (editorState == BrandEditorState.Idle) {
                 FloatingActionButton(onClick = {
-                    isAddingBrand = true
-                    newBrandText = ""
-                    editingBrandId = null
+                    editorState = BrandEditorState.Adding()
                 }) {
                     Icon(Icons.Default.Add, contentDescription = stringResource(R.string.brand_management_add_brand))
                 }
@@ -102,28 +109,26 @@ internal fun BrandManagementContent(
                 .padding(padding),
             contentPadding = PaddingValues(bottom = 88.dp)
         ) {
-            if (isAddingBrand) {
+            if (editorState is BrandEditorState.Adding) {
+                val addState = editorState as BrandEditorState.Adding
                 item {
                     AddBrandRow(
-                        text = newBrandText,
-                        onTextChange = { newBrandText = it },
+                        text = addState.text,
+                        onTextChange = { editorState = addState.copy(text = it) },
+                        isSaving = addState.saving,
                         onConfirm = {
-                            if (newBrandText.isNotBlank()) {
-                                onSaveBrand(null, newBrandText)
-                                isAddingBrand = false
-                                newBrandText = ""
+                            if (addState.text.isNotBlank()) {
+                                editorState = addState.copy(saving = true)
+                                onSaveBrand(null, addState.text)
                             }
                         },
-                        onCancel = {
-                            isAddingBrand = false
-                            newBrandText = ""
-                        }
+                        onCancel = { editorState = BrandEditorState.Idle }
                     )
                     HorizontalDivider()
                 }
             }
 
-            if (uiState.brands.isEmpty() && !isAddingBrand) {
+            if (uiState.brands.isEmpty() && editorState !is BrandEditorState.Adding) {
                 item {
                     Box(
                         modifier = Modifier
@@ -141,25 +146,25 @@ internal fun BrandManagementContent(
             }
 
             items(uiState.brands, key = { it.id }) { brand ->
-                if (editingBrandId == brand.id) {
+                val editState = editorState as? BrandEditorState.Editing
+                if (editState != null && editState.brandId == brand.id) {
                     EditBrandRow(
-                        text = editText,
-                        onTextChange = { editText = it },
+                        text = editState.text,
+                        onTextChange = { editorState = editState.copy(text = it) },
+                        isSaving = editState.saving,
                         onConfirm = {
-                            if (editText.isNotBlank()) {
-                                onSaveBrand(brand.id, editText)
-                                editingBrandId = null
+                            if (editState.text.isNotBlank()) {
+                                editorState = editState.copy(saving = true)
+                                onSaveBrand(brand.id, editState.text)
                             }
                         },
-                        onCancel = { editingBrandId = null }
+                        onCancel = { editorState = BrandEditorState.Idle }
                     )
                 } else {
                     BrandRow(
                         brand = brand,
                         onEditClick = {
-                            editingBrandId = brand.id
-                            editText = brand.name
-                            isAddingBrand = false
+                            editorState = BrandEditorState.Editing(brandId = brand.id, text = brand.name)
                         },
                         onDeleteClick = { onRequestDelete(brand) }
                     )
@@ -213,105 +218,6 @@ internal fun BrandManagementContent(
             )
         }
         null -> Unit
-    }
-}
-
-@Composable
-private fun BrandRow(
-    brand: BrandEntity,
-    onEditClick: () -> Unit,
-    onDeleteClick: () -> Unit
-) {
-    ListItem(
-        headlineContent = { Text(brand.name) },
-        trailingContent = {
-            Row {
-                IconButton(onClick = onEditClick) {
-                    Icon(Icons.Default.Edit, contentDescription = stringResource(R.string.wardrobe_edit))
-                }
-                IconButton(onClick = onDeleteClick) {
-                    Icon(
-                        Icons.Default.Delete,
-                        contentDescription = stringResource(R.string.wardrobe_delete),
-                        tint = MaterialTheme.colorScheme.error
-                    )
-                }
-            }
-        }
-    )
-}
-
-@Composable
-private fun AddBrandRow(
-    text: String,
-    onTextChange: (String) -> Unit,
-    onConfirm: () -> Unit,
-    onCancel: () -> Unit
-) {
-    val focusRequester = remember { FocusRequester() }
-    LaunchedEffect(Unit) { focusRequester.requestFocus() }
-
-    Row(
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(horizontal = 16.dp, vertical = 8.dp),
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.spacedBy(8.dp)
-    ) {
-        OutlinedTextField(
-            value = text,
-            onValueChange = onTextChange,
-            modifier = Modifier
-                .weight(1f)
-                .focusRequester(focusRequester),
-            label = { Text(stringResource(R.string.brand_management_new_brand_hint)) },
-            singleLine = true,
-            keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
-            keyboardActions = KeyboardActions(onDone = { onConfirm() })
-        )
-        IconButton(onClick = onConfirm, enabled = text.isNotBlank()) {
-            Icon(Icons.Default.Check, contentDescription = stringResource(R.string.wardrobe_save))
-        }
-        IconButton(onClick = onCancel) {
-            Icon(Icons.Default.Close, contentDescription = stringResource(R.string.wardrobe_cancel))
-        }
-    }
-}
-
-@Composable
-private fun EditBrandRow(
-    text: String,
-    onTextChange: (String) -> Unit,
-    onConfirm: () -> Unit,
-    onCancel: () -> Unit
-) {
-    val focusRequester = remember { FocusRequester() }
-    LaunchedEffect(Unit) { focusRequester.requestFocus() }
-
-    Row(
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(horizontal = 16.dp, vertical = 8.dp),
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.spacedBy(8.dp)
-    ) {
-        OutlinedTextField(
-            value = text,
-            onValueChange = onTextChange,
-            modifier = Modifier
-                .weight(1f)
-                .focusRequester(focusRequester),
-            label = { Text(stringResource(R.string.brand_management_edit_hint)) },
-            singleLine = true,
-            keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
-            keyboardActions = KeyboardActions(onDone = { onConfirm() })
-        )
-        IconButton(onClick = onConfirm, enabled = text.isNotBlank()) {
-            Icon(Icons.Default.Check, contentDescription = stringResource(R.string.wardrobe_save))
-        }
-        IconButton(onClick = onCancel) {
-            Icon(Icons.Default.Close, contentDescription = stringResource(R.string.wardrobe_cancel))
-        }
     }
 }
 

--- a/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/BrandManagementScreen.kt
+++ b/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/BrandManagementScreen.kt
@@ -18,6 +18,7 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.closet.core.data.model.BrandEntity
+import com.closet.core.ui.components.StringErrorSnackbarEffect
 import com.closet.core.ui.theme.ClosetTheme
 
 @Composable
@@ -51,13 +52,7 @@ internal fun BrandManagementContent(
     val snackbarHostState = remember { SnackbarHostState() }
     var editorState by remember { mutableStateOf<BrandEditorState>(BrandEditorState.Idle) }
 
-    val errorMessage = uiState.errorMessage
-    LaunchedEffect(errorMessage) {
-        if (errorMessage != null) {
-            snackbarHostState.showSnackbar(errorMessage)
-            onErrorConsumed()
-        }
-    }
+    StringErrorSnackbarEffect(uiState.errorMessage, snackbarHostState, onErrorConsumed)
 
     // Close the active row only when a pending save completes successfully.
     // On error the row stays open so the user can correct the input.

--- a/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/BrandManagementScreen.kt
+++ b/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/BrandManagementScreen.kt
@@ -108,7 +108,8 @@ internal fun BrandManagementContent(
             if (editorState is BrandEditorState.Adding) {
                 val addState = editorState as BrandEditorState.Adding
                 item {
-                    AddBrandRow(
+                    BrandInputRow(
+                        label = stringResource(R.string.brand_management_new_brand_hint),
                         text = addState.text,
                         onTextChange = { editorState = addState.copy(text = it) },
                         isSaving = addState.saving,
@@ -144,7 +145,8 @@ internal fun BrandManagementContent(
             items(uiState.brands, key = { it.id }) { brand ->
                 val editState = editorState as? BrandEditorState.Editing
                 if (editState != null && editState.brandId == brand.id) {
-                    EditBrandRow(
+                    BrandInputRow(
+                        label = stringResource(R.string.brand_management_edit_hint),
                         text = editState.text,
                         onTextChange = { editorState = editState.copy(text = it) },
                         isSaving = editState.saving,

--- a/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/BrandManagementScreen.kt
+++ b/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/BrandManagementScreen.kt
@@ -220,7 +220,7 @@ internal fun BrandManagementContent(
 
 // --- Previews ---
 
-private val previewBrands = listOf(
+private val previewBrandsList = listOf(
     BrandEntity(id = 1, name = "Nike"),
     BrandEntity(id = 2, name = "Adidas"),
     BrandEntity(id = 3, name = "Levi's"),
@@ -235,7 +235,7 @@ private fun BrandManagementContentPreview() {
     ClosetTheme {
         Surface {
             BrandManagementContent(
-                uiState = BrandManagementUiState(brands = previewBrands),
+                uiState = BrandManagementUiState(brands = previewBrandsList),
                 onBack = {},
                 onSaveBrand = { _, _ -> },
                 onRequestDelete = {},
@@ -272,8 +272,8 @@ private fun BrandManagementConfirmDeletePreview() {
         Surface {
             BrandManagementContent(
                 uiState = BrandManagementUiState(
-                    brands = previewBrands,
-                    dialog = BrandManagementDialog.ConfirmDelete(previewBrands[0])
+                    brands = previewBrandsList,
+                    dialog = BrandManagementDialog.ConfirmDelete(previewBrandsList[0])
                 ),
                 onBack = {},
                 onSaveBrand = { _, _ -> },
@@ -293,8 +293,8 @@ private fun BrandManagementBlockedDeletePreview() {
         Surface {
             BrandManagementContent(
                 uiState = BrandManagementUiState(
-                    brands = previewBrands,
-                    dialog = BrandManagementDialog.BlockedDelete(previewBrands[1], itemCount = 7)
+                    brands = previewBrandsList,
+                    dialog = BrandManagementDialog.BlockedDelete(previewBrandsList[1], itemCount = 7)
                 ),
                 onBack = {},
                 onSaveBrand = { _, _ -> },

--- a/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/BrandManagementScreen.kt
+++ b/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/BrandManagementScreen.kt
@@ -1,0 +1,292 @@
+package com.closet.features.wardrobe
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.res.pluralStringResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.closet.core.data.model.BrandEntity
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun BrandManagementScreen(
+    onBack: () -> Unit,
+    viewModel: BrandManagementViewModel = hiltViewModel()
+) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val snackbarHostState = remember { SnackbarHostState() }
+
+    var isAddingBrand by remember { mutableStateOf(false) }
+    var newBrandText by remember { mutableStateOf("") }
+    var editingBrandId by remember { mutableStateOf<Long?>(null) }
+    var editText by remember { mutableStateOf("") }
+
+    val errorMessage = uiState.errorMessage
+    LaunchedEffect(errorMessage) {
+        if (errorMessage != null) {
+            snackbarHostState.showSnackbar(errorMessage)
+            viewModel.onErrorConsumed()
+        }
+    }
+
+    Scaffold(
+        snackbarHost = { SnackbarHost(snackbarHostState) },
+        topBar = {
+            TopAppBar(
+                title = { Text(stringResource(R.string.brand_management_title)) },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = stringResource(R.string.wardrobe_back))
+                    }
+                }
+            )
+        },
+        floatingActionButton = {
+            if (!isAddingBrand) {
+                FloatingActionButton(onClick = {
+                    isAddingBrand = true
+                    newBrandText = ""
+                    editingBrandId = null
+                }) {
+                    Icon(Icons.Default.Add, contentDescription = stringResource(R.string.brand_management_add_brand))
+                }
+            }
+        }
+    ) { padding ->
+        LazyColumn(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding),
+            contentPadding = PaddingValues(bottom = 88.dp)
+        ) {
+            if (isAddingBrand) {
+                item {
+                    AddBrandRow(
+                        text = newBrandText,
+                        onTextChange = { newBrandText = it },
+                        onConfirm = {
+                            if (newBrandText.isNotBlank()) {
+                                viewModel.saveBrand(null, newBrandText)
+                                isAddingBrand = false
+                                newBrandText = ""
+                            }
+                        },
+                        onCancel = {
+                            isAddingBrand = false
+                            newBrandText = ""
+                        }
+                    )
+                    HorizontalDivider()
+                }
+            }
+
+            if (uiState.brands.isEmpty() && !isAddingBrand) {
+                item {
+                    Box(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(32.dp),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        Text(
+                            text = stringResource(R.string.brand_management_empty),
+                            style = MaterialTheme.typography.bodyLarge,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                    }
+                }
+            }
+
+            items(uiState.brands, key = { it.id }) { brand ->
+                if (editingBrandId == brand.id) {
+                    EditBrandRow(
+                        text = editText,
+                        onTextChange = { editText = it },
+                        onConfirm = {
+                            if (editText.isNotBlank()) {
+                                viewModel.saveBrand(brand.id, editText)
+                                editingBrandId = null
+                            }
+                        },
+                        onCancel = { editingBrandId = null }
+                    )
+                } else {
+                    BrandRow(
+                        brand = brand,
+                        onEditClick = {
+                            editingBrandId = brand.id
+                            editText = brand.name
+                            isAddingBrand = false
+                        },
+                        onDeleteClick = { viewModel.requestDelete(brand) }
+                    )
+                }
+                HorizontalDivider(modifier = Modifier.padding(horizontal = 16.dp))
+            }
+        }
+    }
+
+    when (val dialog = uiState.dialog) {
+        is BrandManagementDialog.ConfirmDelete -> {
+            AlertDialog(
+                onDismissRequest = viewModel::dismissDialog,
+                title = { Text(stringResource(R.string.brand_management_delete_confirm_title)) },
+                text = {
+                    Text(stringResource(R.string.brand_management_delete_confirm_message, dialog.brand.name))
+                },
+                confirmButton = {
+                    TextButton(
+                        onClick = { viewModel.confirmDelete(dialog.brand.id) },
+                        colors = ButtonDefaults.textButtonColors(contentColor = MaterialTheme.colorScheme.error)
+                    ) {
+                        Text(stringResource(R.string.brand_management_confirm_delete))
+                    }
+                },
+                dismissButton = {
+                    TextButton(onClick = viewModel::dismissDialog) {
+                        Text(stringResource(R.string.wardrobe_cancel))
+                    }
+                }
+            )
+        }
+        is BrandManagementDialog.BlockedDelete -> {
+            AlertDialog(
+                onDismissRequest = viewModel::dismissDialog,
+                title = { Text(stringResource(R.string.brand_management_delete_blocked_title)) },
+                text = {
+                    Text(
+                        stringResource(
+                            R.string.brand_management_delete_blocked_message,
+                            dialog.brand.name,
+                            dialog.itemCount
+                        )
+                    )
+                },
+                confirmButton = {
+                    TextButton(onClick = viewModel::dismissDialog) {
+                        Text(stringResource(R.string.wardrobe_cancel))
+                    }
+                }
+            )
+        }
+        null -> Unit
+    }
+}
+
+@Composable
+private fun BrandRow(
+    brand: BrandEntity,
+    onEditClick: () -> Unit,
+    onDeleteClick: () -> Unit
+) {
+    ListItem(
+        headlineContent = { Text(brand.name) },
+        trailingContent = {
+            Row {
+                IconButton(onClick = onEditClick) {
+                    Icon(Icons.Default.Edit, contentDescription = stringResource(R.string.wardrobe_edit))
+                }
+                IconButton(onClick = onDeleteClick) {
+                    Icon(
+                        Icons.Default.Delete,
+                        contentDescription = stringResource(R.string.wardrobe_delete),
+                        tint = MaterialTheme.colorScheme.error
+                    )
+                }
+            }
+        }
+    )
+}
+
+@Composable
+private fun AddBrandRow(
+    text: String,
+    onTextChange: (String) -> Unit,
+    onConfirm: () -> Unit,
+    onCancel: () -> Unit
+) {
+    val focusRequester = remember { FocusRequester() }
+    LaunchedEffect(Unit) { focusRequester.requestFocus() }
+
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 8.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(8.dp)
+    ) {
+        OutlinedTextField(
+            value = text,
+            onValueChange = onTextChange,
+            modifier = Modifier
+                .weight(1f)
+                .focusRequester(focusRequester),
+            label = { Text(stringResource(R.string.brand_management_new_brand_hint)) },
+            singleLine = true,
+            keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
+            keyboardActions = KeyboardActions(onDone = { onConfirm() })
+        )
+        IconButton(onClick = onConfirm, enabled = text.isNotBlank()) {
+            Icon(Icons.Default.Check, contentDescription = stringResource(R.string.wardrobe_save))
+        }
+        IconButton(onClick = onCancel) {
+            Icon(Icons.Default.Close, contentDescription = stringResource(R.string.wardrobe_cancel))
+        }
+    }
+}
+
+@Composable
+private fun EditBrandRow(
+    text: String,
+    onTextChange: (String) -> Unit,
+    onConfirm: () -> Unit,
+    onCancel: () -> Unit
+) {
+    val focusRequester = remember { FocusRequester() }
+    LaunchedEffect(Unit) { focusRequester.requestFocus() }
+
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 8.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(8.dp)
+    ) {
+        OutlinedTextField(
+            value = text,
+            onValueChange = onTextChange,
+            modifier = Modifier
+                .weight(1f)
+                .focusRequester(focusRequester),
+            label = { Text(stringResource(R.string.brand_management_edit_hint)) },
+            singleLine = true,
+            keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
+            keyboardActions = KeyboardActions(onDone = { onConfirm() })
+        )
+        IconButton(onClick = onConfirm, enabled = text.isNotBlank()) {
+            Icon(Icons.Default.Check, contentDescription = stringResource(R.string.wardrobe_save))
+        }
+        IconButton(onClick = onCancel) {
+            Icon(Icons.Default.Close, contentDescription = stringResource(R.string.wardrobe_cancel))
+        }
+    }
+}

--- a/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/BrandManagementScreen.kt
+++ b/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/BrandManagementScreen.kt
@@ -73,6 +73,7 @@ internal fun BrandManagementContent(
 
     Scaffold(
         snackbarHost = { SnackbarHost(snackbarHostState) },
+        contentWindowInsets = WindowInsets(0),
         topBar = {
             TopAppBar(
                 title = { Text(stringResource(R.string.brand_management_title)) },

--- a/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/BrandManagementScreen.kt
+++ b/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/BrandManagementScreen.kt
@@ -1,5 +1,6 @@
 package com.closet.features.wardrobe
 
+import android.content.res.Configuration
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
@@ -18,21 +19,43 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
-import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.closet.core.data.model.BrandEntity
+import com.closet.core.ui.theme.ClosetTheme
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun BrandManagementScreen(
     onBack: () -> Unit,
     viewModel: BrandManagementViewModel = hiltViewModel()
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    BrandManagementContent(
+        uiState = uiState,
+        onBack = onBack,
+        onSaveBrand = viewModel::saveBrand,
+        onRequestDelete = viewModel::requestDelete,
+        onConfirmDelete = viewModel::confirmDelete,
+        onDismissDialog = viewModel::dismissDialog,
+        onErrorConsumed = viewModel::onErrorConsumed
+    )
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+internal fun BrandManagementContent(
+    uiState: BrandManagementUiState,
+    onBack: () -> Unit,
+    onSaveBrand: (id: Long?, name: String) -> Unit,
+    onRequestDelete: (BrandEntity) -> Unit,
+    onConfirmDelete: (Long) -> Unit,
+    onDismissDialog: () -> Unit,
+    onErrorConsumed: () -> Unit
+) {
     val snackbarHostState = remember { SnackbarHostState() }
 
     var isAddingBrand by remember { mutableStateOf(false) }
@@ -44,7 +67,7 @@ fun BrandManagementScreen(
     LaunchedEffect(errorMessage) {
         if (errorMessage != null) {
             snackbarHostState.showSnackbar(errorMessage)
-            viewModel.onErrorConsumed()
+            onErrorConsumed()
         }
     }
 
@@ -85,7 +108,7 @@ fun BrandManagementScreen(
                         onTextChange = { newBrandText = it },
                         onConfirm = {
                             if (newBrandText.isNotBlank()) {
-                                viewModel.saveBrand(null, newBrandText)
+                                onSaveBrand(null, newBrandText)
                                 isAddingBrand = false
                                 newBrandText = ""
                             }
@@ -123,7 +146,7 @@ fun BrandManagementScreen(
                         onTextChange = { editText = it },
                         onConfirm = {
                             if (editText.isNotBlank()) {
-                                viewModel.saveBrand(brand.id, editText)
+                                onSaveBrand(brand.id, editText)
                                 editingBrandId = null
                             }
                         },
@@ -137,7 +160,7 @@ fun BrandManagementScreen(
                             editText = brand.name
                             isAddingBrand = false
                         },
-                        onDeleteClick = { viewModel.requestDelete(brand) }
+                        onDeleteClick = { onRequestDelete(brand) }
                     )
                 }
                 HorizontalDivider(modifier = Modifier.padding(horizontal = 16.dp))
@@ -148,21 +171,21 @@ fun BrandManagementScreen(
     when (val dialog = uiState.dialog) {
         is BrandManagementDialog.ConfirmDelete -> {
             AlertDialog(
-                onDismissRequest = viewModel::dismissDialog,
+                onDismissRequest = onDismissDialog,
                 title = { Text(stringResource(R.string.brand_management_delete_confirm_title)) },
                 text = {
                     Text(stringResource(R.string.brand_management_delete_confirm_message, dialog.brand.name))
                 },
                 confirmButton = {
                     TextButton(
-                        onClick = { viewModel.confirmDelete(dialog.brand.id) },
+                        onClick = { onConfirmDelete(dialog.brand.id) },
                         colors = ButtonDefaults.textButtonColors(contentColor = MaterialTheme.colorScheme.error)
                     ) {
                         Text(stringResource(R.string.brand_management_confirm_delete))
                     }
                 },
                 dismissButton = {
-                    TextButton(onClick = viewModel::dismissDialog) {
+                    TextButton(onClick = onDismissDialog) {
                         Text(stringResource(R.string.wardrobe_cancel))
                     }
                 }
@@ -170,7 +193,7 @@ fun BrandManagementScreen(
         }
         is BrandManagementDialog.BlockedDelete -> {
             AlertDialog(
-                onDismissRequest = viewModel::dismissDialog,
+                onDismissRequest = onDismissDialog,
                 title = { Text(stringResource(R.string.brand_management_delete_blocked_title)) },
                 text = {
                     Text(
@@ -182,7 +205,7 @@ fun BrandManagementScreen(
                     )
                 },
                 confirmButton = {
-                    TextButton(onClick = viewModel::dismissDialog) {
+                    TextButton(onClick = onDismissDialog) {
                         Text(stringResource(R.string.wardrobe_cancel))
                     }
                 }
@@ -287,6 +310,95 @@ private fun EditBrandRow(
         }
         IconButton(onClick = onCancel) {
             Icon(Icons.Default.Close, contentDescription = stringResource(R.string.wardrobe_cancel))
+        }
+    }
+}
+
+// --- Previews ---
+
+private val previewBrands = listOf(
+    BrandEntity(id = 1, name = "Nike"),
+    BrandEntity(id = 2, name = "Adidas"),
+    BrandEntity(id = 3, name = "Levi's"),
+    BrandEntity(id = 4, name = "Uniqlo"),
+    BrandEntity(id = 5, name = "Zara"),
+)
+
+@Preview(showBackground = true, name = "Brand List - Light")
+@Preview(showBackground = true, uiMode = Configuration.UI_MODE_NIGHT_YES, name = "Brand List - Dark")
+@Composable
+private fun BrandManagementContentPreview() {
+    ClosetTheme {
+        Surface {
+            BrandManagementContent(
+                uiState = BrandManagementUiState(brands = previewBrands),
+                onBack = {},
+                onSaveBrand = { _, _ -> },
+                onRequestDelete = {},
+                onConfirmDelete = {},
+                onDismissDialog = {},
+                onErrorConsumed = {}
+            )
+        }
+    }
+}
+
+@Preview(showBackground = true, name = "Empty State")
+@Composable
+private fun BrandManagementEmptyPreview() {
+    ClosetTheme {
+        Surface {
+            BrandManagementContent(
+                uiState = BrandManagementUiState(brands = emptyList()),
+                onBack = {},
+                onSaveBrand = { _, _ -> },
+                onRequestDelete = {},
+                onConfirmDelete = {},
+                onDismissDialog = {},
+                onErrorConsumed = {}
+            )
+        }
+    }
+}
+
+@Preview(showBackground = true, name = "Confirm Delete Dialog")
+@Composable
+private fun BrandManagementConfirmDeletePreview() {
+    ClosetTheme {
+        Surface {
+            BrandManagementContent(
+                uiState = BrandManagementUiState(
+                    brands = previewBrands,
+                    dialog = BrandManagementDialog.ConfirmDelete(previewBrands[0])
+                ),
+                onBack = {},
+                onSaveBrand = { _, _ -> },
+                onRequestDelete = {},
+                onConfirmDelete = {},
+                onDismissDialog = {},
+                onErrorConsumed = {}
+            )
+        }
+    }
+}
+
+@Preview(showBackground = true, name = "Blocked Delete Dialog")
+@Composable
+private fun BrandManagementBlockedDeletePreview() {
+    ClosetTheme {
+        Surface {
+            BrandManagementContent(
+                uiState = BrandManagementUiState(
+                    brands = previewBrands,
+                    dialog = BrandManagementDialog.BlockedDelete(previewBrands[1], itemCount = 7)
+                ),
+                onBack = {},
+                onSaveBrand = { _, _ -> },
+                onRequestDelete = {},
+                onConfirmDelete = {},
+                onDismissDialog = {},
+                onErrorConsumed = {}
+            )
         }
     }
 }

--- a/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/BrandManagementScreen.kt
+++ b/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/BrandManagementScreen.kt
@@ -11,6 +11,7 @@ import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -203,8 +204,9 @@ internal fun BrandManagementContent(
                 title = { Text(stringResource(R.string.brand_management_delete_blocked_title)) },
                 text = {
                     Text(
-                        stringResource(
-                            R.string.brand_management_delete_blocked_message,
+                        pluralStringResource(
+                            R.plurals.brand_management_delete_blocked_message,
+                            dialog.itemCount,
                             dialog.brand.name,
                             dialog.itemCount
                         )

--- a/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/BrandManagementViewModel.kt
+++ b/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/BrandManagementViewModel.kt
@@ -56,9 +56,15 @@ class BrandManagementViewModel @Inject constructor(
         viewModelScope.launch {
             brandRepository.getAllBrands().collect { result ->
                 when (result) {
-                    is DataResult.Loading -> Unit
-                    is DataResult.Success -> _brands.value = result.data
-                    is DataResult.Error -> _errorMessage.value = mapAppErrorToMessage(result.throwable)
+                    is DataResult.Loading -> _isLoading.value = true
+                    is DataResult.Success -> {
+                        _isLoading.value = false
+                        _brands.value = result.data
+                    }
+                    is DataResult.Error -> {
+                        _isLoading.value = false
+                        _errorMessage.value = mapAppErrorToMessage(result.throwable)
+                    }
                 }
             }
         }

--- a/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/BrandManagementViewModel.kt
+++ b/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/BrandManagementViewModel.kt
@@ -15,11 +15,19 @@ import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
+/**
+ * Dialog state shown on the Brand Management screen.
+ * Either prompts for confirmation to delete an unused brand, or informs
+ * the user that the brand is blocked because it is still assigned to items.
+ */
 sealed interface BrandManagementDialog {
+    /** Confirmation prompt shown when the brand has zero clothing items. */
     data class ConfirmDelete(val brand: BrandEntity) : BrandManagementDialog
+    /** Informational dialog shown when the brand is assigned to one or more items. */
     data class BlockedDelete(val brand: BrandEntity, val itemCount: Int) : BrandManagementDialog
 }
 
+/** UI state for the Brand Management screen. */
 data class BrandManagementUiState(
     val brands: List<BrandEntity> = emptyList(),
     val dialog: BrandManagementDialog? = null,
@@ -27,6 +35,13 @@ data class BrandManagementUiState(
     val errorMessage: String? = null
 )
 
+/**
+ * ViewModel for the Brand Management screen.
+ *
+ * Exposes a single [uiState] derived from the live brand list combined with
+ * transient loading/error/dialog state. All write operations dispatch to
+ * [BrandRepository] and surface errors via [uiState].
+ */
 @HiltViewModel
 class BrandManagementViewModel @Inject constructor(
     private val brandRepository: BrandRepository
@@ -66,6 +81,11 @@ class BrandManagementViewModel @Inject constructor(
         initialValue = BrandManagementUiState()
     )
 
+    /**
+     * Initiates a delete request for [brand].
+     * Shows [BrandManagementDialog.ConfirmDelete] if the brand is unused, or
+     * [BrandManagementDialog.BlockedDelete] if clothing items still reference it.
+     */
     fun requestDelete(brand: BrandEntity) {
         viewModelScope.launch {
             when (val result = brandRepository.getItemCountForBrand(brand.id)) {
@@ -82,6 +102,7 @@ class BrandManagementViewModel @Inject constructor(
         }
     }
 
+    /** Executes the delete for the brand with [id] and dismisses the dialog on completion. */
     fun confirmDelete(id: Long) {
         viewModelScope.launch {
             _isLoading.value = true
@@ -100,6 +121,10 @@ class BrandManagementViewModel @Inject constructor(
         }
     }
 
+    /**
+     * Inserts a new brand when [id] is null, or renames the existing brand when [id] is non-null.
+     * Blank names are silently ignored.
+     */
     fun saveBrand(id: Long?, name: String) {
         val trimmed = name.trim()
         if (trimmed.isBlank()) return
@@ -121,14 +146,17 @@ class BrandManagementViewModel @Inject constructor(
         }
     }
 
+    /** Clears the currently shown dialog. */
     fun dismissDialog() {
         _dialog.value = null
     }
 
+    /** Clears the transient error message once the UI has consumed it. */
     fun onErrorConsumed() {
         _errorMessage.value = null
     }
 
+    /** Maps an [AppError] (or any throwable) to a human-readable message for the UI. */
     private fun mapAppErrorToMessage(throwable: Throwable): String = when (throwable) {
         is AppError.DatabaseError.ConstraintViolation -> "A brand with that name already exists."
         is AppError.DatabaseError.NotFound -> "Brand not found."

--- a/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/BrandManagementViewModel.kt
+++ b/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/BrandManagementViewModel.kt
@@ -47,34 +47,35 @@ class BrandManagementViewModel @Inject constructor(
     private val brandRepository: BrandRepository
 ) : ViewModel() {
 
+    private val _brands = MutableStateFlow<List<BrandEntity>>(emptyList())
     private val _dialog = MutableStateFlow<BrandManagementDialog?>(null)
     private val _isLoading = MutableStateFlow(false)
     private val _errorMessage = MutableStateFlow<String?>(null)
 
+    init {
+        viewModelScope.launch {
+            brandRepository.getAllBrands().collect { result ->
+                when (result) {
+                    is DataResult.Loading -> Unit
+                    is DataResult.Success -> _brands.value = result.data
+                    is DataResult.Error -> _errorMessage.value = mapAppErrorToMessage(result.throwable)
+                }
+            }
+        }
+    }
+
     val uiState: StateFlow<BrandManagementUiState> = combine(
-        brandRepository.getAllBrands(),
+        _brands,
         _dialog,
         _isLoading,
         _errorMessage
-    ) { brandsResult, dialog, loading, error ->
-        when (brandsResult) {
-            is DataResult.Loading -> BrandManagementUiState(
-                dialog = dialog,
-                isLoading = true,
-                errorMessage = error
-            )
-            is DataResult.Success -> BrandManagementUiState(
-                brands = brandsResult.data,
-                dialog = dialog,
-                isLoading = loading,
-                errorMessage = error
-            )
-            is DataResult.Error -> BrandManagementUiState(
-                dialog = dialog,
-                isLoading = false,
-                errorMessage = mapAppErrorToMessage(brandsResult.throwable)
-            )
-        }
+    ) { brands, dialog, loading, error ->
+        BrandManagementUiState(
+            brands = brands,
+            dialog = dialog,
+            isLoading = loading,
+            errorMessage = error
+        )
     }.stateIn(
         scope = viewModelScope,
         started = SharingStarted.WhileSubscribed(5_000),

--- a/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/BrandManagementViewModel.kt
+++ b/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/BrandManagementViewModel.kt
@@ -1,0 +1,112 @@
+package com.closet.features.wardrobe
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.closet.core.data.model.BrandEntity
+import com.closet.core.data.repository.BrandRepository
+import com.closet.core.data.util.DataResult
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+sealed interface BrandManagementDialog {
+    data class ConfirmDelete(val brand: BrandEntity) : BrandManagementDialog
+    data class BlockedDelete(val brand: BrandEntity, val itemCount: Int) : BrandManagementDialog
+}
+
+data class BrandManagementUiState(
+    val brands: List<BrandEntity> = emptyList(),
+    val dialog: BrandManagementDialog? = null,
+    val isLoading: Boolean = false,
+    val errorMessage: String? = null
+)
+
+@HiltViewModel
+class BrandManagementViewModel @Inject constructor(
+    private val brandRepository: BrandRepository
+) : ViewModel() {
+
+    private val _dialog = MutableStateFlow<BrandManagementDialog?>(null)
+    private val _isLoading = MutableStateFlow(false)
+    private val _errorMessage = MutableStateFlow<String?>(null)
+
+    val uiState: StateFlow<BrandManagementUiState> = combine(
+        brandRepository.getAllBrands(),
+        _dialog,
+        _isLoading,
+        _errorMessage
+    ) { brands, dialog, loading, error ->
+        BrandManagementUiState(
+            brands = brands,
+            dialog = dialog,
+            isLoading = loading,
+            errorMessage = error
+        )
+    }.stateIn(
+        scope = viewModelScope,
+        started = SharingStarted.WhileSubscribed(5_000),
+        initialValue = BrandManagementUiState()
+    )
+
+    fun requestDelete(brand: BrandEntity) {
+        viewModelScope.launch {
+            when (val result = brandRepository.getItemCountForBrand(brand.id)) {
+                is DataResult.Success -> {
+                    _dialog.value = if (result.data > 0) {
+                        BrandManagementDialog.BlockedDelete(brand, result.data)
+                    } else {
+                        BrandManagementDialog.ConfirmDelete(brand)
+                    }
+                }
+                is DataResult.Error -> _errorMessage.value = "Could not check item count."
+                else -> Unit
+            }
+        }
+    }
+
+    fun confirmDelete(id: Long) {
+        viewModelScope.launch {
+            _isLoading.value = true
+            when (val result = brandRepository.deleteBrand(id)) {
+                is DataResult.Success -> dismissDialog()
+                is DataResult.Error -> {
+                    _errorMessage.value = "Failed to delete brand."
+                    dismissDialog()
+                }
+                else -> Unit
+            }
+            _isLoading.value = false
+        }
+    }
+
+    fun saveBrand(id: Long?, name: String) {
+        val trimmed = name.trim()
+        if (trimmed.isBlank()) return
+
+        viewModelScope.launch {
+            _isLoading.value = true
+            val result = if (id == null) {
+                brandRepository.insertBrand(trimmed)
+            } else {
+                brandRepository.updateBrand(id, trimmed)
+            }
+            if (result is DataResult.Error) {
+                _errorMessage.value = "Failed to save brand."
+            }
+            _isLoading.value = false
+        }
+    }
+
+    fun dismissDialog() {
+        _dialog.value = null
+    }
+
+    fun onErrorConsumed() {
+        _errorMessage.value = null
+    }
+}

--- a/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/BrandManagementViewModel.kt
+++ b/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/BrandManagementViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.closet.core.data.model.BrandEntity
 import com.closet.core.data.repository.BrandRepository
+import com.closet.core.data.util.AppError
 import com.closet.core.data.util.DataResult
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -40,13 +41,25 @@ class BrandManagementViewModel @Inject constructor(
         _dialog,
         _isLoading,
         _errorMessage
-    ) { brands, dialog, loading, error ->
-        BrandManagementUiState(
-            brands = brands,
-            dialog = dialog,
-            isLoading = loading,
-            errorMessage = error
-        )
+    ) { brandsResult, dialog, loading, error ->
+        when (brandsResult) {
+            is DataResult.Loading -> BrandManagementUiState(
+                dialog = dialog,
+                isLoading = true,
+                errorMessage = error
+            )
+            is DataResult.Success -> BrandManagementUiState(
+                brands = brandsResult.data,
+                dialog = dialog,
+                isLoading = loading,
+                errorMessage = error
+            )
+            is DataResult.Error -> BrandManagementUiState(
+                dialog = dialog,
+                isLoading = false,
+                errorMessage = mapAppErrorToMessage(brandsResult.throwable)
+            )
+        }
     }.stateIn(
         scope = viewModelScope,
         started = SharingStarted.WhileSubscribed(5_000),
@@ -63,7 +76,7 @@ class BrandManagementViewModel @Inject constructor(
                         BrandManagementDialog.ConfirmDelete(brand)
                     }
                 }
-                is DataResult.Error -> _errorMessage.value = "Could not check item count."
+                is DataResult.Error -> _errorMessage.value = mapAppErrorToMessage(result.throwable)
                 else -> Unit
             }
         }
@@ -72,15 +85,18 @@ class BrandManagementViewModel @Inject constructor(
     fun confirmDelete(id: Long) {
         viewModelScope.launch {
             _isLoading.value = true
-            when (val result = brandRepository.deleteBrand(id)) {
-                is DataResult.Success -> dismissDialog()
-                is DataResult.Error -> {
-                    _errorMessage.value = "Failed to delete brand."
-                    dismissDialog()
+            try {
+                when (val result = brandRepository.deleteBrand(id)) {
+                    is DataResult.Success -> dismissDialog()
+                    is DataResult.Error -> {
+                        _errorMessage.value = mapAppErrorToMessage(result.throwable)
+                        dismissDialog()
+                    }
+                    else -> Unit
                 }
-                else -> Unit
+            } finally {
+                _isLoading.value = false
             }
-            _isLoading.value = false
         }
     }
 
@@ -90,15 +106,18 @@ class BrandManagementViewModel @Inject constructor(
 
         viewModelScope.launch {
             _isLoading.value = true
-            val result = if (id == null) {
-                brandRepository.insertBrand(trimmed)
-            } else {
-                brandRepository.updateBrand(id, trimmed)
+            try {
+                val result = if (id == null) {
+                    brandRepository.insertBrand(trimmed)
+                } else {
+                    brandRepository.updateBrand(id, trimmed)
+                }
+                if (result is DataResult.Error) {
+                    _errorMessage.value = mapAppErrorToMessage(result.throwable)
+                }
+            } finally {
+                _isLoading.value = false
             }
-            if (result is DataResult.Error) {
-                _errorMessage.value = "Failed to save brand."
-            }
-            _isLoading.value = false
         }
     }
 
@@ -108,5 +127,15 @@ class BrandManagementViewModel @Inject constructor(
 
     fun onErrorConsumed() {
         _errorMessage.value = null
+    }
+
+    private fun mapAppErrorToMessage(throwable: Throwable): String = when (throwable) {
+        is AppError.DatabaseError.ConstraintViolation -> "A brand with that name already exists."
+        is AppError.DatabaseError.NotFound -> "Brand not found."
+        is AppError.DatabaseError.QueryError -> "A database error occurred."
+        is AppError.ValidationError.InvalidInput -> throwable.message ?: "Invalid input."
+        is AppError.ValidationError.MissingField -> "Missing required field: ${throwable.fieldName}."
+        is AppError.Unexpected -> "An unexpected error occurred."
+        else -> "Something went wrong."
     }
 }

--- a/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/ClosetScreen.kt
+++ b/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/ClosetScreen.kt
@@ -204,13 +204,14 @@ private fun ClosetScreenPreview() {
                         item = ClothingItemEntity(
                             id = 1,
                             name = "Vintage Denim Jacket",
-                            brand = "Levi's",
+                            brandId = 1,
                             categoryId = 1,
                             status = ClothingStatus.Active,
                             isFavorite = 1,
                             washStatus = WashStatus.Clean
                         ),
                         wearCount = 12,
+                        brand = com.closet.core.data.model.BrandEntity(id = 1, name = "Levi's"),
                         category = CategoryEntity(id = 1, name = "Outerwear", sortOrder = 3),
                         subcategory = null,
                         sizeValue = null,

--- a/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/ClothingDetailComponents.kt
+++ b/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/ClothingDetailComponents.kt
@@ -161,7 +161,7 @@ internal fun AttributeSection(
             IconButton(onClick = onEditClick) {
                 Icon(
                     imageVector = Icons.Default.Add,
-                    contentDescription = "Edit $title",
+                    contentDescription = stringResource(R.string.wardrobe_edit_with_section, title),
                     tint = MaterialTheme.colorScheme.primary
                 )
             }

--- a/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/ClothingDetailComponents.kt
+++ b/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/ClothingDetailComponents.kt
@@ -1,0 +1,223 @@
+package com.closet.features.wardrobe
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.closet.core.data.model.ClothingItemDetail
+import com.closet.core.ui.util.IconMapper
+
+// ─── ClothingAttributes ───────────────────────────────────────────────────────
+
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+internal fun ClothingAttributes(
+    item: ClothingItemDetail,
+    onEditSeasons: () -> Unit,
+    onEditOccasions: () -> Unit,
+    onEditColors: () -> Unit,
+    onEditMaterials: () -> Unit,
+    onEditPatterns: () -> Unit
+) {
+    Column(verticalArrangement = Arrangement.spacedBy(16.dp)) {
+        AttributeSection(
+            title = stringResource(R.string.wardrobe_seasons),
+            onEditClick = onEditSeasons
+        ) {
+            FlowRow(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                if (item.seasons.isEmpty()) {
+                    AttributeEmptyHint()
+                } else {
+                    item.seasons.forEach { season ->
+                        AttributeChip(
+                            label = season.name,
+                            iconResId = IconMapper.getIconResource(season.icon),
+                            onClick = onEditSeasons
+                        )
+                    }
+                }
+            }
+        }
+
+        AttributeSection(
+            title = stringResource(R.string.wardrobe_colors),
+            onEditClick = onEditColors
+        ) {
+            FlowRow(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                if (item.colors.isEmpty()) {
+                    AttributeEmptyHint()
+                } else {
+                    item.colors.forEach { color ->
+                        AttributeChip(
+                            label = color.name,
+                            color = color.hex?.let {
+                                try { Color(android.graphics.Color.parseColor(it)) }
+                                catch (_: Exception) { null }
+                            },
+                            onClick = onEditColors
+                        )
+                    }
+                }
+            }
+        }
+
+        AttributeSection(
+            title = stringResource(R.string.wardrobe_materials),
+            onEditClick = onEditMaterials
+        ) {
+            FlowRow(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                if (item.materials.isEmpty()) {
+                    AttributeEmptyHint()
+                } else {
+                    item.materials.forEach { material ->
+                        AttributeChip(label = material.name, onClick = onEditMaterials)
+                    }
+                }
+            }
+        }
+
+        AttributeSection(
+            title = stringResource(R.string.wardrobe_patterns),
+            onEditClick = onEditPatterns
+        ) {
+            FlowRow(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                if (item.patterns.isEmpty()) {
+                    AttributeEmptyHint()
+                } else {
+                    item.patterns.forEach { pattern ->
+                        AttributeChip(label = pattern.name, onClick = onEditPatterns)
+                    }
+                }
+            }
+        }
+
+        AttributeSection(
+            title = stringResource(R.string.wardrobe_occasions),
+            onEditClick = onEditOccasions
+        ) {
+            FlowRow(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                if (item.occasions.isEmpty()) {
+                    AttributeEmptyHint()
+                } else {
+                    item.occasions.forEach { occasion ->
+                        AttributeChip(
+                            label = occasion.name,
+                            iconResId = IconMapper.getIconResource(occasion.icon),
+                            onClick = onEditOccasions
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+// ─── AttributeSection ─────────────────────────────────────────────────────────
+
+@Composable
+internal fun AttributeSection(
+    title: String,
+    onEditClick: () -> Unit,
+    content: @Composable () -> Unit
+) {
+    Column {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(
+                text = title,
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.Bold
+            )
+            IconButton(onClick = onEditClick) {
+                Icon(
+                    imageVector = Icons.Default.Add,
+                    contentDescription = "Edit $title",
+                    tint = MaterialTheme.colorScheme.primary
+                )
+            }
+        }
+        Spacer(modifier = Modifier.height(4.dp))
+        content()
+    }
+}
+
+// ─── AttributeChip ────────────────────────────────────────────────────────────
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+internal fun AttributeChip(
+    label: String,
+    iconResId: Int? = null,
+    color: Color? = null,
+    onClick: () -> Unit
+) {
+    Surface(
+        onClick = onClick,
+        shape = RoundedCornerShape(8.dp),
+        color = MaterialTheme.colorScheme.surfaceVariant
+    ) {
+        Row(
+            modifier = Modifier.padding(horizontal = 12.dp, vertical = 6.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            if (color != null) {
+                Box(
+                    modifier = Modifier
+                        .size(16.dp)
+                        .clip(CircleShape)
+                        .background(color)
+                )
+            } else if (iconResId != null) {
+                Icon(
+                    painter = painterResource(id = iconResId),
+                    contentDescription = null,
+                    modifier = Modifier.size(16.dp),
+                    tint = MaterialTheme.colorScheme.primary
+                )
+            }
+            Text(text = label, style = MaterialTheme.typography.labelLarge)
+        }
+    }
+}
+
+// ─── AttributeEmptyHint ───────────────────────────────────────────────────────
+
+@Composable
+private fun AttributeEmptyHint() {
+    Text(
+        text = stringResource(R.string.wardrobe_none_selected),
+        style = MaterialTheme.typography.bodyMedium,
+        color = MaterialTheme.colorScheme.onSurfaceVariant
+    )
+}

--- a/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/ClothingDetailPreviews.kt
+++ b/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/ClothingDetailPreviews.kt
@@ -1,0 +1,159 @@
+package com.closet.features.wardrobe
+
+import android.content.res.Configuration
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Surface
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.closet.core.data.model.BrandEntity
+import com.closet.core.data.model.CategoryEntity
+import com.closet.core.data.model.ClothingItemDetail
+import com.closet.core.data.model.ClothingItemEntity
+import com.closet.core.data.model.ClothingStatus
+import com.closet.core.data.model.ColorEntity
+import com.closet.core.data.model.MaterialEntity
+import com.closet.core.data.model.OccasionEntity
+import com.closet.core.data.model.SeasonEntity
+import com.closet.core.data.model.SubcategoryEntity
+import com.closet.core.data.model.WashStatus
+import com.closet.core.ui.theme.ClosetTheme
+
+// ─── Shared preview data ──────────────────────────────────────────────────────
+
+internal val previewDetailItem = ClothingItemDetail(
+    item = ClothingItemEntity(
+        id = 1L,
+        name = "Vintage Denim Jacket",
+        purchasePrice = 85.00,
+        status = ClothingStatus.Active,
+        washStatus = WashStatus.Clean,
+        isFavorite = 1,
+        notes = "Great for layering. Found at a thrift store in Brooklyn."
+    ),
+    wearCount = 12,
+    category = CategoryEntity(id = 1L, name = "Tops", sortOrder = 1),
+    subcategory = SubcategoryEntity(id = 2L, categoryId = 1L, name = "Jackets", sortOrder = 2),
+    brand = BrandEntity(id = 1L, name = "Levi's"),
+    sizeValue = null,
+    colors = listOf(
+        ColorEntity(id = 1L, name = "Blue", hex = "#3A6BAE"),
+        ColorEntity(id = 2L, name = "White", hex = "#FFFFFF"),
+    ),
+    materials = listOf(
+        MaterialEntity(id = 1L, name = "Denim"),
+        MaterialEntity(id = 2L, name = "Cotton")
+    ),
+    seasons = listOf(
+        SeasonEntity(id = 1L, name = "Spring", icon = "flower"),
+        SeasonEntity(id = 3L, name = "Fall", icon = "leaf")
+    ),
+    occasions = listOf(
+        OccasionEntity(id = 1L, name = "Casual", icon = "couch"),
+        OccasionEntity(id = 2L, name = "Weekend", icon = "coffee")
+    ),
+    patterns = emptyList()
+)
+
+internal val previewDetailItemMinimal = ClothingItemDetail(
+    item = ClothingItemEntity(
+        id = 2L,
+        name = "Plain White Tee",
+        status = ClothingStatus.Active,
+        washStatus = WashStatus.Dirty,
+        isFavorite = 0
+    ),
+    wearCount = 0,
+    category = CategoryEntity(id = 1L, name = "Tops", sortOrder = 1),
+    subcategory = null,
+    brand = null,
+    sizeValue = null,
+    colors = emptyList(),
+    materials = emptyList(),
+    seasons = emptyList(),
+    occasions = emptyList(),
+    patterns = emptyList()
+)
+
+// ─── ClothingAttributes previews ─────────────────────────────────────────────
+
+@Preview(showBackground = true, name = "Attributes - Filled - Light")
+@Preview(showBackground = true, uiMode = Configuration.UI_MODE_NIGHT_YES, name = "Attributes - Filled - Dark")
+@Composable
+private fun ClothingAttributesFilledPreview() {
+    ClosetTheme {
+        Surface {
+            Column(modifier = Modifier.padding(16.dp)) {
+                ClothingAttributes(
+                    item = previewDetailItem,
+                    onEditSeasons = {},
+                    onEditOccasions = {},
+                    onEditColors = {},
+                    onEditMaterials = {},
+                    onEditPatterns = {}
+                )
+            }
+        }
+    }
+}
+
+@Preview(showBackground = true, name = "Attributes - Empty State")
+@Composable
+private fun ClothingAttributesEmptyPreview() {
+    ClosetTheme {
+        Surface {
+            Column(modifier = Modifier.padding(16.dp)) {
+                ClothingAttributes(
+                    item = previewDetailItemMinimal,
+                    onEditSeasons = {},
+                    onEditOccasions = {},
+                    onEditColors = {},
+                    onEditMaterials = {},
+                    onEditPatterns = {}
+                )
+            }
+        }
+    }
+}
+
+// ─── AttributeChip / AttributeSection previews ───────────────────────────────
+
+@Preview(showBackground = true, name = "AttributeChip - Text Only")
+@Preview(showBackground = true, name = "AttributeChip - With Color")
+@Composable
+private fun AttributeChipPreview() {
+    ClosetTheme {
+        Surface {
+            Row(
+                modifier = Modifier.padding(12.dp),
+                horizontalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                AttributeChip(label = "Casual", onClick = {})
+                AttributeChip(label = "Blue", color = Color(0xFF3A6BAE), onClick = {})
+                AttributeChip(label = "Fall", onClick = {})
+            }
+        }
+    }
+}
+
+@Preview(showBackground = true, name = "AttributeSection - With Items")
+@Composable
+private fun AttributeSectionPreview() {
+    ClosetTheme {
+        Surface {
+            Column(modifier = Modifier.padding(16.dp)) {
+                AttributeSection(title = "Colors", onEditClick = {}) {
+                    Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                        AttributeChip(label = "Blue", color = Color(0xFF3A6BAE), onClick = {})
+                        AttributeChip(label = "White", color = Color(0xFFFFFFFF), onClick = {})
+                    }
+                }
+            }
+        }
+    }
+}

--- a/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/ClothingDetailScreen.kt
+++ b/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/ClothingDetailScreen.kt
@@ -13,6 +13,7 @@ import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import android.content.res.Configuration
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
@@ -21,6 +22,7 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
 import java.util.Locale
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -28,6 +30,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import coil.compose.AsyncImage
 import com.closet.core.data.model.*
 import com.closet.core.ui.R as CoreR
+import com.closet.core.ui.theme.ClosetTheme
 import com.closet.core.ui.util.IconMapper
 
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)
@@ -603,3 +606,126 @@ private fun AttributeChip(
         }
     }
 }
+
+// region Previews
+
+private val previewItem = ClothingItemDetail(
+    item = ClothingItemEntity(
+        id = 1L,
+        name = "Vintage Denim Jacket",
+        purchasePrice = 85.00,
+        status = ClothingStatus.Active,
+        washStatus = WashStatus.Clean,
+        isFavorite = 1,
+        notes = "Great for layering. Found at a thrift store in Brooklyn."
+    ),
+    wearCount = 12,
+    category = CategoryEntity(id = 1L, name = "Tops", sortOrder = 1),
+    subcategory = SubcategoryEntity(id = 2L, categoryId = 1L, name = "Jackets", sortOrder = 2),
+    brand = BrandEntity(id = 1L, name = "Levi's"),
+    sizeValue = null,
+    colors = listOf(
+        ColorEntity(id = 1L, name = "Blue", hex = "#3A6BAE"),
+        ColorEntity(id = 2L, name = "White", hex = "#FFFFFF"),
+    ),
+    materials = listOf(MaterialEntity(id = 1L, name = "Denim"), MaterialEntity(id = 2L, name = "Cotton")),
+    seasons = listOf(SeasonEntity(id = 1L, name = "Spring"), SeasonEntity(id = 3L, name = "Fall")),
+    occasions = listOf(OccasionEntity(id = 1L, name = "Casual"), OccasionEntity(id = 2L, name = "Weekend")),
+    patterns = emptyList()
+)
+
+private val previewItemMinimal = ClothingItemDetail(
+    item = ClothingItemEntity(
+        id = 2L,
+        name = "Plain White Tee",
+        status = ClothingStatus.Active,
+        washStatus = WashStatus.Dirty,
+        isFavorite = 0
+    ),
+    wearCount = 0,
+    category = CategoryEntity(id = 1L, name = "Tops", sortOrder = 1),
+    subcategory = null,
+    brand = null,
+    sizeValue = null,
+    colors = emptyList(),
+    materials = emptyList(),
+    seasons = emptyList(),
+    occasions = emptyList(),
+    patterns = emptyList()
+)
+
+@Preview(showBackground = true, name = "Attributes - Filled - Light")
+@Preview(showBackground = true, uiMode = Configuration.UI_MODE_NIGHT_YES, name = "Attributes - Filled - Dark")
+@Composable
+private fun ClothingAttributesFilledPreview() {
+    ClosetTheme {
+        Surface {
+            Column(modifier = Modifier.padding(16.dp)) {
+                ClothingAttributes(
+                    item = previewItem,
+                    onEditSeasons = {},
+                    onEditOccasions = {},
+                    onEditColors = {},
+                    onEditMaterials = {},
+                    onEditPatterns = {}
+                )
+            }
+        }
+    }
+}
+
+@Preview(showBackground = true, name = "Attributes - Empty State")
+@Composable
+private fun ClothingAttributesEmptyPreview() {
+    ClosetTheme {
+        Surface {
+            Column(modifier = Modifier.padding(16.dp)) {
+                ClothingAttributes(
+                    item = previewItemMinimal,
+                    onEditSeasons = {},
+                    onEditOccasions = {},
+                    onEditColors = {},
+                    onEditMaterials = {},
+                    onEditPatterns = {}
+                )
+            }
+        }
+    }
+}
+
+@Preview(showBackground = true, name = "AttributeChip - Text Only")
+@Preview(showBackground = true, name = "AttributeChip - With Color")
+@Composable
+private fun AttributeChipPreview() {
+    ClosetTheme {
+        Surface {
+            Row(
+                modifier = Modifier.padding(12.dp),
+                horizontalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                AttributeChip(label = "Casual", onClick = {})
+                AttributeChip(label = "Blue", color = Color(0xFF3A6BAE), onClick = {})
+                AttributeChip(label = "Fall", onClick = {})
+            }
+        }
+    }
+}
+
+@Preview(showBackground = true, name = "AttributeSection - With Items")
+@Composable
+private fun AttributeSectionPreview() {
+    ClosetTheme {
+        Surface {
+            Column(modifier = Modifier.padding(16.dp)) {
+                AttributeSection(title = "Colors", onEditClick = {}) {
+                    Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                        AttributeChip(label = "Blue", color = Color(0xFF3A6BAE), onClick = {})
+                        AttributeChip(label = "White", color = Color(0xFFFFFFFF), onClick = {})
+                    }
+                }
+            }
+        }
+    }
+}
+
+// endregion

--- a/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/ClothingDetailScreen.kt
+++ b/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/ClothingDetailScreen.kt
@@ -4,7 +4,6 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
@@ -13,16 +12,13 @@ import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import android.content.res.Configuration
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.tooling.preview.Preview
 import java.util.Locale
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -30,8 +26,9 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import coil.compose.AsyncImage
 import com.closet.core.data.model.*
 import com.closet.core.ui.R as CoreR
-import com.closet.core.ui.theme.ClosetTheme
 import com.closet.core.ui.util.IconMapper
+
+private enum class AttributePicker { SEASONS, OCCASIONS, COLORS, MATERIALS, PATTERNS }
 
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)
 @Composable
@@ -61,11 +58,7 @@ fun ClothingDetailScreen(
         }
     }
 
-    var showSeasonPicker by remember { mutableStateOf(false) }
-    var showOccasionPicker by remember { mutableStateOf(false) }
-    var showColorPicker by remember { mutableStateOf(false) }
-    var showMaterialPicker by remember { mutableStateOf(false) }
-    var showPatternPicker by remember { mutableStateOf(false) }
+    var activePicker by remember { mutableStateOf<AttributePicker?>(null) }
 
     Scaffold(
         snackbarHost = { SnackbarHost(snackbarHostState) },
@@ -285,11 +278,11 @@ fun ClothingDetailScreen(
                         // Attributes
                         ClothingAttributes(
                             item = detail,
-                            onEditSeasons = { showSeasonPicker = true },
-                            onEditOccasions = { showOccasionPicker = true },
-                            onEditColors = { showColorPicker = true },
-                            onEditMaterials = { showMaterialPicker = true },
-                            onEditPatterns = { showPatternPicker = true }
+                            onEditSeasons = { activePicker = AttributePicker.SEASONS },
+                            onEditOccasions = { activePicker = AttributePicker.OCCASIONS },
+                            onEditColors = { activePicker = AttributePicker.COLORS },
+                            onEditMaterials = { activePicker = AttributePicker.MATERIALS },
+                            onEditPatterns = { activePicker = AttributePicker.PATTERNS }
                         )
 
                         // Notes
@@ -314,418 +307,48 @@ fun ClothingDetailScreen(
         }
     }
 
-    // Multi-Select Sheets
-    if (showSeasonPicker) {
-        MultiSelectSheet(
-            title = stringResource(R.string.wardrobe_seasons),
-            items = allSeasons.map {
-                MultiSelectItem(
-                    it.id,
-                    it.name,
-                    it,
-                    iconResId = IconMapper.getIconResource(it.icon)
-                )
-            },
-            selectedIds = (uiState as? ClothingDetailUiState.Success)?.item?.seasons?.map { it.id }
-                ?.toSet() ?: emptySet(),
-            onDismiss = { showSeasonPicker = false },
-            onConfirm = {
-                viewModel.updateSeasons(it)
-                showSeasonPicker = false
-            }
-        )
-    }
+    // Attribute picker sheet — driven by activePicker state
+    activePicker?.let { picker ->
+        val successItem = (uiState as? ClothingDetailUiState.Success)?.item
+        val title = stringResource(when (picker) {
+            AttributePicker.SEASONS   -> R.string.wardrobe_seasons
+            AttributePicker.OCCASIONS -> R.string.wardrobe_occasions
+            AttributePicker.COLORS    -> R.string.wardrobe_colors
+            AttributePicker.MATERIALS -> R.string.wardrobe_materials
+            AttributePicker.PATTERNS  -> R.string.wardrobe_patterns
+        })
+        val items = when (picker) {
+            AttributePicker.SEASONS   -> allSeasons.map { MultiSelectItem(it.id, it.name, it, iconResId = IconMapper.getIconResource(it.icon)) }
+            AttributePicker.OCCASIONS -> allOccasions.map { MultiSelectItem(it.id, it.name, it, iconResId = IconMapper.getIconResource(it.icon)) }
+            AttributePicker.COLORS    -> allColors.map { MultiSelectItem(it.id, it.name, it, colorHex = it.hex) }
+            AttributePicker.MATERIALS -> allMaterials.map { MultiSelectItem(it.id, it.name, it) }
+            AttributePicker.PATTERNS  -> allPatterns.map { MultiSelectItem(it.id, it.name, it) }
+        }
+        val selectedIds = when (picker) {
+            AttributePicker.SEASONS   -> successItem?.seasons?.map { it.id }?.toSet()
+            AttributePicker.OCCASIONS -> successItem?.occasions?.map { it.id }?.toSet()
+            AttributePicker.COLORS    -> successItem?.colors?.map { it.id }?.toSet()
+            AttributePicker.MATERIALS -> successItem?.materials?.map { it.id }?.toSet()
+            AttributePicker.PATTERNS  -> successItem?.patterns?.map { it.id }?.toSet()
+        } ?: emptySet()
 
-    if (showOccasionPicker) {
         MultiSelectSheet(
-            title = stringResource(R.string.wardrobe_occasions),
-            items = allOccasions.map {
-                MultiSelectItem(
-                    it.id,
-                    it.name,
-                    it,
-                    iconResId = IconMapper.getIconResource(it.icon)
-                )
-            },
-            selectedIds = (uiState as? ClothingDetailUiState.Success)?.item?.occasions?.map { it.id }
-                ?.toSet() ?: emptySet(),
-            onDismiss = { showOccasionPicker = false },
-            onConfirm = {
-                viewModel.updateOccasions(it)
-                showOccasionPicker = false
-            }
-        )
-    }
-
-    if (showColorPicker) {
-        MultiSelectSheet(
-            title = stringResource(R.string.wardrobe_colors),
-            items = allColors.map { MultiSelectItem(it.id, it.name, it, colorHex = it.hex) },
-            selectedIds = (uiState as? ClothingDetailUiState.Success)?.item?.colors?.map { it.id }
-                ?.toSet() ?: emptySet(),
-            onDismiss = { showColorPicker = false },
-            onConfirm = {
-                viewModel.updateColors(it)
-                showColorPicker = false
-            }
-        )
-    }
-
-    if (showMaterialPicker) {
-        MultiSelectSheet(
-            title = stringResource(R.string.wardrobe_materials),
-            items = allMaterials.map { MultiSelectItem(it.id, it.name, it) },
-            selectedIds = (uiState as? ClothingDetailUiState.Success)?.item?.materials?.map { it.id }
-                ?.toSet() ?: emptySet(),
-            onDismiss = { showMaterialPicker = false },
-            onConfirm = {
-                viewModel.updateMaterials(it)
-                showMaterialPicker = false
-            }
-        )
-    }
-
-    if (showPatternPicker) {
-        MultiSelectSheet(
-            title = stringResource(R.string.wardrobe_patterns),
-            items = allPatterns.map { MultiSelectItem(it.id, it.name, it) },
-            selectedIds = (uiState as? ClothingDetailUiState.Success)?.item?.patterns?.map { it.id }
-                ?.toSet() ?: emptySet(),
-            onDismiss = { showPatternPicker = false },
-            onConfirm = {
-                viewModel.updatePatterns(it)
-                showPatternPicker = false
+            title = title,
+            items = items,
+            selectedIds = selectedIds,
+            onDismiss = { activePicker = null },
+            onConfirm = { selected ->
+                when (picker) {
+                    AttributePicker.SEASONS   -> viewModel.updateSeasons(selected)
+                    AttributePicker.OCCASIONS -> viewModel.updateOccasions(selected)
+                    AttributePicker.COLORS    -> viewModel.updateColors(selected)
+                    AttributePicker.MATERIALS -> viewModel.updateMaterials(selected)
+                    AttributePicker.PATTERNS  -> viewModel.updatePatterns(selected)
+                }
+                activePicker = null
             }
         )
     }
 }
 
-@OptIn(ExperimentalLayoutApi::class)
-@Composable
-private fun ClothingAttributes(
-    item: ClothingItemDetail,
-    onEditSeasons: () -> Unit,
-    onEditOccasions: () -> Unit,
-    onEditColors: () -> Unit,
-    onEditMaterials: () -> Unit,
-    onEditPatterns: () -> Unit
-) {
-    Column(verticalArrangement = Arrangement.spacedBy(16.dp)) {
-        // Seasons
-        AttributeSection(
-            title = stringResource(R.string.wardrobe_seasons),
-            onEditClick = onEditSeasons
-        ) {
-            FlowRow(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                if (item.seasons.isEmpty()) {
-                    Text(
-                        text = stringResource(R.string.wardrobe_none_selected),
-                        style = MaterialTheme.typography.bodyMedium,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant
-                    )
-                } else {
-                    item.seasons.forEach { season ->
-                        AttributeChip(
-                            label = season.name,
-                            iconResId = IconMapper.getIconResource(season.icon),
-                            onClick = onEditSeasons
-                        )
-                    }
-                }
-            }
-        }
 
-        // Colors
-        AttributeSection(
-            title = stringResource(R.string.wardrobe_colors),
-            onEditClick = onEditColors
-        ) {
-            FlowRow(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                if (item.colors.isEmpty()) {
-                    Text(
-                        text = stringResource(R.string.wardrobe_none_selected),
-                        style = MaterialTheme.typography.bodyMedium,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant
-                    )
-                } else {
-                    item.colors.forEach { color ->
-                        AttributeChip(
-                            label = color.name,
-                            color = color.hex?.let {
-                                try {
-                                    Color(android.graphics.Color.parseColor(it))
-                                } catch (e: Exception) {
-                                    null
-                                }
-                            },
-                            onClick = onEditColors
-                        )
-                    }
-                }
-            }
-        }
-
-        // Materials
-        AttributeSection(
-            title = stringResource(R.string.wardrobe_materials),
-            onEditClick = onEditMaterials
-        ) {
-            FlowRow(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                if (item.materials.isEmpty()) {
-                    Text(
-                        text = stringResource(R.string.wardrobe_none_selected),
-                        style = MaterialTheme.typography.bodyMedium,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant
-                    )
-                } else {
-                    item.materials.forEach { material ->
-                        AttributeChip(
-                            label = material.name,
-                            onClick = onEditMaterials
-                        )
-                    }
-                }
-            }
-        }
-
-        // Patterns
-        AttributeSection(
-            title = stringResource(R.string.wardrobe_patterns),
-            onEditClick = onEditPatterns
-        ) {
-            FlowRow(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                if (item.patterns.isEmpty()) {
-                    Text(
-                        text = stringResource(R.string.wardrobe_none_selected),
-                        style = MaterialTheme.typography.bodyMedium,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant
-                    )
-                } else {
-                    item.patterns.forEach { pattern ->
-                        AttributeChip(
-                            label = pattern.name,
-                            onClick = onEditPatterns
-                        )
-                    }
-                }
-            }
-        }
-
-        AttributeSection(
-            title = stringResource(R.string.wardrobe_occasions),
-            onEditClick = onEditOccasions
-        ) {
-            FlowRow(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                if (item.occasions.isEmpty()) {
-                    Text(
-                        text = stringResource(R.string.wardrobe_none_selected),
-                        style = MaterialTheme.typography.bodyMedium,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant
-                    )
-                } else {
-                    item.occasions.forEach { occasion ->
-                        AttributeChip(
-                            label = occasion.name,
-                            iconResId = IconMapper.getIconResource(occasion.icon),
-                            onClick = onEditOccasions
-                        )
-                    }
-                }
-            }
-        }
-    }
-}
-
-@Composable
-private fun AttributeSection(
-    title: String,
-    onEditClick: () -> Unit,
-    content: @Composable () -> Unit
-) {
-    Column {
-        Row(
-            modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.SpaceBetween,
-            verticalAlignment = Alignment.CenterVertically
-        ) {
-            Text(
-                text = title,
-                style = MaterialTheme.typography.titleMedium,
-                fontWeight = FontWeight.Bold
-            )
-            IconButton(onClick = onEditClick) {
-                Icon(
-                    imageVector = Icons.Default.Add,
-                    contentDescription = "Edit $title",
-                    tint = MaterialTheme.colorScheme.primary
-                )
-            }
-        }
-        Spacer(modifier = Modifier.height(4.dp))
-        content()
-    }
-}
-
-@OptIn(ExperimentalMaterial3Api::class)
-@Composable
-private fun AttributeChip(
-    label: String,
-    iconResId: Int? = null,
-    color: Color? = null,
-    onClick: () -> Unit
-) {
-    Surface(
-        onClick = onClick,
-        shape = RoundedCornerShape(8.dp),
-        color = MaterialTheme.colorScheme.surfaceVariant
-    ) {
-        Row(
-            modifier = Modifier.padding(horizontal = 12.dp, vertical = 6.dp),
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.spacedBy(8.dp)
-        ) {
-            if (color != null) {
-                Box(
-                    modifier = Modifier
-                        .size(16.dp)
-                        .clip(CircleShape)
-                        .background(color)
-                )
-            } else if (iconResId != null) {
-                Icon(
-                    painter = painterResource(id = iconResId),
-                    contentDescription = null,
-                    modifier = Modifier.size(16.dp),
-                    tint = MaterialTheme.colorScheme.primary
-                )
-            }
-            Text(
-                text = label,
-                style = MaterialTheme.typography.labelLarge
-            )
-        }
-    }
-}
-
-// region Previews
-
-private val previewItem = ClothingItemDetail(
-    item = ClothingItemEntity(
-        id = 1L,
-        name = "Vintage Denim Jacket",
-        purchasePrice = 85.00,
-        status = ClothingStatus.Active,
-        washStatus = WashStatus.Clean,
-        isFavorite = 1,
-        notes = "Great for layering. Found at a thrift store in Brooklyn."
-    ),
-    wearCount = 12,
-    category = CategoryEntity(id = 1L, name = "Tops", sortOrder = 1),
-    subcategory = SubcategoryEntity(id = 2L, categoryId = 1L, name = "Jackets", sortOrder = 2),
-    brand = BrandEntity(id = 1L, name = "Levi's"),
-    sizeValue = null,
-    colors = listOf(
-        ColorEntity(id = 1L, name = "Blue", hex = "#3A6BAE"),
-        ColorEntity(id = 2L, name = "White", hex = "#FFFFFF"),
-    ),
-    materials = listOf(MaterialEntity(id = 1L, name = "Denim"), MaterialEntity(id = 2L, name = "Cotton")),
-    seasons = listOf(SeasonEntity(id = 1L, name = "Spring", icon = "flower"), SeasonEntity(id = 3L, name = "Fall", icon = "leaf")),
-    occasions = listOf(OccasionEntity(id = 1L, name = "Casual", icon = "couch"), OccasionEntity(id = 2L, name = "Weekend", icon = "coffee")),
-    patterns = emptyList()
-)
-
-private val previewItemMinimal = ClothingItemDetail(
-    item = ClothingItemEntity(
-        id = 2L,
-        name = "Plain White Tee",
-        status = ClothingStatus.Active,
-        washStatus = WashStatus.Dirty,
-        isFavorite = 0
-    ),
-    wearCount = 0,
-    category = CategoryEntity(id = 1L, name = "Tops", sortOrder = 1),
-    subcategory = null,
-    brand = null,
-    sizeValue = null,
-    colors = emptyList(),
-    materials = emptyList(),
-    seasons = emptyList(),
-    occasions = emptyList(),
-    patterns = emptyList()
-)
-
-@Preview(showBackground = true, name = "Attributes - Filled - Light")
-@Preview(showBackground = true, uiMode = Configuration.UI_MODE_NIGHT_YES, name = "Attributes - Filled - Dark")
-@Composable
-private fun ClothingAttributesFilledPreview() {
-    ClosetTheme {
-        Surface {
-            Column(modifier = Modifier.padding(16.dp)) {
-                ClothingAttributes(
-                    item = previewItem,
-                    onEditSeasons = {},
-                    onEditOccasions = {},
-                    onEditColors = {},
-                    onEditMaterials = {},
-                    onEditPatterns = {}
-                )
-            }
-        }
-    }
-}
-
-@Preview(showBackground = true, name = "Attributes - Empty State")
-@Composable
-private fun ClothingAttributesEmptyPreview() {
-    ClosetTheme {
-        Surface {
-            Column(modifier = Modifier.padding(16.dp)) {
-                ClothingAttributes(
-                    item = previewItemMinimal,
-                    onEditSeasons = {},
-                    onEditOccasions = {},
-                    onEditColors = {},
-                    onEditMaterials = {},
-                    onEditPatterns = {}
-                )
-            }
-        }
-    }
-}
-
-@Preview(showBackground = true, name = "AttributeChip - Text Only")
-@Preview(showBackground = true, name = "AttributeChip - With Color")
-@Composable
-private fun AttributeChipPreview() {
-    ClosetTheme {
-        Surface {
-            Row(
-                modifier = Modifier.padding(12.dp),
-                horizontalArrangement = Arrangement.spacedBy(8.dp)
-            ) {
-                AttributeChip(label = "Casual", onClick = {})
-                AttributeChip(label = "Blue", color = Color(0xFF3A6BAE), onClick = {})
-                AttributeChip(label = "Fall", onClick = {})
-            }
-        }
-    }
-}
-
-@Preview(showBackground = true, name = "AttributeSection - With Items")
-@Composable
-private fun AttributeSectionPreview() {
-    ClosetTheme {
-        Surface {
-            Column(modifier = Modifier.padding(16.dp)) {
-                AttributeSection(title = "Colors", onEditClick = {}) {
-                    Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                        AttributeChip(label = "Blue", color = Color(0xFF3A6BAE), onClick = {})
-                        AttributeChip(label = "White", color = Color(0xFFFFFFFF), onClick = {})
-                    }
-                }
-            }
-        }
-    }
-}
-
-// endregion

--- a/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/ClothingDetailScreen.kt
+++ b/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/ClothingDetailScreen.kt
@@ -38,11 +38,6 @@ fun ClothingDetailScreen(
     viewModel: ClothingDetailViewModel = hiltViewModel()
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
-    val allSeasons by viewModel.seasons.collectAsStateWithLifecycle()
-    val allOccasions by viewModel.occasions.collectAsStateWithLifecycle()
-    val allColors by viewModel.colors.collectAsStateWithLifecycle()
-    val allMaterials by viewModel.materials.collectAsStateWithLifecycle()
-    val allPatterns by viewModel.patterns.collectAsStateWithLifecycle()
 
     val scrollState = rememberScrollState()
     val snackbarHostState = remember { SnackbarHostState() }
@@ -309,7 +304,8 @@ fun ClothingDetailScreen(
 
     // Attribute picker sheet — driven by activePicker state
     activePicker?.let { picker ->
-        val successItem = (uiState as? ClothingDetailUiState.Success)?.item
+        val successState = uiState as? ClothingDetailUiState.Success
+        val successItem = successState?.item
         val title = stringResource(when (picker) {
             AttributePicker.SEASONS   -> R.string.wardrobe_seasons
             AttributePicker.OCCASIONS -> R.string.wardrobe_occasions
@@ -318,11 +314,11 @@ fun ClothingDetailScreen(
             AttributePicker.PATTERNS  -> R.string.wardrobe_patterns
         })
         val items = when (picker) {
-            AttributePicker.SEASONS   -> allSeasons.map { MultiSelectItem(it.id, it.name, it, iconResId = IconMapper.getIconResource(it.icon)) }
-            AttributePicker.OCCASIONS -> allOccasions.map { MultiSelectItem(it.id, it.name, it, iconResId = IconMapper.getIconResource(it.icon)) }
-            AttributePicker.COLORS    -> allColors.map { MultiSelectItem(it.id, it.name, it, colorHex = it.hex) }
-            AttributePicker.MATERIALS -> allMaterials.map { MultiSelectItem(it.id, it.name, it) }
-            AttributePicker.PATTERNS  -> allPatterns.map { MultiSelectItem(it.id, it.name, it) }
+            AttributePicker.SEASONS   -> successState?.seasons.orEmpty().map { MultiSelectItem(it.id, it.name, it, iconResId = IconMapper.getIconResource(it.icon)) }
+            AttributePicker.OCCASIONS -> successState?.occasions.orEmpty().map { MultiSelectItem(it.id, it.name, it, iconResId = IconMapper.getIconResource(it.icon)) }
+            AttributePicker.COLORS    -> successState?.colors.orEmpty().map { MultiSelectItem(it.id, it.name, it, colorHex = it.hex) }
+            AttributePicker.MATERIALS -> successState?.materials.orEmpty().map { MultiSelectItem(it.id, it.name, it) }
+            AttributePicker.PATTERNS  -> successState?.patterns.orEmpty().map { MultiSelectItem(it.id, it.name, it) }
         }
         val selectedIds = when (picker) {
             AttributePicker.SEASONS   -> successItem?.seasons?.map { it.id }?.toSet()

--- a/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/ClothingDetailScreen.kt
+++ b/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/ClothingDetailScreen.kt
@@ -170,7 +170,7 @@ fun ClothingDetailScreen(
                                     style = MaterialTheme.typography.headlineMedium,
                                     fontWeight = FontWeight.Bold
                                 )
-                                detail.item.brand?.let {
+                                detail.brand?.name?.let {
                                     Text(
                                         text = it,
                                         style = MaterialTheme.typography.titleMedium,

--- a/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/ClothingDetailScreen.kt
+++ b/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/ClothingDetailScreen.kt
@@ -629,8 +629,8 @@ private val previewItem = ClothingItemDetail(
         ColorEntity(id = 2L, name = "White", hex = "#FFFFFF"),
     ),
     materials = listOf(MaterialEntity(id = 1L, name = "Denim"), MaterialEntity(id = 2L, name = "Cotton")),
-    seasons = listOf(SeasonEntity(id = 1L, name = "Spring"), SeasonEntity(id = 3L, name = "Fall")),
-    occasions = listOf(OccasionEntity(id = 1L, name = "Casual"), OccasionEntity(id = 2L, name = "Weekend")),
+    seasons = listOf(SeasonEntity(id = 1L, name = "Spring", icon = "flower"), SeasonEntity(id = 3L, name = "Fall", icon = "leaf")),
+    occasions = listOf(OccasionEntity(id = 1L, name = "Casual", icon = "couch"), OccasionEntity(id = 2L, name = "Weekend", icon = "coffee")),
     patterns = emptyList()
 )
 

--- a/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/ClothingDetailScreen.kt
+++ b/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/ClothingDetailScreen.kt
@@ -12,7 +12,6 @@ import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
@@ -26,6 +25,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import coil.compose.AsyncImage
 import com.closet.core.data.model.*
 import com.closet.core.ui.R as CoreR
+import com.closet.core.ui.components.UserMessageSnackbarEffect
 import com.closet.core.ui.util.IconMapper
 
 private enum class AttributePicker { SEASONS, OCCASIONS, COLORS, MATERIALS, PATTERNS }
@@ -41,17 +41,7 @@ fun ClothingDetailScreen(
 
     val scrollState = rememberScrollState()
     val snackbarHostState = remember { SnackbarHostState() }
-    val context = LocalContext.current
-    LaunchedEffect(Unit) {
-        viewModel.actionError.collect { message ->
-            val text = if (message.args.isEmpty()) {
-                context.getString(message.resId)
-            } else {
-                context.getString(message.resId, *message.args)
-            }
-            snackbarHostState.showSnackbar(text)
-        }
-    }
+    UserMessageSnackbarEffect(viewModel.actionError, snackbarHostState)
 
     var activePicker by remember { mutableStateOf<AttributePicker?>(null) }
 
@@ -117,7 +107,7 @@ fun ClothingDetailScreen(
                     ) {
                         detail.item.imagePath?.let { path ->
                             AsyncImage(
-                                model = viewModel.getAbsoluteFile(path),
+                                model = viewModel.resolveImagePath(path),
                                 contentDescription = detail.item.name,
                                 modifier = Modifier.fillMaxSize(),
                                 contentScale = ContentScale.Fit

--- a/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/ClothingDetailViewModel.kt
+++ b/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/ClothingDetailViewModel.kt
@@ -195,9 +195,7 @@ class ClothingDetailViewModel @Inject constructor(
         }
     }
 
-    fun getAbsoluteFile(relativePath: String): File {
-        return storageRepository.getFile(relativePath)
-    }
+    fun resolveImagePath(path: String?): File? = path?.let { storageRepository.getFile(it) }
 
     private fun handleActionError(throwable: Throwable) {
         val error = throwable as? AppError ?: AppError.Unexpected(throwable)

--- a/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/ClothingDetailViewModel.kt
+++ b/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/ClothingDetailViewModel.kt
@@ -4,13 +4,11 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import androidx.navigation.toRoute
-import androidx.palette.graphics.Palette
 import com.closet.core.data.model.*
 import com.closet.core.data.repository.ClothingRepository
 import com.closet.core.data.repository.LookupRepository
 import com.closet.core.data.repository.StorageRepository
 import com.closet.core.data.util.AppError
-import com.closet.core.data.util.PaletteUtil
 import com.closet.core.data.util.fold
 import com.closet.core.ui.util.UserMessage
 import com.closet.core.ui.util.asUserMessage
@@ -18,7 +16,6 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.launch
-import timber.log.Timber
 import java.io.File
 import javax.inject.Inject
 
@@ -73,32 +70,9 @@ class ClothingDetailViewModel @Inject constructor(
     )
     val actionError: SharedFlow<UserMessage> = _actionError.asSharedFlow()
 
-    private val _palette = MutableStateFlow<Palette?>(null)
-    val palette: StateFlow<Palette?> = _palette.asStateFlow()
-
-    init {
-        viewModelScope.launch {
-            itemDetailFlow.collect { detail ->
-                extractPalette(detail?.item?.imagePath)
-            }
-        }
-    }
-
-    private fun extractPalette(imagePath: String?) {
-        if (imagePath == null) return
-        viewModelScope.launch {
-            try {
-                val file = storageRepository.getFile(imagePath)
-                _palette.value = PaletteUtil.extractPalette(file)
-            } catch (e: Throwable) {
-                Timber.e(e, "Failed to extract palette for image path: $imagePath")
-            }
-        }
-    }
-
     fun toggleFavorite() {
         viewModelScope.launch {
-            val currentState = _uiState.value
+            val currentState = uiState.value
             if (currentState is ClothingDetailUiState.Success) {
                 val newFavorite = currentState.item.item.isFavorite == 0
                 clothingRepository.updateFavoriteStatus(itemId, newFavorite).fold(
@@ -112,7 +86,7 @@ class ClothingDetailViewModel @Inject constructor(
 
     fun toggleWashStatus() {
         viewModelScope.launch {
-            val currentState = _uiState.value
+            val currentState = uiState.value
             if (currentState is ClothingDetailUiState.Success) {
                 val newStatus = if (currentState.item.item.washStatus == WashStatus.Clean) {
                     WashStatus.Dirty
@@ -130,7 +104,7 @@ class ClothingDetailViewModel @Inject constructor(
 
     fun deleteItem(onDeleted: () -> Unit) {
         viewModelScope.launch {
-            val currentState = _uiState.value
+            val currentState = uiState.value
             if (currentState is ClothingDetailUiState.Success) {
                 currentState.item.item.imagePath?.let { storageRepository.deleteImage(it) }
             }

--- a/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/ClothingDetailViewModel.kt
+++ b/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/ClothingDetailViewModel.kt
@@ -37,18 +37,34 @@ class ClothingDetailViewModel @Inject constructor(
     private val destination = savedStateHandle.toRoute<ClothingDetailDestination>()
     val itemId = destination.itemId
 
-    // Detailed item flow
     private val itemDetailFlow = clothingRepository.getItemDetail(itemId)
 
-    // Lookup data flows
-    val colors = lookupRepository.getColors().stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
-    val materials = lookupRepository.getMaterials().stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
-    val seasons = lookupRepository.getSeasons().stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
-    val occasions = lookupRepository.getOccasions().stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
-    val patterns = lookupRepository.getPatterns().stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
+    private val lookupFlow = combine(
+        lookupRepository.getColors(),
+        lookupRepository.getMaterials(),
+        lookupRepository.getSeasons(),
+        lookupRepository.getOccasions(),
+        lookupRepository.getPatterns()
+    ) { colors, materials, seasons, occasions, patterns ->
+        ClothingDetailLookup(colors, materials, seasons, occasions, patterns)
+    }
 
-    private val _uiState = MutableStateFlow<ClothingDetailUiState>(ClothingDetailUiState.Loading)
-    val uiState: StateFlow<ClothingDetailUiState> = _uiState.asStateFlow()
+    val uiState: StateFlow<ClothingDetailUiState> = combine(
+        itemDetailFlow, lookupFlow
+    ) { detail, lookup ->
+        if (detail != null) {
+            ClothingDetailUiState.Success(
+                item = detail,
+                colors = lookup.colors,
+                materials = lookup.materials,
+                seasons = lookup.seasons,
+                occasions = lookup.occasions,
+                patterns = lookup.patterns
+            )
+        } else {
+            ClothingDetailUiState.Error(AppError.DatabaseError.NotFound().asUserMessage())
+        }
+    }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), ClothingDetailUiState.Loading)
 
     private val _actionError = MutableSharedFlow<UserMessage>(
         replay = 0,
@@ -63,12 +79,7 @@ class ClothingDetailViewModel @Inject constructor(
     init {
         viewModelScope.launch {
             itemDetailFlow.collect { detail ->
-                if (detail != null) {
-                    _uiState.value = ClothingDetailUiState.Success(detail)
-                    extractPalette(detail.item.imagePath)
-                } else {
-                    _uiState.value = ClothingDetailUiState.Error(AppError.DatabaseError.NotFound().asUserMessage())
-                }
+                extractPalette(detail?.item?.imagePath)
             }
         }
     }
@@ -196,11 +207,26 @@ class ClothingDetailViewModel @Inject constructor(
     }
 }
 
+private data class ClothingDetailLookup(
+    val colors: List<ColorEntity>,
+    val materials: List<MaterialEntity>,
+    val seasons: List<SeasonEntity>,
+    val occasions: List<OccasionEntity>,
+    val patterns: List<PatternEntity>
+)
+
 /**
  * UI state for the Clothing Detail screen.
  */
 sealed interface ClothingDetailUiState {
     data object Loading : ClothingDetailUiState
-    data class Success(val item: ClothingItemDetail) : ClothingDetailUiState
+    data class Success(
+        val item: ClothingItemDetail,
+        val colors: List<ColorEntity> = emptyList(),
+        val materials: List<MaterialEntity> = emptyList(),
+        val seasons: List<SeasonEntity> = emptyList(),
+        val occasions: List<OccasionEntity> = emptyList(),
+        val patterns: List<PatternEntity> = emptyList()
+    ) : ClothingDetailUiState
     data class Error(val userMessage: UserMessage) : ClothingDetailUiState
 }

--- a/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/ClothingDetailViewModel.kt
+++ b/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/ClothingDetailViewModel.kt
@@ -32,6 +32,7 @@ class ClothingDetailViewModel @Inject constructor(
 ) : ViewModel() {
 
     private val destination = savedStateHandle.toRoute<ClothingDetailDestination>()
+    /** The ID of the item being displayed, extracted from the navigation destination. */
     val itemId = destination.itemId
 
     private val itemDetailFlow = clothingRepository.getItemDetail(itemId)
@@ -46,6 +47,7 @@ class ClothingDetailViewModel @Inject constructor(
         ClothingDetailLookup(colors, materials, seasons, occasions, patterns)
     }
 
+    /** UI state combining item detail and all lookup lists for inline editing chips. */
     val uiState: StateFlow<ClothingDetailUiState> = combine(
         itemDetailFlow, lookupFlow
     ) { detail, lookup ->
@@ -68,8 +70,10 @@ class ClothingDetailViewModel @Inject constructor(
         extraBufferCapacity = 1,
         onBufferOverflow = BufferOverflow.DROP_OLDEST
     )
+    /** One-shot error events emitted when a quick action (toggle, delete, update) fails. */
     val actionError: SharedFlow<UserMessage> = _actionError.asSharedFlow()
 
+    /** Toggles the favorite status of the current item. */
     fun toggleFavorite() {
         viewModelScope.launch {
             val currentState = uiState.value
@@ -84,6 +88,7 @@ class ClothingDetailViewModel @Inject constructor(
         }
     }
 
+    /** Toggles the wash status between [WashStatus.Clean] and [WashStatus.Dirty]. */
     fun toggleWashStatus() {
         viewModelScope.launch {
             val currentState = uiState.value
@@ -102,6 +107,10 @@ class ClothingDetailViewModel @Inject constructor(
         }
     }
 
+    /**
+     * Deletes the item and its associated image file, then calls [onDeleted] on success.
+     * Emits [actionError] if the delete fails.
+     */
     fun deleteItem(onDeleted: () -> Unit) {
         viewModelScope.launch {
             val currentState = uiState.value
@@ -119,6 +128,7 @@ class ClothingDetailViewModel @Inject constructor(
 
     // --- Junction Table Updates ---
 
+    /** Replaces the item's color associations with [colorIds] (delete-then-insert). */
     fun updateColors(colorIds: List<Long>) {
         viewModelScope.launch {
             clothingRepository.updateItemColors(itemId, colorIds).fold(
@@ -129,6 +139,7 @@ class ClothingDetailViewModel @Inject constructor(
         }
     }
 
+    /** Replaces the item's material associations with [materialIds] (delete-then-insert). */
     fun updateMaterials(materialIds: List<Long>) {
         viewModelScope.launch {
             clothingRepository.updateItemMaterials(itemId, materialIds).fold(
@@ -139,6 +150,7 @@ class ClothingDetailViewModel @Inject constructor(
         }
     }
 
+    /** Replaces the item's season associations with [seasonIds] (delete-then-insert). */
     fun updateSeasons(seasonIds: List<Long>) {
         viewModelScope.launch {
             clothingRepository.updateItemSeasons(itemId, seasonIds).fold(
@@ -149,6 +161,7 @@ class ClothingDetailViewModel @Inject constructor(
         }
     }
 
+    /** Replaces the item's occasion associations with [occasionIds] (delete-then-insert). */
     fun updateOccasions(occasionIds: List<Long>) {
         viewModelScope.launch {
             clothingRepository.updateItemOccasions(itemId, occasionIds).fold(
@@ -159,6 +172,7 @@ class ClothingDetailViewModel @Inject constructor(
         }
     }
 
+    /** Replaces the item's pattern associations with [patternIds] (delete-then-insert). */
     fun updatePatterns(patternIds: List<Long>) {
         viewModelScope.launch {
             clothingRepository.updateItemPatterns(itemId, patternIds).fold(
@@ -169,6 +183,7 @@ class ClothingDetailViewModel @Inject constructor(
         }
     }
 
+    /** Resolves a stored relative image [path] to a [File], or null if [path] is null. */
     fun resolveImagePath(path: String?): File? = path?.let { storageRepository.getFile(it) }
 
     private fun handleActionError(throwable: Throwable) {

--- a/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/ClothingFormScreen.kt
+++ b/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/ClothingFormScreen.kt
@@ -1,12 +1,10 @@
 package com.closet.features.wardrobe
 
-import android.content.res.Configuration
 import androidx.activity.compose.BackHandler
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.PickVisualMediaRequest
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.background
-import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -20,41 +18,28 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.LazyRow
-import androidx.compose.foundation.lazy.items
-import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
-import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.AddAPhoto
-import androidx.compose.material.icons.filled.Settings
-import androidx.compose.material.icons.filled.CalendarMonth
 import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.Palette
+import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.CircularProgressIndicator
-import androidx.compose.material3.DatePicker
-import androidx.compose.material3.DatePickerDialog
-import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.ExposedDropdownMenuBox
-import androidx.compose.material3.ExposedDropdownMenuDefaults
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.MenuAnchorType
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
-import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
-import androidx.compose.material3.rememberDatePickerState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -63,30 +48,20 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.semantics.Role
-import androidx.compose.ui.semantics.contentDescription
-import androidx.compose.ui.semantics.role
-import androidx.compose.ui.semantics.selected
-import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import com.closet.core.ui.theme.ClosetTheme
 import coil.compose.AsyncImage
 import com.closet.core.data.model.BrandEntity
 import com.closet.core.data.model.CategoryEntity
 import com.closet.core.data.model.ColorEntity
 import com.closet.core.data.model.SubcategoryEntity
-import java.time.Instant
 import java.time.LocalDate
-import java.time.ZoneId
 
 /**
  * Unified screen for adding or editing a clothing item.
@@ -198,7 +173,7 @@ fun ClothingFormScreen(
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-private fun ClothingFormTopBar(
+internal fun ClothingFormTopBar(
     isEditMode: Boolean,
     canSave: Boolean,
     onBackClick: () -> Unit,
@@ -234,7 +209,7 @@ private fun ClothingFormTopBar(
 }
 
 @Composable
-private fun ClothingFormContent(
+internal fun ClothingFormContent(
     uiState: ClothingFormUiState,
     onNameChange: (String) -> Unit,
     onBrandQueryChange: (String) -> Unit,
@@ -332,18 +307,22 @@ private fun ClothingFormContent(
 
         // Category & Subcategory
         item {
-            CategoryDropdown(
-                selectedCategory = uiState.category,
-                categories = uiState.categories,
-                onCategorySelect = onCategorySelect
+            DropdownSelector(
+                selectedItem = uiState.category,
+                items = uiState.categories,
+                onItemSelect = onCategorySelect,
+                label = stringResource(R.string.wardrobe_field_category),
+                itemLabel = { it.name }
             )
         }
 
         item {
-            SubcategoryDropdown(
-                selectedSubcategory = uiState.subcategory,
-                subcategories = uiState.subcategories,
-                onSubcategorySelect = onSubcategorySelect,
+            DropdownSelector(
+                selectedItem = uiState.subcategory,
+                items = uiState.subcategories,
+                onItemSelect = onSubcategorySelect,
+                label = stringResource(R.string.wardrobe_field_subcategory),
+                itemLabel = { it.name },
                 enabled = uiState.category != null
             )
         }
@@ -421,496 +400,3 @@ private fun ClothingFormContent(
     }
 }
 
-@OptIn(ExperimentalMaterial3Api::class)
-@Composable
-private fun CategoryDropdown(
-    selectedCategory: CategoryEntity?,
-    categories: List<CategoryEntity>,
-    onCategorySelect: (CategoryEntity?) -> Unit
-) {
-    var expanded by remember { mutableStateOf(false) }
-    
-    Box(modifier = Modifier.fillMaxWidth()) {
-        OutlinedTextField(
-            value = selectedCategory?.name ?: "",
-            onValueChange = {},
-            readOnly = true,
-            label = { Text(stringResource(R.string.wardrobe_field_category)) },
-            modifier = Modifier.fillMaxWidth(),
-            trailingIcon = {
-                androidx.compose.material3.ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded)
-            },
-            colors = androidx.compose.material3.ExposedDropdownMenuDefaults.outlinedTextFieldColors()
-        )
-        // Simple overlay to handle click since OutlinedTextField readOnly doesn't trigger onClick easily
-        Box(
-            modifier = Modifier
-                .matchParentSize()
-                .clickable { expanded = true }
-        )
-
-        androidx.compose.material3.DropdownMenu(
-            expanded = expanded,
-            onDismissRequest = { expanded = false },
-            modifier = Modifier.fillMaxWidth(0.9f)
-        ) {
-            androidx.compose.material3.DropdownMenuItem(
-                text = { Text(stringResource(R.string.wardrobe_field_none)) },
-                onClick = {
-                    onCategorySelect(null)
-                    expanded = false
-                }
-            )
-            categories.forEach { category ->
-                androidx.compose.material3.DropdownMenuItem(
-                    text = { Text(category.name) },
-                    onClick = {
-                        onCategorySelect(category)
-                        expanded = false
-                    }
-                )
-            }
-        }
-    }
-}
-
-@OptIn(ExperimentalMaterial3Api::class)
-@Composable
-private fun SubcategoryDropdown(
-    selectedSubcategory: SubcategoryEntity?,
-    subcategories: List<SubcategoryEntity>,
-    onSubcategorySelect: (SubcategoryEntity?) -> Unit,
-    enabled: Boolean
-) {
-    var expanded by remember { mutableStateOf(false) }
-    
-    Box(modifier = Modifier.fillMaxWidth()) {
-        OutlinedTextField(
-            value = selectedSubcategory?.name ?: "",
-            onValueChange = {},
-            readOnly = true,
-            enabled = enabled,
-            label = { Text(stringResource(R.string.wardrobe_field_subcategory)) },
-            modifier = Modifier.fillMaxWidth(),
-            trailingIcon = {
-                androidx.compose.material3.ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded)
-            },
-            colors = androidx.compose.material3.ExposedDropdownMenuDefaults.outlinedTextFieldColors()
-        )
-        if (enabled) {
-            Box(
-                modifier = Modifier
-                    .matchParentSize()
-                    .clickable { expanded = true }
-            )
-        }
-
-        androidx.compose.material3.DropdownMenu(
-            expanded = expanded,
-            onDismissRequest = { expanded = false },
-            modifier = Modifier.fillMaxWidth(0.9f)
-        ) {
-            androidx.compose.material3.DropdownMenuItem(
-                text = { Text(stringResource(R.string.wardrobe_field_none)) },
-                onClick = {
-                    onSubcategorySelect(null)
-                    expanded = false
-                }
-            )
-            subcategories.forEach { sub ->
-                androidx.compose.material3.DropdownMenuItem(
-                    text = { Text(sub.name) },
-                    onClick = {
-                        onSubcategorySelect(sub)
-                        expanded = false
-                    }
-                )
-            }
-        }
-    }
-}
-
-@Composable
-private fun ColorSelectionGrid(
-    selectedColors: List<ColorEntity>,
-    allColors: List<ColorEntity>,
-    onColorToggle: (ColorEntity) -> Unit
-) {
-    LazyRow(
-        horizontalArrangement = Arrangement.spacedBy(12.dp),
-        contentPadding = androidx.compose.foundation.layout.PaddingValues(vertical = 4.dp)
-    ) {
-        items(allColors) { color ->
-            val isSelected = selectedColors.any { it.id == color.id }
-            val hexColor = try { Color(android.graphics.Color.parseColor(color.hex)) } catch(_: Exception) { Color.Gray }
-            val label = color.name.ifBlank { color.hex ?: "" }
-
-            Box(
-                modifier = Modifier
-                    .size(48.dp)
-                    .semantics {
-                        contentDescription = label
-                        selected = isSelected
-                        role = Role.Checkbox
-                    }
-                    .clickable { onColorToggle(color) },
-                contentAlignment = Alignment.Center
-            ) {
-                Box(
-                    modifier = Modifier
-                        .size(44.dp)
-                        .clip(CircleShape)
-                        .background(hexColor)
-                        .border(
-                            width = if (isSelected) 3.dp else 1.dp,
-                            color = if (isSelected) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.outlineVariant,
-                            shape = CircleShape
-                        ),
-                    contentAlignment = Alignment.Center
-                ) {
-                    if (isSelected) {
-                        Icon(
-                            imageVector = Icons.Default.Check,
-                            contentDescription = null,
-                            tint = if (isColorDark(hexColor)) Color.White else Color.Black,
-                            modifier = Modifier.size(24.dp)
-                        )
-                    }
-                }
-            }
-        }
-    }
-}
-
-@OptIn(ExperimentalMaterial3Api::class)
-@Composable
-private fun DatePickerField(
-    selectedDate: LocalDate?,
-    onDateChange: (LocalDate?) -> Unit
-) {
-    var showDatePicker by remember { mutableStateOf(false) }
-
-    OutlinedTextField(
-        value = selectedDate?.toString() ?: "",
-        onValueChange = {},
-        readOnly = true,
-        label = { Text(stringResource(R.string.wardrobe_field_purchase_date)) },
-        modifier = Modifier.fillMaxWidth(),
-        trailingIcon = {
-            IconButton(onClick = { showDatePicker = true }) {
-                Icon(imageVector = Icons.Default.CalendarMonth, contentDescription = null)
-            }
-        }
-    )
-
-    if (showDatePicker) {
-        val datePickerState = rememberDatePickerState(
-            initialSelectedDateMillis = selectedDate?.atStartOfDay(ZoneId.systemDefault())?.toInstant()?.toEpochMilli()
-        )
-        DatePickerDialog(
-            onDismissRequest = { showDatePicker = false },
-            confirmButton = {
-                TextButton(onClick = {
-                    datePickerState.selectedDateMillis?.let {
-                        val date = Instant.ofEpochMilli(it).atZone(ZoneId.systemDefault()).toLocalDate()
-                        onDateChange(date)
-                    }
-                    showDatePicker = false
-                }) {
-                    Text(stringResource(R.string.wardrobe_date_confirm))
-                }
-            },
-            dismissButton = {
-                Row {
-                    TextButton(onClick = {
-                        onDateChange(null)
-                        showDatePicker = false
-                    }) {
-                        Text(stringResource(R.string.wardrobe_date_clear))
-                    }
-                    TextButton(onClick = { showDatePicker = false }) {
-                        Text(stringResource(R.string.wardrobe_date_cancel))
-                    }
-                }
-            }
-        ) {
-            DatePicker(state = datePickerState)
-        }
-    }
-}
-
-@OptIn(ExperimentalMaterial3Api::class)
-@Composable
-private fun BrandAutocompleteField(
-    query: String,
-    allBrands: List<BrandEntity>,
-    onQueryChange: (String) -> Unit,
-    onBrandSelect: (BrandEntity) -> Unit,
-    onAddNewBrand: (String) -> Unit
-) {
-    val filteredBrands = allBrands.filter { it.name.contains(query, ignoreCase = true) }
-    val showAddOption = query.isNotBlank() && filteredBrands.none { it.name.equals(query, ignoreCase = true) }
-
-    var expanded by remember { mutableStateOf(false) }
-
-    ExposedDropdownMenuBox(
-        expanded = expanded,
-        onExpandedChange = { expanded = it }
-    ) {
-        OutlinedTextField(
-            value = query,
-            onValueChange = { onQueryChange(it); expanded = true },
-            label = { Text(stringResource(R.string.wardrobe_field_brand)) },
-            trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded) },
-            singleLine = true,
-            modifier = Modifier
-                .fillMaxWidth()
-                .menuAnchor(MenuAnchorType.PrimaryEditable)
-        )
-
-        ExposedDropdownMenu(
-            expanded = expanded && (filteredBrands.isNotEmpty() || showAddOption),
-            onDismissRequest = { expanded = false }
-        ) {
-            filteredBrands.forEach { brand ->
-                DropdownMenuItem(
-                    text = { Text(brand.name) },
-                    onClick = { onBrandSelect(brand); expanded = false }
-                )
-            }
-            if (showAddOption) {
-                HorizontalDivider()
-                DropdownMenuItem(
-                    text = { Text(stringResource(R.string.wardrobe_brand_add, query)) },
-                    leadingIcon = { Icon(Icons.Default.Add, contentDescription = null) },
-                    onClick = { onAddNewBrand(query); expanded = false }
-                )
-            }
-        }
-    }
-}
-
-private fun isColorDark(color: Color): Boolean {
-    val luminance = 0.2126 * color.red + 0.7152 * color.green + 0.0722 * color.blue
-    return luminance < 0.5
-}
-
-// region Previews
-
-private val previewCategories = listOf(
-    CategoryEntity(id = 1L, name = "Tops", sortOrder = 1),
-    CategoryEntity(id = 2L, name = "Bottoms", sortOrder = 2),
-    CategoryEntity(id = 3L, name = "Shoes", sortOrder = 3),
-)
-
-private val previewSubcategories = listOf(
-    SubcategoryEntity(id = 1L, categoryId = 1L, name = "T-Shirts", sortOrder = 1),
-    SubcategoryEntity(id = 2L, categoryId = 1L, name = "Jackets", sortOrder = 2),
-)
-
-private val previewColors = listOf(
-    ColorEntity(id = 1L, name = "Black", hex = "#000000"),
-    ColorEntity(id = 2L, name = "White", hex = "#FFFFFF"),
-    ColorEntity(id = 3L, name = "Navy", hex = "#001F5B"),
-    ColorEntity(id = 4L, name = "Red", hex = "#CC0000"),
-    ColorEntity(id = 5L, name = "Olive", hex = "#708238"),
-    ColorEntity(id = 6L, name = "Tan", hex = "#D2B48C"),
-)
-
-private val previewBrands = listOf(
-    BrandEntity(id = 1L, name = "Nike"),
-    BrandEntity(id = 2L, name = "Levi's"),
-    BrandEntity(id = 3L, name = "Uniqlo"),
-)
-
-@Preview(showBackground = true, name = "Top Bar - Add Mode")
-@Composable
-private fun ClothingFormTopBarAddPreview() {
-    ClosetTheme {
-        Surface {
-            ClothingFormTopBar(
-                isEditMode = false,
-                canSave = false,
-                onBackClick = {},
-                onSaveClick = {}
-            )
-        }
-    }
-}
-
-@Preview(showBackground = true, name = "Top Bar - Edit Mode - Can Save")
-@Composable
-private fun ClothingFormTopBarEditPreview() {
-    ClosetTheme {
-        Surface {
-            ClothingFormTopBar(
-                isEditMode = true,
-                canSave = true,
-                onBackClick = {},
-                onSaveClick = {}
-            )
-        }
-    }
-}
-
-@Preview(showBackground = true, name = "Form - Empty/Add Mode - Light")
-@Preview(showBackground = true, uiMode = Configuration.UI_MODE_NIGHT_YES, name = "Form - Empty/Add Mode - Dark")
-@Composable
-private fun ClothingFormContentEmptyPreview() {
-    ClosetTheme {
-        Surface {
-            ClothingFormContent(
-                uiState = ClothingFormUiState(
-                    isEditMode = false,
-                    categories = previewCategories,
-                    allColors = previewColors,
-                    allBrands = previewBrands
-                ),
-                onNameChange = {},
-                onBrandQueryChange = {},
-                onBrandSelect = {},
-                onAddNewBrand = {},
-                onManageBrands = {},
-                onCategorySelect = {},
-                onSubcategorySelect = {},
-                onPriceChange = {},
-                onDateChange = {},
-                onLocationChange = {},
-                onNotesChange = {},
-                onImageClick = {},
-                onColorToggle = {}
-            )
-        }
-    }
-}
-
-@Preview(showBackground = true, name = "Form - Partially Filled")
-@Composable
-private fun ClothingFormContentFilledPreview() {
-    ClosetTheme {
-        Surface {
-            ClothingFormContent(
-                uiState = ClothingFormUiState(
-                    isEditMode = true,
-                    name = "Vintage Denim Jacket",
-                    brandQuery = "Levi's",
-                    category = previewCategories[0],
-                    subcategory = previewSubcategories[1],
-                    price = "85.00",
-                    purchaseLocation = "Brooklyn Thrift Store",
-                    categories = previewCategories,
-                    subcategories = previewSubcategories,
-                    allColors = previewColors,
-                    selectedColors = listOf(previewColors[2]),
-                    allBrands = previewBrands,
-                    canSave = true,
-                    isDirty = true
-                ),
-                onNameChange = {},
-                onBrandQueryChange = {},
-                onBrandSelect = {},
-                onAddNewBrand = {},
-                onManageBrands = {},
-                onCategorySelect = {},
-                onSubcategorySelect = {},
-                onPriceChange = {},
-                onDateChange = {},
-                onLocationChange = {},
-                onNotesChange = {},
-                onImageClick = {},
-                onColorToggle = {}
-            )
-        }
-    }
-}
-
-@Preview(showBackground = true, name = "Color Selection Grid")
-@Composable
-private fun ColorSelectionGridPreview() {
-    ClosetTheme {
-        Surface {
-            Column(modifier = Modifier.padding(16.dp)) {
-                ColorSelectionGrid(
-                    allColors = previewColors,
-                    selectedColors = listOf(previewColors[0], previewColors[2]),
-                    onColorToggle = {}
-                )
-            }
-        }
-    }
-}
-
-@Preview(showBackground = true, name = "Brand Autocomplete - With Results")
-@Composable
-private fun BrandAutocompleteFieldPreview() {
-    ClosetTheme {
-        Surface {
-            Column(modifier = Modifier.padding(16.dp)) {
-                BrandAutocompleteField(
-                    query = "Ni",
-                    allBrands = previewBrands,
-                    onQueryChange = {},
-                    onBrandSelect = {},
-                    onAddNewBrand = {}
-                )
-            }
-        }
-    }
-}
-
-@Preview(showBackground = true, name = "Category Dropdown - Selected")
-@Composable
-private fun CategoryDropdownPreview() {
-    ClosetTheme {
-        Surface {
-            Column(modifier = Modifier.padding(16.dp)) {
-                CategoryDropdown(
-                    selectedCategory = previewCategories[0],
-                    categories = previewCategories,
-                    onCategorySelect = {}
-                )
-            }
-        }
-    }
-}
-
-@Preview(showBackground = true, name = "Subcategory Dropdown - Enabled")
-@Preview(showBackground = true, name = "Subcategory Dropdown - Disabled")
-@Composable
-private fun SubcategoryDropdownPreview() {
-    ClosetTheme {
-        Surface {
-            Column(
-                modifier = Modifier.padding(16.dp),
-                verticalArrangement = Arrangement.spacedBy(16.dp)
-            ) {
-                SubcategoryDropdown(
-                    selectedSubcategory = previewSubcategories[0],
-                    subcategories = previewSubcategories,
-                    onSubcategorySelect = {},
-                    enabled = true
-                )
-                SubcategoryDropdown(
-                    selectedSubcategory = null,
-                    subcategories = emptyList(),
-                    onSubcategorySelect = {},
-                    enabled = false
-                )
-            }
-        }
-    }
-}
-
-@Preview(showBackground = true, name = "Date Picker Field - No Date")
-@Composable
-private fun DatePickerFieldPreview() {
-    ClosetTheme {
-        Surface {
-            Column(modifier = Modifier.padding(16.dp)) {
-                DatePickerField(selectedDate = null, onDateChange = {})
-            }
-        }
-    }
-}
-
-// endregion

--- a/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/ClothingFormScreen.kt
+++ b/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/ClothingFormScreen.kt
@@ -26,6 +26,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.AddAPhoto
 import androidx.compose.material.icons.filled.CalendarMonth
 import androidx.compose.material.icons.filled.Check
@@ -34,11 +35,15 @@ import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.DatePicker
 import androidx.compose.material3.DatePickerDialog
+import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExposedDropdownMenuBox
+import androidx.compose.material3.ExposedDropdownMenuDefaults
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.MenuAnchorType
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
@@ -70,6 +75,7 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import coil.compose.AsyncImage
+import com.closet.core.data.model.BrandEntity
 import com.closet.core.data.model.CategoryEntity
 import com.closet.core.data.model.ColorEntity
 import com.closet.core.data.model.SubcategoryEntity
@@ -164,7 +170,9 @@ fun ClothingFormScreen(
             ClothingFormContent(
                 uiState = uiState,
                 onNameChange = viewModel::updateName,
-                onBrandChange = viewModel::updateBrand,
+                onBrandQueryChange = viewModel::onBrandQueryChange,
+                onBrandSelect = viewModel::onBrandSelect,
+                onAddNewBrand = viewModel::onAddNewBrand,
                 onCategorySelect = viewModel::selectCategory,
                 onSubcategorySelect = viewModel::selectSubcategory,
                 onPriceChange = viewModel::updatePrice,
@@ -222,7 +230,9 @@ private fun ClothingFormTopBar(
 private fun ClothingFormContent(
     uiState: ClothingFormUiState,
     onNameChange: (String) -> Unit,
-    onBrandChange: (String) -> Unit,
+    onBrandQueryChange: (String) -> Unit,
+    onBrandSelect: (BrandEntity) -> Unit,
+    onAddNewBrand: (String) -> Unit,
     onCategorySelect: (CategoryEntity?) -> Unit,
     onSubcategorySelect: (SubcategoryEntity?) -> Unit,
     onPriceChange: (String) -> Unit,
@@ -289,13 +299,12 @@ private fun ClothingFormContent(
         }
 
         item {
-            OutlinedTextField(
-                value = uiState.brand,
-                onValueChange = onBrandChange,
-                label = { Text(stringResource(R.string.wardrobe_field_brand)) },
-                modifier = Modifier.fillMaxWidth(),
-                singleLine = true,
-                keyboardOptions = KeyboardOptions(imeAction = ImeAction.Next)
+            BrandAutocompleteField(
+                query = uiState.brandQuery,
+                allBrands = uiState.allBrands,
+                onQueryChange = onBrandQueryChange,
+                onBrandSelect = onBrandSelect,
+                onAddNewBrand = onAddNewBrand
             )
         }
 
@@ -604,6 +613,57 @@ private fun DatePickerField(
             }
         ) {
             DatePicker(state = datePickerState)
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun BrandAutocompleteField(
+    query: String,
+    allBrands: List<BrandEntity>,
+    onQueryChange: (String) -> Unit,
+    onBrandSelect: (BrandEntity) -> Unit,
+    onAddNewBrand: (String) -> Unit
+) {
+    val filteredBrands = allBrands.filter { it.name.contains(query, ignoreCase = true) }
+    val showAddOption = query.isNotBlank() && filteredBrands.none { it.name.equals(query, ignoreCase = true) }
+
+    var expanded by remember { mutableStateOf(false) }
+
+    ExposedDropdownMenuBox(
+        expanded = expanded,
+        onExpandedChange = { expanded = it }
+    ) {
+        OutlinedTextField(
+            value = query,
+            onValueChange = { onQueryChange(it); expanded = true },
+            label = { Text(stringResource(R.string.wardrobe_field_brand)) },
+            trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded) },
+            singleLine = true,
+            modifier = Modifier
+                .fillMaxWidth()
+                .menuAnchor(MenuAnchorType.PrimaryEditable)
+        )
+
+        ExposedDropdownMenu(
+            expanded = expanded && (filteredBrands.isNotEmpty() || showAddOption),
+            onDismissRequest = { expanded = false }
+        ) {
+            filteredBrands.forEach { brand ->
+                DropdownMenuItem(
+                    text = { Text(brand.name) },
+                    onClick = { onBrandSelect(brand); expanded = false }
+                )
+            }
+            if (showAddOption) {
+                HorizontalDivider()
+                DropdownMenuItem(
+                    text = { Text(stringResource(R.string.wardrobe_brand_add, query)) },
+                    leadingIcon = { Icon(Icons.Default.Add, contentDescription = null) },
+                    onClick = { onAddNewBrand(query); expanded = false }
+                )
+            }
         }
     }
 }

--- a/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/ClothingFormScreen.kt
+++ b/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/ClothingFormScreen.kt
@@ -50,6 +50,7 @@ import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar

--- a/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/ClothingFormScreen.kt
+++ b/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/ClothingFormScreen.kt
@@ -28,6 +28,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.AddAPhoto
+import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material.icons.filled.CalendarMonth
 import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.Palette
@@ -89,6 +90,7 @@ import java.time.ZoneId
 @Composable
 fun ClothingFormScreen(
     onBackClick: () -> Unit,
+    onManageBrands: () -> Unit,
     modifier: Modifier = Modifier,
     viewModel: ClothingFormViewModel = hiltViewModel()
 ) {
@@ -173,6 +175,7 @@ fun ClothingFormScreen(
                 onBrandQueryChange = viewModel::onBrandQueryChange,
                 onBrandSelect = viewModel::onBrandSelect,
                 onAddNewBrand = viewModel::onAddNewBrand,
+                onManageBrands = onManageBrands,
                 onCategorySelect = viewModel::selectCategory,
                 onSubcategorySelect = viewModel::selectSubcategory,
                 onPriceChange = viewModel::updatePrice,
@@ -233,6 +236,7 @@ private fun ClothingFormContent(
     onBrandQueryChange: (String) -> Unit,
     onBrandSelect: (BrandEntity) -> Unit,
     onAddNewBrand: (String) -> Unit,
+    onManageBrands: () -> Unit,
     onCategorySelect: (CategoryEntity?) -> Unit,
     onSubcategorySelect: (SubcategoryEntity?) -> Unit,
     onPriceChange: (String) -> Unit,
@@ -299,13 +303,27 @@ private fun ClothingFormContent(
         }
 
         item {
-            BrandAutocompleteField(
-                query = uiState.brandQuery,
-                allBrands = uiState.allBrands,
-                onQueryChange = onBrandQueryChange,
-                onBrandSelect = onBrandSelect,
-                onAddNewBrand = onAddNewBrand
-            )
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(4.dp)
+            ) {
+                Box(modifier = Modifier.weight(1f)) {
+                    BrandAutocompleteField(
+                        query = uiState.brandQuery,
+                        allBrands = uiState.allBrands,
+                        onQueryChange = onBrandQueryChange,
+                        onBrandSelect = onBrandSelect,
+                        onAddNewBrand = onAddNewBrand
+                    )
+                }
+                IconButton(onClick = onManageBrands) {
+                    Icon(
+                        imageVector = Icons.Default.Settings,
+                        contentDescription = stringResource(R.string.brand_management_manage_brands),
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+            }
         }
 
         // Category & Subcategory

--- a/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/ClothingFormScreen.kt
+++ b/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/ClothingFormScreen.kt
@@ -1,5 +1,6 @@
 package com.closet.features.wardrobe
 
+import android.content.res.Configuration
 import androidx.activity.compose.BackHandler
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.PickVisualMediaRequest
@@ -72,9 +73,11 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.closet.core.ui.theme.ClosetTheme
 import coil.compose.AsyncImage
 import com.closet.core.data.model.BrandEntity
 import com.closet.core.data.model.CategoryEntity
@@ -690,3 +693,223 @@ private fun isColorDark(color: Color): Boolean {
     val luminance = 0.2126 * color.red + 0.7152 * color.green + 0.0722 * color.blue
     return luminance < 0.5
 }
+
+// region Previews
+
+private val previewCategories = listOf(
+    CategoryEntity(id = 1L, name = "Tops", sortOrder = 1),
+    CategoryEntity(id = 2L, name = "Bottoms", sortOrder = 2),
+    CategoryEntity(id = 3L, name = "Shoes", sortOrder = 3),
+)
+
+private val previewSubcategories = listOf(
+    SubcategoryEntity(id = 1L, categoryId = 1L, name = "T-Shirts", sortOrder = 1),
+    SubcategoryEntity(id = 2L, categoryId = 1L, name = "Jackets", sortOrder = 2),
+)
+
+private val previewColors = listOf(
+    ColorEntity(id = 1L, name = "Black", hex = "#000000"),
+    ColorEntity(id = 2L, name = "White", hex = "#FFFFFF"),
+    ColorEntity(id = 3L, name = "Navy", hex = "#001F5B"),
+    ColorEntity(id = 4L, name = "Red", hex = "#CC0000"),
+    ColorEntity(id = 5L, name = "Olive", hex = "#708238"),
+    ColorEntity(id = 6L, name = "Tan", hex = "#D2B48C"),
+)
+
+private val previewBrands = listOf(
+    BrandEntity(id = 1L, name = "Nike"),
+    BrandEntity(id = 2L, name = "Levi's"),
+    BrandEntity(id = 3L, name = "Uniqlo"),
+)
+
+@Preview(showBackground = true, name = "Top Bar - Add Mode")
+@Composable
+private fun ClothingFormTopBarAddPreview() {
+    ClosetTheme {
+        Surface {
+            ClothingFormTopBar(
+                isEditMode = false,
+                canSave = false,
+                onBackClick = {},
+                onSaveClick = {}
+            )
+        }
+    }
+}
+
+@Preview(showBackground = true, name = "Top Bar - Edit Mode - Can Save")
+@Composable
+private fun ClothingFormTopBarEditPreview() {
+    ClosetTheme {
+        Surface {
+            ClothingFormTopBar(
+                isEditMode = true,
+                canSave = true,
+                onBackClick = {},
+                onSaveClick = {}
+            )
+        }
+    }
+}
+
+@Preview(showBackground = true, name = "Form - Empty/Add Mode - Light")
+@Preview(showBackground = true, uiMode = Configuration.UI_MODE_NIGHT_YES, name = "Form - Empty/Add Mode - Dark")
+@Composable
+private fun ClothingFormContentEmptyPreview() {
+    ClosetTheme {
+        Surface {
+            ClothingFormContent(
+                uiState = ClothingFormUiState(
+                    isEditMode = false,
+                    categories = previewCategories,
+                    allColors = previewColors,
+                    allBrands = previewBrands
+                ),
+                onNameChange = {},
+                onBrandQueryChange = {},
+                onBrandSelect = {},
+                onAddNewBrand = {},
+                onManageBrands = {},
+                onCategorySelect = {},
+                onSubcategorySelect = {},
+                onPriceChange = {},
+                onDateChange = {},
+                onLocationChange = {},
+                onNotesChange = {},
+                onImageClick = {},
+                onColorToggle = {}
+            )
+        }
+    }
+}
+
+@Preview(showBackground = true, name = "Form - Partially Filled")
+@Composable
+private fun ClothingFormContentFilledPreview() {
+    ClosetTheme {
+        Surface {
+            ClothingFormContent(
+                uiState = ClothingFormUiState(
+                    isEditMode = true,
+                    name = "Vintage Denim Jacket",
+                    brandQuery = "Levi's",
+                    category = previewCategories[0],
+                    subcategory = previewSubcategories[1],
+                    price = "85.00",
+                    purchaseLocation = "Brooklyn Thrift Store",
+                    categories = previewCategories,
+                    subcategories = previewSubcategories,
+                    allColors = previewColors,
+                    selectedColors = listOf(previewColors[2]),
+                    allBrands = previewBrands,
+                    canSave = true,
+                    isDirty = true
+                ),
+                onNameChange = {},
+                onBrandQueryChange = {},
+                onBrandSelect = {},
+                onAddNewBrand = {},
+                onManageBrands = {},
+                onCategorySelect = {},
+                onSubcategorySelect = {},
+                onPriceChange = {},
+                onDateChange = {},
+                onLocationChange = {},
+                onNotesChange = {},
+                onImageClick = {},
+                onColorToggle = {}
+            )
+        }
+    }
+}
+
+@Preview(showBackground = true, name = "Color Selection Grid")
+@Composable
+private fun ColorSelectionGridPreview() {
+    ClosetTheme {
+        Surface {
+            Column(modifier = Modifier.padding(16.dp)) {
+                ColorSelectionGrid(
+                    allColors = previewColors,
+                    selectedColors = listOf(previewColors[0], previewColors[2]),
+                    onColorToggle = {}
+                )
+            }
+        }
+    }
+}
+
+@Preview(showBackground = true, name = "Brand Autocomplete - With Results")
+@Composable
+private fun BrandAutocompleteFieldPreview() {
+    ClosetTheme {
+        Surface {
+            Column(modifier = Modifier.padding(16.dp)) {
+                BrandAutocompleteField(
+                    query = "Ni",
+                    allBrands = previewBrands,
+                    onQueryChange = {},
+                    onBrandSelect = {},
+                    onAddNewBrand = {}
+                )
+            }
+        }
+    }
+}
+
+@Preview(showBackground = true, name = "Category Dropdown - Selected")
+@Composable
+private fun CategoryDropdownPreview() {
+    ClosetTheme {
+        Surface {
+            Column(modifier = Modifier.padding(16.dp)) {
+                CategoryDropdown(
+                    selectedCategory = previewCategories[0],
+                    categories = previewCategories,
+                    onCategorySelect = {}
+                )
+            }
+        }
+    }
+}
+
+@Preview(showBackground = true, name = "Subcategory Dropdown - Enabled")
+@Preview(showBackground = true, name = "Subcategory Dropdown - Disabled")
+@Composable
+private fun SubcategoryDropdownPreview() {
+    ClosetTheme {
+        Surface {
+            Column(
+                modifier = Modifier.padding(16.dp),
+                verticalArrangement = Arrangement.spacedBy(16.dp)
+            ) {
+                SubcategoryDropdown(
+                    selectedSubcategory = previewSubcategories[0],
+                    subcategories = previewSubcategories,
+                    onSubcategorySelect = {},
+                    enabled = true
+                )
+                SubcategoryDropdown(
+                    selectedSubcategory = null,
+                    subcategories = emptyList(),
+                    onSubcategorySelect = {},
+                    enabled = false
+                )
+            }
+        }
+    }
+}
+
+@Preview(showBackground = true, name = "Date Picker Field - No Date")
+@Composable
+private fun DatePickerFieldPreview() {
+    ClosetTheme {
+        Surface {
+            Column(modifier = Modifier.padding(16.dp)) {
+                DatePickerField(selectedDate = null, onDateChange = {})
+            }
+        }
+    }
+}
+
+// endregion

--- a/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/ClothingFormScreen.kt
+++ b/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/ClothingFormScreen.kt
@@ -57,6 +57,7 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import coil.compose.AsyncImage
+import com.closet.core.ui.components.ResErrorSnackbarEffect
 import com.closet.core.data.model.BrandEntity
 import com.closet.core.data.model.CategoryEntity
 import com.closet.core.data.model.ColorEntity
@@ -85,13 +86,7 @@ fun ClothingFormScreen(
         }
     }
 
-    uiState.errorMessage?.let { messageRes ->
-        val message = stringResource(messageRes)
-        LaunchedEffect(messageRes) {
-            snackbarHostState.showSnackbar(message)
-            viewModel.onErrorConsumed()
-        }
-    }
+    ResErrorSnackbarEffect(uiState.errorMessage, snackbarHostState, viewModel::onErrorConsumed)
 
     val launcher = rememberLauncherForActivityResult(
         contract = ActivityResultContracts.PickVisualMedia(),

--- a/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/ClothingFormViewModel.kt
+++ b/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/ClothingFormViewModel.kt
@@ -62,7 +62,6 @@ data class ClothingFormUiState(
     val canSave: Boolean = false,
     val isDirty: Boolean = false
 ) {
-    val formattedDate: String? = purchaseDate?.format(DateTimeFormatter.ISO_LOCAL_DATE)
 }
 
 private data class FormState(
@@ -138,7 +137,7 @@ class ClothingFormViewModel @Inject constructor(
 
     val uiState: StateFlow<ClothingFormUiState> = combine(
         _form, categories, subcategories, allColors, allBrands
-    ) { form, cats, subcats, colors, brands ->
+    ) { form, cats, subs, colors, brands ->
         ClothingFormUiState(
             isEditMode = isEditMode,
             name = form.name,
@@ -159,7 +158,7 @@ class ClothingFormViewModel @Inject constructor(
             isLoading = form.isLoading,
             errorMessage = form.errorMessage,
             categories = cats,
-            subcategories = subcats,
+            subcategories = subs,
             allColors = colors,
             canSave = form.name.isNotBlank() && !form.isSaving &&
                     !(form.brandQuery.isNotBlank() && form.selectedBrandId == null),
@@ -279,7 +278,7 @@ class ClothingFormViewModel @Inject constructor(
             when (val result = brandRepository.insertBrand(nameNormalized)) {
                 is DataResult.Success -> onBrandSelect(BrandEntity(id = result.data, name = nameNormalized))
                 is DataResult.Error -> _form.update { it.copy(
-                    errorMessage = when (result.error) {
+                    errorMessage = when (result.throwable) {
                         is AppError.DatabaseError.ConstraintViolation -> R.string.wardrobe_error_brand_duplicate
                         else -> R.string.wardrobe_error_brand_save_failed
                     }
@@ -368,13 +367,6 @@ class ClothingFormViewModel @Inject constructor(
                 current.selectedColors + color
             }
             current.copy(selectedColors = updated)
-        }
-    }
-
-    fun updateColors(colorIds: List<Long>) {
-        viewModelScope.launch {
-            val colors = lookupRepository.getColors().first()
-            _form.update { it.copy(selectedColors = colors.filter { c -> c.id in colorIds }) }
         }
     }
 

--- a/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/ClothingFormViewModel.kt
+++ b/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/ClothingFormViewModel.kt
@@ -123,6 +123,7 @@ class ClothingFormViewModel @Inject constructor(
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
 
     val allBrands: StateFlow<List<BrandEntity>> = brandRepository.getAllBrands()
+        .map { result -> if (result is DataResult.Success) result.data else emptyList() }
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
 
     @OptIn(ExperimentalCoroutinesApi::class)
@@ -211,7 +212,8 @@ class ClothingFormViewModel @Inject constructor(
 
                     // Hydrate the fields
                     val brandName = if (entity.brandId != null) {
-                        brandRepository.getAllBrands().first().find { it.id == entity.brandId }?.name ?: ""
+                        (brandRepository.getAllBrands().first { it is DataResult.Success } as DataResult.Success).data
+                            .find { it.id == entity.brandId }?.name ?: ""
                     } else ""
 
                     val selectedCat = if (entity.categoryId != null) {

--- a/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/ClothingFormViewModel.kt
+++ b/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/ClothingFormViewModel.kt
@@ -17,6 +17,7 @@ import com.closet.core.data.repository.BrandRepository
 import com.closet.core.data.repository.ClothingRepository
 import com.closet.core.data.repository.LookupRepository
 import com.closet.core.data.repository.StorageRepository
+import com.closet.core.data.util.AppError
 import com.closet.core.data.util.ColorMatcher
 import com.closet.core.data.util.DataResult
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -197,7 +198,7 @@ class ClothingFormViewModel @Inject constructor(
             details.imagePath != e.imagePath ||
             colorsChanged
         } else {
-            basic.name.isNotBlank() || basic.selectedBrandId != null || basic.category != null ||
+            basic.name.isNotBlank() || basic.brandQuery.isNotBlank() || basic.selectedBrandId != null || basic.category != null ||
             basic.price.isNotBlank() || details.purchaseDate != null || details.purchaseLocation.isNotBlank() ||
             details.notes.isNotBlank() || details.imagePath != null || details.selectedColors.isNotEmpty()
         }
@@ -224,7 +225,8 @@ class ClothingFormViewModel @Inject constructor(
             categories = cats,
             subcategories = subcats,
             allColors = colors,
-            canSave = basic.name.isNotBlank() && !status.isSaving,
+            canSave = basic.name.isNotBlank() && !status.isSaving &&
+                    !(basic.brandQuery.isNotBlank() && basic.selectedBrandId == null),
             isDirty = isDirty
         )
     }.stateIn(
@@ -306,10 +308,16 @@ class ClothingFormViewModel @Inject constructor(
     }
 
     fun onAddNewBrand(name: String) {
+        val nameNormalized = name.trim()
+        if (nameNormalized.isBlank()) return
         viewModelScope.launch {
-            val result = brandRepository.insertBrand(name)
-            if (result is DataResult.Success) {
-                onBrandSelect(BrandEntity(id = result.data, name = name))
+            when (val result = brandRepository.insertBrand(nameNormalized)) {
+                is DataResult.Success -> onBrandSelect(BrandEntity(id = result.data, name = nameNormalized))
+                is DataResult.Error -> _errorMessage.value = when (result.error) {
+                    is AppError.DatabaseError.ConstraintViolation -> R.string.wardrobe_error_brand_duplicate
+                    else -> R.string.wardrobe_error_brand_save_failed
+                }
+                else -> Unit
             }
         }
     }
@@ -414,6 +422,7 @@ class ClothingFormViewModel @Inject constructor(
             _isNameError.value = true
             return
         }
+        if (_brandQuery.value.isNotBlank() && _selectedBrandId.value == null) return
 
         _isSaving.value = true
         _errorMessage.value = null

--- a/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/ClothingFormViewModel.kt
+++ b/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/ClothingFormViewModel.kt
@@ -36,6 +36,12 @@ import javax.inject.Inject
 
 /**
  * UI state for the Clothing Form (Add/Edit).
+ *
+ * @property isEditMode True when editing an existing item; false for a new item.
+ * @property canSave True when the form is valid and no save is in progress.
+ * @property isDirty True when the form has unsaved changes relative to the original item (edit)
+ *   or has any filled field (add).
+ * @property errorMessage String resource ID for the current error, or null if none.
  */
 data class ClothingFormUiState(
     val isEditMode: Boolean = false,
@@ -113,18 +119,23 @@ class ClothingFormViewModel @Inject constructor(
 
     // One-time events for navigation
     private val _events = Channel<ClothingFormEvent>()
+    /** One-time navigation events (e.g. [ClothingFormEvent.NavigateBack]) for the screen to collect. */
     val events = _events.receiveAsFlow()
 
+    /** All top-level categories, used to populate the category picker. */
     val categories: StateFlow<List<CategoryEntity>> = lookupRepository.getCategories()
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
 
+    /** All available colors, used to populate the color chip selector. */
     val allColors: StateFlow<List<ColorEntity>> = lookupRepository.getColors()
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
 
+    /** All brands for the autocomplete dropdown. */
     val allBrands: StateFlow<List<BrandEntity>> = brandRepository.getAllBrands()
         .map { result -> if (result is DataResult.Success) result.data else emptyList() }
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
 
+    /** Subcategories filtered by the currently selected category; resets to empty when no category is chosen. */
     @OptIn(ExperimentalCoroutinesApi::class)
     val subcategories: StateFlow<List<SubcategoryEntity>> = _form
         .map { it.category }
@@ -135,6 +146,7 @@ class ClothingFormViewModel @Inject constructor(
         }
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
 
+    /** Consolidated UI state combining the form fields with all lookup lists. */
     val uiState: StateFlow<ClothingFormUiState> = combine(
         _form, categories, subcategories, allColors, allBrands
     ) { form, cats, subs, colors, brands ->
@@ -259,18 +271,25 @@ class ClothingFormViewModel @Inject constructor(
         }
     }
 
+    /** Updates the item name field and clears any name validation error. */
     fun updateName(newName: String) {
         _form.update { it.copy(name = newName, isNameError = false) }
     }
 
+    /** Updates the brand search text and clears any previously confirmed brand selection. */
     fun onBrandQueryChange(text: String) {
         _form.update { it.copy(brandQuery = text, selectedBrandId = null) }
     }
 
+    /** Confirms a brand selection from the autocomplete dropdown. */
     fun onBrandSelect(brand: BrandEntity) {
         _form.update { it.copy(selectedBrandId = brand.id, brandQuery = brand.name) }
     }
 
+    /**
+     * Inserts a new brand with [name] and immediately selects it.
+     * Surfaces an error in [uiState] if the name is a duplicate or the insert fails.
+     */
     fun onAddNewBrand(name: String) {
         val nameNormalized = name.trim()
         if (nameNormalized.isBlank()) return
@@ -288,32 +307,43 @@ class ClothingFormViewModel @Inject constructor(
         }
     }
 
+    /** Selects [category] and clears the subcategory since it belongs to the old category. */
     fun selectCategory(category: CategoryEntity?) {
         _form.update { it.copy(category = category, subcategory = null) }
     }
 
+    /** Selects [subcategory] within the currently chosen category. */
     fun selectSubcategory(subcategory: SubcategoryEntity?) {
         _form.update { it.copy(subcategory = subcategory) }
     }
 
+    /** Updates the price field, accepting only valid decimal strings (up to 2 decimal places). */
     fun updatePrice(newPrice: String) {
         if (newPrice.isEmpty() || newPrice.matches(Regex("""^\d*\.?\d{0,2}$"""))) {
             _form.update { it.copy(price = newPrice) }
         }
     }
 
+    /** Updates the purchase date field. */
     fun updatePurchaseDate(date: LocalDate?) {
         _form.update { it.copy(purchaseDate = date) }
     }
 
+    /** Updates the purchase location text field. */
     fun updatePurchaseLocation(location: String) {
         _form.update { it.copy(purchaseLocation = location) }
     }
 
+    /** Updates the notes text field. */
     fun updateNotes(newNotes: String) {
         _form.update { it.copy(notes = newNotes) }
     }
 
+    /**
+     * Copies the image at [uri] into app-owned storage, stores its relative path, and
+     * auto-suggests colors from the image palette. Deletes any previously staged (unsaved)
+     * replacement image. No-ops if [uri] is null.
+     */
     fun onImageSelected(uri: Uri?) {
         if (uri == null) return
         viewModelScope.launch {
@@ -359,6 +389,7 @@ class ClothingFormViewModel @Inject constructor(
         }
     }
 
+    /** Adds [color] to the selection if not present, or removes it if already selected. */
     fun toggleColor(color: ColorEntity) {
         _form.update { current ->
             val updated = if (current.selectedColors.any { it.id == color.id }) {
@@ -370,10 +401,17 @@ class ClothingFormViewModel @Inject constructor(
         }
     }
 
+    /** Clears the transient error message once the UI has consumed it. */
     fun onErrorConsumed() {
         _form.update { it.copy(errorMessage = null) }
     }
 
+    /**
+     * Validates the form and persists the item (insert on add, update on edit).
+     * Emits [ClothingFormEvent.NavigateBack] on success.
+     * Sets [ClothingFormUiState.isNameError] if the name is blank, or surfaces a save error
+     * via [ClothingFormUiState.errorMessage] if the repository call fails.
+     */
     fun save() {
         val currentForm = _form.value
         if (currentForm.isSaving) return
@@ -431,6 +469,8 @@ class ClothingFormViewModel @Inject constructor(
     }
 }
 
+/** One-time navigation events emitted by [ClothingFormViewModel]. */
 sealed class ClothingFormEvent {
+    /** Emitted when the item was saved successfully; the screen should navigate back. */
     data object NavigateBack : ClothingFormEvent()
 }

--- a/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/ClothingFormViewModel.kt
+++ b/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/ClothingFormViewModel.kt
@@ -6,12 +6,14 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import androidx.navigation.toRoute
 import androidx.palette.graphics.Palette
+import com.closet.core.data.model.BrandEntity
 import com.closet.core.data.model.CategoryEntity
 import com.closet.core.data.model.ClothingItemEntity
 import com.closet.core.data.model.ClothingStatus
 import com.closet.core.data.model.ColorEntity
 import com.closet.core.data.model.SubcategoryEntity
 import com.closet.core.data.model.WashStatus
+import com.closet.core.data.repository.BrandRepository
 import com.closet.core.data.repository.ClothingRepository
 import com.closet.core.data.repository.LookupRepository
 import com.closet.core.data.repository.StorageRepository
@@ -37,7 +39,9 @@ import javax.inject.Inject
 data class ClothingFormUiState(
     val isEditMode: Boolean = false,
     val name: String = "",
-    val brand: String = "",
+    val brandQuery: String = "",
+    val selectedBrandId: Long? = null,
+    val allBrands: List<BrandEntity> = emptyList(),
     val category: CategoryEntity? = null,
     val subcategory: SubcategoryEntity? = null,
     val price: String = "",
@@ -62,7 +66,8 @@ data class ClothingFormUiState(
 
 private data class FormBasic(
     val name: String,
-    val brand: String,
+    val brandQuery: String,
+    val selectedBrandId: Long?,
     val category: CategoryEntity?,
     val subcategory: SubcategoryEntity?,
     val price: String
@@ -91,6 +96,7 @@ private data class FormStatus(
 class ClothingFormViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
     private val lookupRepository: LookupRepository,
+    private val brandRepository: BrandRepository,
     private val storageRepository: StorageRepository,
     private val clothingRepository: ClothingRepository
 ) : ViewModel() {
@@ -105,7 +111,8 @@ class ClothingFormViewModel @Inject constructor(
     private val isEditMode = itemId != null
 
     private val _name = MutableStateFlow("")
-    private val _brand = MutableStateFlow("")
+    private val _brandQuery = MutableStateFlow("")
+    private val _selectedBrandId = MutableStateFlow<Long?>(null)
     private val _selectedCategory = MutableStateFlow<CategoryEntity?>(null)
     private val _selectedSubcategory = MutableStateFlow<SubcategoryEntity?>(null)
     private val _price = MutableStateFlow("")
@@ -114,12 +121,12 @@ class ClothingFormViewModel @Inject constructor(
     private val _notes = MutableStateFlow("")
     private val _imagePath = MutableStateFlow<String?>(null)
     private val _selectedColors = MutableStateFlow<List<ColorEntity>>(emptyList())
-    
+
     private val _isNameError = MutableStateFlow(false)
     private val _isSaving = MutableStateFlow(false)
     private val _isLoading = MutableStateFlow(isEditMode)
     private val _errorMessage = MutableStateFlow<Int?>(null)
-    
+
     // To handle image replacement cleanup
     private var originalImagePath: String? = null
     private var originalEntity: ClothingItemEntity? = null
@@ -135,6 +142,9 @@ class ClothingFormViewModel @Inject constructor(
     val allColors: StateFlow<List<ColorEntity>> = lookupRepository.getColors()
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
 
+    val allBrands: StateFlow<List<BrandEntity>> = brandRepository.getAllBrands()
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
+
     @OptIn(ExperimentalCoroutinesApi::class)
     val subcategories: StateFlow<List<SubcategoryEntity>> = _selectedCategory
         .flatMapLatest { category ->
@@ -144,9 +154,12 @@ class ClothingFormViewModel @Inject constructor(
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
 
     private val basicFields = combine(
-        _name, _brand, _selectedCategory, _selectedSubcategory, _price
-    ) { name, brand, category, subcategory, price ->
-        FormBasic(name, brand, category, subcategory, price)
+        combine(_name, _brandQuery, _selectedBrandId) { name, query, id -> Triple(name, query, id) },
+        _selectedCategory,
+        _selectedSubcategory,
+        _price
+    ) { (name, query, id), category, subcategory, price ->
+        FormBasic(name, query, id, category, subcategory, price)
     }
 
     private val detailFields = combine(
@@ -165,16 +178,17 @@ class ClothingFormViewModel @Inject constructor(
         combine(basicFields, detailFields, statusFields) { b, d, s -> Triple(b, d, s) },
         categories,
         subcategories,
-        allColors
-    ) { (basic, details, status), cats, subcats, colors ->
+        allColors,
+        allBrands
+    ) { (basic, details, status), cats, subcats, colors, brands ->
         val isDirty = if (isEditMode && originalEntity != null) {
             val e = originalEntity!!
             val colorsChanged = details.selectedColors.size != originalColors.size ||
                     !details.selectedColors.containsAll(originalColors)
 
-            basic.name != e.name || 
-            basic.brand != (e.brand ?: "") || 
-            basic.category?.id != e.categoryId || 
+            basic.name != e.name ||
+            basic.selectedBrandId != e.brandId ||
+            basic.category?.id != e.categoryId ||
             basic.subcategory?.id != e.subcategoryId ||
             basic.price != (e.purchasePrice?.toString() ?: "") ||
             details.purchaseDate?.format(DateTimeFormatter.ISO_LOCAL_DATE) != e.purchaseDate ||
@@ -183,7 +197,7 @@ class ClothingFormViewModel @Inject constructor(
             details.imagePath != e.imagePath ||
             colorsChanged
         } else {
-            basic.name.isNotBlank() || basic.brand.isNotBlank() || basic.category != null || 
+            basic.name.isNotBlank() || basic.selectedBrandId != null || basic.category != null ||
             basic.price.isNotBlank() || details.purchaseDate != null || details.purchaseLocation.isNotBlank() ||
             details.notes.isNotBlank() || details.imagePath != null || details.selectedColors.isNotEmpty()
         }
@@ -191,7 +205,9 @@ class ClothingFormViewModel @Inject constructor(
         ClothingFormUiState(
             isEditMode = isEditMode,
             name = basic.name,
-            brand = basic.brand,
+            brandQuery = basic.brandQuery,
+            selectedBrandId = basic.selectedBrandId,
+            allBrands = brands,
             category = basic.category,
             subcategory = basic.subcategory,
             price = basic.price,
@@ -227,28 +243,32 @@ class ClothingFormViewModel @Inject constructor(
         viewModelScope.launch {
             _isLoading.value = true
             val entityResult = clothingRepository.getItemEntityById(id)
-            
+
             if (entityResult is DataResult.Success) {
                 val entity = entityResult.data
                 originalEntity = entity
                 originalImagePath = entity.imagePath
-                
+
                 // Hydrate the fields
                 _name.value = entity.name
-                _brand.value = entity.brand ?: ""
+                _selectedBrandId.value = entity.brandId
+                if (entity.brandId != null) {
+                    val brands = brandRepository.getAllBrands().first()
+                    _brandQuery.value = brands.find { it.id == entity.brandId }?.name ?: ""
+                }
                 _price.value = entity.purchasePrice?.toString() ?: ""
-                _purchaseDate.value = entity.purchaseDate?.let { try { LocalDate.parse(it) } catch(_: Exception) { null } }
+                _purchaseDate.value = entity.purchaseDate?.let { try { LocalDate.parse(it) } catch (_: Exception) { null } }
                 _purchaseLocation.value = entity.purchaseLocation ?: ""
                 _notes.value = entity.notes ?: ""
                 _imagePath.value = entity.imagePath
-                
+
                 // Fetch Category and Subcategory entities for the selectors
                 val catId = entity.categoryId
                 if (catId != null) {
                     val cats = lookupRepository.getCategories().first()
                     val selectedCat = cats.find { it.id == catId }
                     _selectedCategory.value = selectedCat
-                    
+
                     val subId = entity.subcategoryId
                     if (subId != null) {
                         val subcats = lookupRepository.getSubcategories(catId).first()
@@ -272,8 +292,26 @@ class ClothingFormViewModel @Inject constructor(
         _isNameError.value = false
     }
 
-    fun updateBrand(newBrand: String) {
-        _brand.value = newBrand
+    fun onBrandQueryChange(text: String) {
+        _brandQuery.value = text
+        // Clear selection if the user edits the text away from the selected brand
+        if (_selectedBrandId.value != null) {
+            _selectedBrandId.value = null
+        }
+    }
+
+    fun onBrandSelect(brand: BrandEntity) {
+        _selectedBrandId.value = brand.id
+        _brandQuery.value = brand.name
+    }
+
+    fun onAddNewBrand(name: String) {
+        viewModelScope.launch {
+            val result = brandRepository.insertBrand(name)
+            if (result is DataResult.Success) {
+                onBrandSelect(BrandEntity(id = result.data, name = name))
+            }
+        }
     }
 
     fun selectCategory(category: CategoryEntity?) {
@@ -313,7 +351,7 @@ class ClothingFormViewModel @Inject constructor(
                 if (previousPath != null && previousPath != originalImagePath) {
                     storageRepository.deleteImage(previousPath)
                 }
-                
+
                 // Process colors from the new image
                 extractColors(uri)
             } catch (e: Exception) {
@@ -327,20 +365,20 @@ class ClothingFormViewModel @Inject constructor(
         try {
             val bitmap = storageRepository.getBitmap(uri) ?: return@withContext
             val palette = Palette.from(bitmap).generate()
-            
+
             val swatches = listOfNotNull(
                 palette.vibrantSwatch,
                 palette.mutedSwatch,
                 palette.dominantSwatch
             )
-            
+
             if (swatches.isNotEmpty()) {
                 val availableColors = lookupRepository.getColors().first()
                 if (availableColors.isNotEmpty()) {
                     val snappedColors = swatches.map { swatch ->
                         ColorMatcher.findNearestColor(swatch.rgb, availableColors)
                     }.distinctBy { it.id }
-                    
+
                     _selectedColors.value = snappedColors
                 }
             }
@@ -385,7 +423,7 @@ class ClothingFormViewModel @Inject constructor(
                 val item = ClothingItemEntity(
                     id = itemId ?: 0,
                     name = _name.value.trim(),
-                    brand = _brand.value.trim().takeIf { it.isNotBlank() },
+                    brandId = _selectedBrandId.value,
                     categoryId = _selectedCategory.value?.id,
                     subcategoryId = _selectedSubcategory.value?.id,
                     purchasePrice = _price.value.toDoubleOrNull(),

--- a/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/ClothingFormViewModel.kt
+++ b/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/ClothingFormViewModel.kt
@@ -65,28 +65,22 @@ data class ClothingFormUiState(
     val formattedDate: String? = purchaseDate?.format(DateTimeFormatter.ISO_LOCAL_DATE)
 }
 
-private data class FormBasic(
-    val name: String,
-    val brandQuery: String,
-    val selectedBrandId: Long?,
-    val category: CategoryEntity?,
-    val subcategory: SubcategoryEntity?,
-    val price: String
-)
-
-private data class FormDetails(
-    val purchaseDate: LocalDate?,
-    val purchaseLocation: String,
-    val notes: String,
-    val imagePath: String?,
-    val selectedColors: List<ColorEntity>
-)
-
-private data class FormStatus(
-    val isNameError: Boolean,
-    val isSaving: Boolean,
-    val isLoading: Boolean,
-    val errorMessage: Int?
+private data class FormState(
+    val name: String = "",
+    val brandQuery: String = "",
+    val selectedBrandId: Long? = null,
+    val category: CategoryEntity? = null,
+    val subcategory: SubcategoryEntity? = null,
+    val price: String = "",
+    val purchaseDate: LocalDate? = null,
+    val purchaseLocation: String = "",
+    val notes: String = "",
+    val imagePath: String? = null,
+    val selectedColors: List<ColorEntity> = emptyList(),
+    val isNameError: Boolean = false,
+    val isSaving: Boolean = false,
+    val isLoading: Boolean = false,
+    val errorMessage: Int? = null
 )
 
 /**
@@ -111,22 +105,7 @@ class ClothingFormViewModel @Inject constructor(
     private val itemId: Long? = editDestination?.itemId
     private val isEditMode = itemId != null
 
-    private val _name = MutableStateFlow("")
-    private val _brandQuery = MutableStateFlow("")
-    private val _selectedBrandId = MutableStateFlow<Long?>(null)
-    private val _selectedCategory = MutableStateFlow<CategoryEntity?>(null)
-    private val _selectedSubcategory = MutableStateFlow<SubcategoryEntity?>(null)
-    private val _price = MutableStateFlow("")
-    private val _purchaseDate = MutableStateFlow<LocalDate?>(null)
-    private val _purchaseLocation = MutableStateFlow("")
-    private val _notes = MutableStateFlow("")
-    private val _imagePath = MutableStateFlow<String?>(null)
-    private val _selectedColors = MutableStateFlow<List<ColorEntity>>(emptyList())
-
-    private val _isNameError = MutableStateFlow(false)
-    private val _isSaving = MutableStateFlow(false)
-    private val _isLoading = MutableStateFlow(isEditMode)
-    private val _errorMessage = MutableStateFlow<Int?>(null)
+    private val _form = MutableStateFlow(FormState(isLoading = isEditMode))
 
     // To handle image replacement cleanup
     private var originalImagePath: String? = null
@@ -147,87 +126,43 @@ class ClothingFormViewModel @Inject constructor(
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
 
     @OptIn(ExperimentalCoroutinesApi::class)
-    val subcategories: StateFlow<List<SubcategoryEntity>> = _selectedCategory
+    val subcategories: StateFlow<List<SubcategoryEntity>> = _form
+        .map { it.category }
+        .distinctUntilChanged()
         .flatMapLatest { category ->
             if (category == null) flowOf(emptyList())
             else lookupRepository.getSubcategories(category.id)
         }
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
 
-    private val basicFields = combine(
-        combine(_name, _brandQuery, _selectedBrandId) { name, query, id -> Triple(name, query, id) },
-        _selectedCategory,
-        _selectedSubcategory,
-        _price
-    ) { (name, query, id), category, subcategory, price ->
-        FormBasic(name, query, id, category, subcategory, price)
-    }
-
-    private val detailFields = combine(
-        _purchaseDate, _purchaseLocation, _notes, _imagePath, _selectedColors
-    ) { date, location, notes, path, colors ->
-        FormDetails(date, location, notes, path, colors)
-    }
-
-    private val statusFields = combine(
-        _isNameError, _isSaving, _isLoading, _errorMessage
-    ) { nameError, saving, loading, error ->
-        FormStatus(nameError, saving, loading, error)
-    }
-
     val uiState: StateFlow<ClothingFormUiState> = combine(
-        combine(basicFields, detailFields, statusFields) { b, d, s -> Triple(b, d, s) },
-        categories,
-        subcategories,
-        allColors,
-        allBrands
-    ) { (basic, details, status), cats, subcats, colors, brands ->
-        val isDirty = if (isEditMode && originalEntity != null) {
-            val e = originalEntity!!
-            val colorsChanged = details.selectedColors.size != originalColors.size ||
-                    !details.selectedColors.containsAll(originalColors)
-
-            basic.name != e.name ||
-            basic.selectedBrandId != e.brandId ||
-            basic.category?.id != e.categoryId ||
-            basic.subcategory?.id != e.subcategoryId ||
-            basic.price != (e.purchasePrice?.toString() ?: "") ||
-            details.purchaseDate?.format(DateTimeFormatter.ISO_LOCAL_DATE) != e.purchaseDate ||
-            details.purchaseLocation != (e.purchaseLocation ?: "") ||
-            details.notes != (e.notes ?: "") ||
-            details.imagePath != e.imagePath ||
-            colorsChanged
-        } else {
-            basic.name.isNotBlank() || basic.brandQuery.isNotBlank() || basic.selectedBrandId != null || basic.category != null ||
-            basic.price.isNotBlank() || details.purchaseDate != null || details.purchaseLocation.isNotBlank() ||
-            details.notes.isNotBlank() || details.imagePath != null || details.selectedColors.isNotEmpty()
-        }
-
+        _form, categories, subcategories, allColors, allBrands
+    ) { form, cats, subcats, colors, brands ->
         ClothingFormUiState(
             isEditMode = isEditMode,
-            name = basic.name,
-            brandQuery = basic.brandQuery,
-            selectedBrandId = basic.selectedBrandId,
+            name = form.name,
+            brandQuery = form.brandQuery,
+            selectedBrandId = form.selectedBrandId,
             allBrands = brands,
-            category = basic.category,
-            subcategory = basic.subcategory,
-            price = basic.price,
-            purchaseDate = details.purchaseDate,
-            purchaseLocation = details.purchaseLocation,
-            notes = details.notes,
-            imagePath = details.imagePath,
-            imageFile = details.imagePath?.let { storageRepository.getFile(it) },
-            selectedColors = details.selectedColors,
-            isNameError = status.isNameError,
-            isSaving = status.isSaving,
-            isLoading = status.isLoading,
-            errorMessage = status.errorMessage,
+            category = form.category,
+            subcategory = form.subcategory,
+            price = form.price,
+            purchaseDate = form.purchaseDate,
+            purchaseLocation = form.purchaseLocation,
+            notes = form.notes,
+            imagePath = form.imagePath,
+            imageFile = form.imagePath?.let { storageRepository.getFile(it) },
+            selectedColors = form.selectedColors,
+            isNameError = form.isNameError,
+            isSaving = form.isSaving,
+            isLoading = form.isLoading,
+            errorMessage = form.errorMessage,
             categories = cats,
             subcategories = subcats,
             allColors = colors,
-            canSave = basic.name.isNotBlank() && !status.isSaving &&
-                    !(basic.brandQuery.isNotBlank() && basic.selectedBrandId == null),
-            isDirty = isDirty
+            canSave = form.name.isNotBlank() && !form.isSaving &&
+                    !(form.brandQuery.isNotBlank() && form.selectedBrandId == null),
+            isDirty = computeIsDirty(form)
         )
     }.stateIn(
         scope = viewModelScope,
@@ -241,70 +176,98 @@ class ClothingFormViewModel @Inject constructor(
         }
     }
 
+    private fun computeIsDirty(form: FormState): Boolean {
+        val original = originalEntity
+        if (isEditMode && original != null) {
+            val colorsChanged = form.selectedColors.size != originalColors.size ||
+                    !form.selectedColors.containsAll(originalColors)
+            return form.name != original.name ||
+                    form.selectedBrandId != original.brandId ||
+                    form.category?.id != original.categoryId ||
+                    form.subcategory?.id != original.subcategoryId ||
+                    form.price != (original.purchasePrice?.toString() ?: "") ||
+                    form.purchaseDate?.format(DateTimeFormatter.ISO_LOCAL_DATE) != original.purchaseDate ||
+                    form.purchaseLocation != (original.purchaseLocation ?: "") ||
+                    form.notes != (original.notes ?: "") ||
+                    form.imagePath != original.imagePath ||
+                    colorsChanged
+        }
+        return form.name.isNotBlank() || form.brandQuery.isNotBlank() || form.selectedBrandId != null ||
+                form.category != null || form.price.isNotBlank() || form.purchaseDate != null ||
+                form.purchaseLocation.isNotBlank() || form.notes.isNotBlank() ||
+                form.imagePath != null || form.selectedColors.isNotEmpty()
+    }
+
     private fun loadItemForEditing(id: Long) {
         viewModelScope.launch {
-            _isLoading.value = true
-            val entityResult = clothingRepository.getItemEntityById(id)
+            _form.update { it.copy(isLoading = true) }
+            try {
+                val entityResult = clothingRepository.getItemEntityById(id)
 
-            if (entityResult is DataResult.Success) {
-                val entity = entityResult.data
-                originalEntity = entity
-                originalImagePath = entity.imagePath
+                if (entityResult is DataResult.Success) {
+                    val entity = entityResult.data
+                    originalEntity = entity
+                    originalImagePath = entity.imagePath
 
-                // Hydrate the fields
-                _name.value = entity.name
-                _selectedBrandId.value = entity.brandId
-                if (entity.brandId != null) {
-                    val brands = brandRepository.getAllBrands().first()
-                    _brandQuery.value = brands.find { it.id == entity.brandId }?.name ?: ""
+                    // Hydrate the fields
+                    val brandName = if (entity.brandId != null) {
+                        brandRepository.getAllBrands().first().find { it.id == entity.brandId }?.name ?: ""
+                    } else ""
+
+                    val selectedCat = if (entity.categoryId != null) {
+                        lookupRepository.getCategories().first().find { it.id == entity.categoryId }
+                    } else null
+
+                    val selectedSub = if (selectedCat != null && entity.subcategoryId != null) {
+                        lookupRepository.getSubcategories(selectedCat.id).first()
+                            .find { it.id == entity.subcategoryId }
+                    } else null
+
+                    val colors = clothingRepository.getItemColors(id).first()
+                    originalColors = colors
+
+                    _form.update { it.copy(
+                        name = entity.name,
+                        selectedBrandId = entity.brandId,
+                        brandQuery = brandName,
+                        price = entity.purchasePrice?.toString() ?: "",
+                        purchaseDate = entity.purchaseDate?.let { d ->
+                            try { LocalDate.parse(d) } catch (_: Exception) { null }
+                        },
+                        purchaseLocation = entity.purchaseLocation ?: "",
+                        notes = entity.notes ?: "",
+                        imagePath = entity.imagePath,
+                        category = selectedCat,
+                        subcategory = selectedSub,
+                        selectedColors = colors,
+                        isLoading = false
+                    ) }
+                } else {
+                    _form.update { it.copy(
+                        errorMessage = R.string.wardrobe_error_load_failed,
+                        isLoading = false
+                    ) }
                 }
-                _price.value = entity.purchasePrice?.toString() ?: ""
-                _purchaseDate.value = entity.purchaseDate?.let { try { LocalDate.parse(it) } catch (_: Exception) { null } }
-                _purchaseLocation.value = entity.purchaseLocation ?: ""
-                _notes.value = entity.notes ?: ""
-                _imagePath.value = entity.imagePath
-
-                // Fetch Category and Subcategory entities for the selectors
-                val catId = entity.categoryId
-                if (catId != null) {
-                    val cats = lookupRepository.getCategories().first()
-                    val selectedCat = cats.find { it.id == catId }
-                    _selectedCategory.value = selectedCat
-
-                    val subId = entity.subcategoryId
-                    if (subId != null) {
-                        val subcats = lookupRepository.getSubcategories(catId).first()
-                        _selectedSubcategory.value = subcats.find { it.id == subId }
-                    }
-                }
-
-                // Hydrate colors
-                val colors = clothingRepository.getItemColors(id).first()
-                originalColors = colors
-                _selectedColors.value = colors
-            } else {
-                _errorMessage.value = R.string.wardrobe_error_load_failed
+            } catch (e: Exception) {
+                if (e is CancellationException) throw e
+                _form.update { it.copy(
+                    errorMessage = R.string.wardrobe_error_load_failed,
+                    isLoading = false
+                ) }
             }
-            _isLoading.value = false
         }
     }
 
     fun updateName(newName: String) {
-        _name.value = newName
-        _isNameError.value = false
+        _form.update { it.copy(name = newName, isNameError = false) }
     }
 
     fun onBrandQueryChange(text: String) {
-        _brandQuery.value = text
-        // Clear selection if the user edits the text away from the selected brand
-        if (_selectedBrandId.value != null) {
-            _selectedBrandId.value = null
-        }
+        _form.update { it.copy(brandQuery = text, selectedBrandId = null) }
     }
 
     fun onBrandSelect(brand: BrandEntity) {
-        _selectedBrandId.value = brand.id
-        _brandQuery.value = brand.name
+        _form.update { it.copy(selectedBrandId = brand.id, brandQuery = brand.name) }
     }
 
     fun onAddNewBrand(name: String) {
@@ -313,58 +276,57 @@ class ClothingFormViewModel @Inject constructor(
         viewModelScope.launch {
             when (val result = brandRepository.insertBrand(nameNormalized)) {
                 is DataResult.Success -> onBrandSelect(BrandEntity(id = result.data, name = nameNormalized))
-                is DataResult.Error -> _errorMessage.value = when (result.error) {
-                    is AppError.DatabaseError.ConstraintViolation -> R.string.wardrobe_error_brand_duplicate
-                    else -> R.string.wardrobe_error_brand_save_failed
-                }
+                is DataResult.Error -> _form.update { it.copy(
+                    errorMessage = when (result.error) {
+                        is AppError.DatabaseError.ConstraintViolation -> R.string.wardrobe_error_brand_duplicate
+                        else -> R.string.wardrobe_error_brand_save_failed
+                    }
+                ) }
                 else -> Unit
             }
         }
     }
 
     fun selectCategory(category: CategoryEntity?) {
-        _selectedCategory.value = category
-        _selectedSubcategory.value = null
+        _form.update { it.copy(category = category, subcategory = null) }
     }
 
     fun selectSubcategory(subcategory: SubcategoryEntity?) {
-        _selectedSubcategory.value = subcategory
+        _form.update { it.copy(subcategory = subcategory) }
     }
 
     fun updatePrice(newPrice: String) {
         if (newPrice.isEmpty() || newPrice.matches(Regex("""^\d*\.?\d{0,2}$"""))) {
-            _price.value = newPrice
+            _form.update { it.copy(price = newPrice) }
         }
     }
 
     fun updatePurchaseDate(date: LocalDate?) {
-        _purchaseDate.value = date
+        _form.update { it.copy(purchaseDate = date) }
     }
 
     fun updatePurchaseLocation(location: String) {
-        _purchaseLocation.value = location
+        _form.update { it.copy(purchaseLocation = location) }
     }
 
     fun updateNotes(newNotes: String) {
-        _notes.value = newNotes
+        _form.update { it.copy(notes = newNotes) }
     }
 
     fun onImageSelected(uri: Uri?) {
         if (uri == null) return
         viewModelScope.launch {
             try {
-                val previousPath = _imagePath.value
+                val previousPath = _form.value.imagePath
                 val relativePath = storageRepository.saveImage(uri)
-                _imagePath.value = relativePath
+                _form.update { it.copy(imagePath = relativePath) }
                 if (previousPath != null && previousPath != originalImagePath) {
                     storageRepository.deleteImage(previousPath)
                 }
-
-                // Process colors from the new image
                 extractColors(uri)
             } catch (e: Exception) {
                 if (e is CancellationException) throw e
-                _errorMessage.value = R.string.wardrobe_error_image_failed
+                _form.update { it.copy(errorMessage = R.string.wardrobe_error_image_failed) }
             }
         }
     }
@@ -387,7 +349,7 @@ class ClothingFormViewModel @Inject constructor(
                         ColorMatcher.findNearestColor(swatch.rgb, availableColors)
                     }.distinctBy { it.id }
 
-                    _selectedColors.value = snappedColors
+                    _form.update { it.copy(selectedColors = snappedColors) }
                 }
             }
         } catch (e: Exception) {
@@ -397,49 +359,52 @@ class ClothingFormViewModel @Inject constructor(
     }
 
     fun toggleColor(color: ColorEntity) {
-        val current = _selectedColors.value
-        _selectedColors.value = if (current.any { it.id == color.id }) {
-            current.filter { it.id != color.id }
-        } else {
-            current + color
+        _form.update { current ->
+            val updated = if (current.selectedColors.any { it.id == color.id }) {
+                current.selectedColors.filter { it.id != color.id }
+            } else {
+                current.selectedColors + color
+            }
+            current.copy(selectedColors = updated)
         }
     }
 
     fun updateColors(colorIds: List<Long>) {
         viewModelScope.launch {
             val colors = lookupRepository.getColors().first()
-            _selectedColors.value = colors.filter { it.id in colorIds }
+            _form.update { it.copy(selectedColors = colors.filter { c -> c.id in colorIds }) }
         }
     }
 
     fun onErrorConsumed() {
-        _errorMessage.value = null
+        _form.update { it.copy(errorMessage = null) }
     }
 
     fun save() {
-        if (_isSaving.value) return
-        if (_name.value.isBlank()) {
-            _isNameError.value = true
+        val currentForm = _form.value
+        if (currentForm.isSaving) return
+        if (currentForm.name.isBlank()) {
+            _form.update { it.copy(isNameError = true) }
             return
         }
-        if (_brandQuery.value.isNotBlank() && _selectedBrandId.value == null) return
+        if (currentForm.brandQuery.isNotBlank() && currentForm.selectedBrandId == null) return
 
-        _isSaving.value = true
-        _errorMessage.value = null
+        _form.update { it.copy(isSaving = true, errorMessage = null) }
 
         viewModelScope.launch {
             try {
+                val form = _form.value
                 val item = ClothingItemEntity(
                     id = itemId ?: 0,
-                    name = _name.value.trim(),
-                    brandId = _selectedBrandId.value,
-                    categoryId = _selectedCategory.value?.id,
-                    subcategoryId = _selectedSubcategory.value?.id,
-                    purchasePrice = _price.value.toDoubleOrNull(),
-                    purchaseDate = _purchaseDate.value?.format(DateTimeFormatter.ISO_LOCAL_DATE),
-                    purchaseLocation = _purchaseLocation.value.trim().takeIf { it.isNotBlank() },
-                    notes = _notes.value.trim().takeIf { it.isNotBlank() },
-                    imagePath = _imagePath.value,
+                    name = form.name.trim(),
+                    brandId = form.selectedBrandId,
+                    categoryId = form.category?.id,
+                    subcategoryId = form.subcategory?.id,
+                    purchasePrice = form.price.toDoubleOrNull(),
+                    purchaseDate = form.purchaseDate?.format(DateTimeFormatter.ISO_LOCAL_DATE),
+                    purchaseLocation = form.purchaseLocation.trim().takeIf { it.isNotBlank() },
+                    notes = form.notes.trim().takeIf { it.isNotBlank() },
+                    imagePath = form.imagePath,
                     status = originalEntity?.status ?: ClothingStatus.Active,
                     washStatus = originalEntity?.washStatus ?: WashStatus.Clean,
                     isFavorite = originalEntity?.isFavorite ?: 0,
@@ -448,25 +413,25 @@ class ClothingFormViewModel @Inject constructor(
                 )
 
                 val result = if (isEditMode) {
-                    clothingRepository.updateItemWithColors(item, _selectedColors.value)
+                    clothingRepository.updateItemWithColors(item, form.selectedColors)
                 } else {
-                    clothingRepository.insertItemWithColors(item, _selectedColors.value)
+                    clothingRepository.insertItemWithColors(item, form.selectedColors)
                 }
 
                 when (result) {
                     is DataResult.Success -> {
-                        if (isEditMode && _imagePath.value != originalImagePath) {
+                        if (isEditMode && form.imagePath != originalImagePath) {
                             originalImagePath?.let { storageRepository.deleteImage(it) }
                         }
                         _events.send(ClothingFormEvent.NavigateBack)
                     }
                     is DataResult.Error -> {
-                        _errorMessage.value = R.string.wardrobe_error_save_failed
+                        _form.update { it.copy(errorMessage = R.string.wardrobe_error_save_failed) }
                     }
                     else -> { /* No-op */ }
                 }
             } finally {
-                _isSaving.value = false
+                _form.update { it.copy(isSaving = false) }
             }
         }
     }

--- a/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/FormComponents.kt
+++ b/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/FormComponents.kt
@@ -145,7 +145,7 @@ internal fun ColorSelectionGrid(
             val hexColor = try {
                 Color(android.graphics.Color.parseColor(color.hex))
             } catch (_: Exception) {
-                Color.Gray
+                MaterialTheme.colorScheme.outlineVariant
             }
             val label = color.name.ifBlank { color.hex ?: "" }
 

--- a/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/FormComponents.kt
+++ b/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/FormComponents.kt
@@ -1,0 +1,312 @@
+package com.closet.features.wardrobe
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.CalendarMonth
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material3.DatePicker
+import androidx.compose.material3.DatePickerDialog
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExposedDropdownMenuBox
+import androidx.compose.material3.ExposedDropdownMenuDefaults
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.MenuAnchorType
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.rememberDatePickerState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.selected
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.unit.dp
+import com.closet.core.data.model.BrandEntity
+import com.closet.core.data.model.ColorEntity
+import java.time.Instant
+import java.time.LocalDate
+import java.time.ZoneId
+
+// ─── DropdownSelector ────────────────────────────────────────────────────────
+
+/**
+ * Generic nullable-selection dropdown backed by an arbitrary list.
+ *
+ * Renders an [OutlinedTextField] (read-only) with a Material trailing chevron and a
+ * [DropdownMenu] that always includes a "None / clear" row at the top.
+ *
+ * @param selectedItem  The currently selected item, or null.
+ * @param items         The full list of options to display.
+ * @param onItemSelect  Called with the selected item, or null when "None" is chosen.
+ * @param label         The floating label shown on the text field.
+ * @param itemLabel     Converts an item to its display string.
+ * @param enabled       When false the field is visually disabled and the menu cannot open.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+internal fun <T> DropdownSelector(
+    selectedItem: T?,
+    items: List<T>,
+    onItemSelect: (T?) -> Unit,
+    label: String,
+    itemLabel: (T) -> String,
+    enabled: Boolean = true,
+    modifier: Modifier = Modifier
+) {
+    var expanded by remember { mutableStateOf(false) }
+
+    Box(modifier = modifier.fillMaxWidth()) {
+        OutlinedTextField(
+            value = selectedItem?.let(itemLabel) ?: "",
+            onValueChange = {},
+            readOnly = true,
+            enabled = enabled,
+            label = { Text(label) },
+            modifier = Modifier.fillMaxWidth(),
+            trailingIcon = {
+                ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded)
+            },
+            colors = ExposedDropdownMenuDefaults.outlinedTextFieldColors()
+        )
+
+        if (enabled) {
+            Box(
+                modifier = Modifier
+                    .matchParentSize()
+                    .clickable { expanded = true }
+            )
+        }
+
+        DropdownMenu(
+            expanded = expanded,
+            onDismissRequest = { expanded = false },
+            modifier = Modifier.fillMaxWidth(0.9f)
+        ) {
+            DropdownMenuItem(
+                text = { Text(stringResource(R.string.wardrobe_field_none)) },
+                onClick = {
+                    onItemSelect(null)
+                    expanded = false
+                }
+            )
+            items.forEach { item ->
+                DropdownMenuItem(
+                    text = { Text(itemLabel(item)) },
+                    onClick = {
+                        onItemSelect(item)
+                        expanded = false
+                    }
+                )
+            }
+        }
+    }
+}
+
+// ─── ColorSelectionGrid ───────────────────────────────────────────────────────
+
+@Composable
+internal fun ColorSelectionGrid(
+    selectedColors: List<ColorEntity>,
+    allColors: List<ColorEntity>,
+    onColorToggle: (ColorEntity) -> Unit
+) {
+    LazyRow(
+        horizontalArrangement = Arrangement.spacedBy(12.dp),
+        contentPadding = androidx.compose.foundation.layout.PaddingValues(vertical = 4.dp)
+    ) {
+        items(allColors) { color ->
+            val isSelected = selectedColors.any { it.id == color.id }
+            val hexColor = try {
+                Color(android.graphics.Color.parseColor(color.hex))
+            } catch (_: Exception) {
+                Color.Gray
+            }
+            val label = color.name.ifBlank { color.hex ?: "" }
+
+            Box(
+                modifier = Modifier
+                    .size(48.dp)
+                    .semantics {
+                        contentDescription = label
+                        selected = isSelected
+                        role = Role.Checkbox
+                    }
+                    .clickable { onColorToggle(color) },
+                contentAlignment = Alignment.Center
+            ) {
+                Box(
+                    modifier = Modifier
+                        .size(44.dp)
+                        .clip(CircleShape)
+                        .background(hexColor)
+                        .border(
+                            width = if (isSelected) 3.dp else 1.dp,
+                            color = if (isSelected) MaterialTheme.colorScheme.primary
+                            else MaterialTheme.colorScheme.outlineVariant,
+                            shape = CircleShape
+                        ),
+                    contentAlignment = Alignment.Center
+                ) {
+                    if (isSelected) {
+                        Icon(
+                            imageVector = Icons.Default.Check,
+                            contentDescription = null,
+                            tint = if (isColorDark(hexColor)) Color.White else Color.Black,
+                            modifier = Modifier.size(24.dp)
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+internal fun isColorDark(color: Color): Boolean {
+    val luminance = 0.2126 * color.red + 0.7152 * color.green + 0.0722 * color.blue
+    return luminance < 0.5
+}
+
+// ─── DatePickerField ──────────────────────────────────────────────────────────
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+internal fun DatePickerField(
+    selectedDate: LocalDate?,
+    onDateChange: (LocalDate?) -> Unit
+) {
+    var showDatePicker by remember { mutableStateOf(false) }
+
+    OutlinedTextField(
+        value = selectedDate?.toString() ?: "",
+        onValueChange = {},
+        readOnly = true,
+        label = { Text(stringResource(R.string.wardrobe_field_purchase_date)) },
+        modifier = Modifier.fillMaxWidth(),
+        trailingIcon = {
+            IconButton(onClick = { showDatePicker = true }) {
+                Icon(imageVector = Icons.Default.CalendarMonth, contentDescription = null)
+            }
+        }
+    )
+
+    if (showDatePicker) {
+        val datePickerState = rememberDatePickerState(
+            initialSelectedDateMillis = selectedDate
+                ?.atStartOfDay(ZoneId.systemDefault())
+                ?.toInstant()
+                ?.toEpochMilli()
+        )
+        DatePickerDialog(
+            onDismissRequest = { showDatePicker = false },
+            confirmButton = {
+                TextButton(onClick = {
+                    datePickerState.selectedDateMillis?.let {
+                        val date = Instant.ofEpochMilli(it)
+                            .atZone(ZoneId.systemDefault())
+                            .toLocalDate()
+                        onDateChange(date)
+                    }
+                    showDatePicker = false
+                }) {
+                    Text(stringResource(R.string.wardrobe_date_confirm))
+                }
+            },
+            dismissButton = {
+                Row {
+                    TextButton(onClick = {
+                        onDateChange(null)
+                        showDatePicker = false
+                    }) {
+                        Text(stringResource(R.string.wardrobe_date_clear))
+                    }
+                    TextButton(onClick = { showDatePicker = false }) {
+                        Text(stringResource(R.string.wardrobe_date_cancel))
+                    }
+                }
+            }
+        ) {
+            DatePicker(state = datePickerState)
+        }
+    }
+}
+
+// ─── BrandAutocompleteField ───────────────────────────────────────────────────
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+internal fun BrandAutocompleteField(
+    query: String,
+    allBrands: List<BrandEntity>,
+    onQueryChange: (String) -> Unit,
+    onBrandSelect: (BrandEntity) -> Unit,
+    onAddNewBrand: (String) -> Unit
+) {
+    val filteredBrands = allBrands.filter { it.name.contains(query, ignoreCase = true) }
+    val showAddOption = query.isNotBlank() &&
+            filteredBrands.none { it.name.equals(query, ignoreCase = true) }
+
+    var expanded by remember { mutableStateOf(false) }
+
+    ExposedDropdownMenuBox(
+        expanded = expanded,
+        onExpandedChange = { expanded = it }
+    ) {
+        OutlinedTextField(
+            value = query,
+            onValueChange = { onQueryChange(it); expanded = true },
+            label = { Text(stringResource(R.string.wardrobe_field_brand)) },
+            trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded) },
+            singleLine = true,
+            modifier = Modifier
+                .fillMaxWidth()
+                .menuAnchor(MenuAnchorType.PrimaryEditable)
+        )
+
+        ExposedDropdownMenu(
+            expanded = expanded && (filteredBrands.isNotEmpty() || showAddOption),
+            onDismissRequest = { expanded = false }
+        ) {
+            filteredBrands.forEach { brand ->
+                DropdownMenuItem(
+                    text = { Text(brand.name) },
+                    onClick = { onBrandSelect(brand); expanded = false }
+                )
+            }
+            if (showAddOption) {
+                HorizontalDivider()
+                DropdownMenuItem(
+                    text = { Text(stringResource(R.string.wardrobe_brand_add, query)) },
+                    leadingIcon = { Icon(Icons.Default.Add, contentDescription = null) },
+                    onClick = { onAddNewBrand(query); expanded = false }
+                )
+            }
+        }
+    }
+}
+

--- a/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/FormPreviews.kt
+++ b/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/FormPreviews.kt
@@ -1,0 +1,246 @@
+package com.closet.features.wardrobe
+
+import android.content.res.Configuration
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Surface
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.closet.core.data.model.BrandEntity
+import com.closet.core.data.model.CategoryEntity
+import com.closet.core.data.model.ColorEntity
+import com.closet.core.data.model.SubcategoryEntity
+import com.closet.core.ui.theme.ClosetTheme
+
+// ─── Shared preview data ──────────────────────────────────────────────────────
+
+internal val previewCategories = listOf(
+    CategoryEntity(id = 1L, name = "Tops", sortOrder = 1),
+    CategoryEntity(id = 2L, name = "Bottoms", sortOrder = 2),
+    CategoryEntity(id = 3L, name = "Shoes", sortOrder = 3),
+)
+
+internal val previewSubcategories = listOf(
+    SubcategoryEntity(id = 1L, categoryId = 1L, name = "T-Shirts", sortOrder = 1),
+    SubcategoryEntity(id = 2L, categoryId = 1L, name = "Jackets", sortOrder = 2),
+)
+
+internal val previewColors = listOf(
+    ColorEntity(id = 1L, name = "Black", hex = "#000000"),
+    ColorEntity(id = 2L, name = "White", hex = "#FFFFFF"),
+    ColorEntity(id = 3L, name = "Navy", hex = "#001F5B"),
+    ColorEntity(id = 4L, name = "Red", hex = "#CC0000"),
+    ColorEntity(id = 5L, name = "Olive", hex = "#708238"),
+    ColorEntity(id = 6L, name = "Tan", hex = "#D2B48C"),
+)
+
+internal val previewBrands = listOf(
+    BrandEntity(id = 1L, name = "Nike"),
+    BrandEntity(id = 2L, name = "Levi's"),
+    BrandEntity(id = 3L, name = "Uniqlo"),
+)
+
+// ─── ClothingFormTopBar previews ──────────────────────────────────────────────
+
+@Preview(showBackground = true, name = "Top Bar - Add Mode")
+@Composable
+private fun ClothingFormTopBarAddPreview() {
+    ClosetTheme {
+        Surface {
+            ClothingFormTopBar(
+                isEditMode = false,
+                canSave = false,
+                onBackClick = {},
+                onSaveClick = {}
+            )
+        }
+    }
+}
+
+@Preview(showBackground = true, name = "Top Bar - Edit Mode - Can Save")
+@Composable
+private fun ClothingFormTopBarEditPreview() {
+    ClosetTheme {
+        Surface {
+            ClothingFormTopBar(
+                isEditMode = true,
+                canSave = true,
+                onBackClick = {},
+                onSaveClick = {}
+            )
+        }
+    }
+}
+
+// ─── ClothingFormContent previews ─────────────────────────────────────────────
+
+@Preview(showBackground = true, name = "Form - Empty/Add Mode - Light")
+@Preview(showBackground = true, uiMode = Configuration.UI_MODE_NIGHT_YES, name = "Form - Empty/Add Mode - Dark")
+@Composable
+private fun ClothingFormContentEmptyPreview() {
+    ClosetTheme {
+        Surface {
+            ClothingFormContent(
+                uiState = ClothingFormUiState(
+                    isEditMode = false,
+                    categories = previewCategories,
+                    allColors = previewColors,
+                    allBrands = previewBrands
+                ),
+                onNameChange = {},
+                onBrandQueryChange = {},
+                onBrandSelect = {},
+                onAddNewBrand = {},
+                onManageBrands = {},
+                onCategorySelect = {},
+                onSubcategorySelect = {},
+                onPriceChange = {},
+                onDateChange = {},
+                onLocationChange = {},
+                onNotesChange = {},
+                onImageClick = {},
+                onColorToggle = {}
+            )
+        }
+    }
+}
+
+@Preview(showBackground = true, name = "Form - Partially Filled")
+@Composable
+private fun ClothingFormContentFilledPreview() {
+    ClosetTheme {
+        Surface {
+            ClothingFormContent(
+                uiState = ClothingFormUiState(
+                    isEditMode = true,
+                    name = "Vintage Denim Jacket",
+                    brandQuery = "Levi's",
+                    category = previewCategories[0],
+                    subcategory = previewSubcategories[1],
+                    price = "85.00",
+                    purchaseLocation = "Brooklyn Thrift Store",
+                    categories = previewCategories,
+                    subcategories = previewSubcategories,
+                    allColors = previewColors,
+                    selectedColors = listOf(previewColors[2]),
+                    allBrands = previewBrands,
+                    canSave = true,
+                    isDirty = true
+                ),
+                onNameChange = {},
+                onBrandQueryChange = {},
+                onBrandSelect = {},
+                onAddNewBrand = {},
+                onManageBrands = {},
+                onCategorySelect = {},
+                onSubcategorySelect = {},
+                onPriceChange = {},
+                onDateChange = {},
+                onLocationChange = {},
+                onNotesChange = {},
+                onImageClick = {},
+                onColorToggle = {}
+            )
+        }
+    }
+}
+
+// ─── FormComponents previews ──────────────────────────────────────────────────
+
+@Preview(showBackground = true, name = "DropdownSelector - Category Selected")
+@Composable
+private fun DropdownSelectorCategoryPreview() {
+    ClosetTheme {
+        Surface {
+            Column(modifier = Modifier.padding(16.dp)) {
+                DropdownSelector(
+                    selectedItem = previewCategories[0],
+                    items = previewCategories,
+                    onItemSelect = {},
+                    label = "Category",
+                    itemLabel = { it.name }
+                )
+            }
+        }
+    }
+}
+
+@Preview(showBackground = true, name = "DropdownSelector - Subcategory Enabled")
+@Preview(showBackground = true, name = "DropdownSelector - Subcategory Disabled")
+@Composable
+private fun DropdownSelectorSubcategoryPreview() {
+    ClosetTheme {
+        Surface {
+            Column(
+                modifier = Modifier.padding(16.dp),
+                verticalArrangement = Arrangement.spacedBy(16.dp)
+            ) {
+                DropdownSelector(
+                    selectedItem = previewSubcategories[0],
+                    items = previewSubcategories,
+                    onItemSelect = {},
+                    label = "Subcategory",
+                    itemLabel = { it.name },
+                    enabled = true
+                )
+                DropdownSelector(
+                    selectedItem = null,
+                    items = emptyList(),
+                    onItemSelect = {},
+                    label = "Subcategory",
+                    itemLabel = { it.name },
+                    enabled = false
+                )
+            }
+        }
+    }
+}
+
+@Preview(showBackground = true, name = "Color Selection Grid")
+@Composable
+private fun ColorSelectionGridPreview() {
+    ClosetTheme {
+        Surface {
+            Column(modifier = Modifier.padding(16.dp)) {
+                ColorSelectionGrid(
+                    allColors = previewColors,
+                    selectedColors = listOf(previewColors[0], previewColors[2]),
+                    onColorToggle = {}
+                )
+            }
+        }
+    }
+}
+
+@Preview(showBackground = true, name = "Date Picker Field - No Date")
+@Composable
+private fun DatePickerFieldPreview() {
+    ClosetTheme {
+        Surface {
+            Column(modifier = Modifier.padding(16.dp)) {
+                DatePickerField(selectedDate = null, onDateChange = {})
+            }
+        }
+    }
+}
+
+@Preview(showBackground = true, name = "Brand Autocomplete - With Results")
+@Composable
+private fun BrandAutocompleteFieldPreview() {
+    ClosetTheme {
+        Surface {
+            Column(modifier = Modifier.padding(16.dp)) {
+                BrandAutocompleteField(
+                    query = "Ni",
+                    allBrands = previewBrands,
+                    onQueryChange = {},
+                    onBrandSelect = {},
+                    onAddNewBrand = {}
+                )
+            }
+        }
+    }
+}

--- a/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/FormPreviews.kt
+++ b/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/FormPreviews.kt
@@ -188,7 +188,7 @@ private fun DropdownSelectorSubcategoryPreview() {
                 )
                 DropdownSelector(
                     selectedItem = null,
-                    items = emptyList(),
+                    items = emptyList<SubcategoryEntity>(),
                     onItemSelect = {},
                     label = "Subcategory",
                     itemLabel = { it.name },

--- a/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/MultiSelectSheet.kt
+++ b/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/MultiSelectSheet.kt
@@ -24,7 +24,7 @@ import com.closet.core.ui.theme.ClosetTheme
 /**
  * Generic multi-select item for the bottom sheet.
  */
-data class MultiSelectItem<T>(
+data class MultiSelectItem<out T>(
     val id: Long,
     val label: String,
     val original: T,

--- a/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/MultiSelectSheet.kt
+++ b/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/MultiSelectSheet.kt
@@ -1,5 +1,6 @@
 package com.closet.features.wardrobe
 
+import android.content.res.Configuration
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
@@ -15,8 +16,10 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.core.graphics.toColorInt
+import com.closet.core.ui.theme.ClosetTheme
 
 /**
  * Generic multi-select item for the bottom sheet.
@@ -142,3 +145,92 @@ private fun MultiSelectRow(
         }
     )
 }
+
+// region Previews
+
+private val previewColorItems = listOf(
+    MultiSelectItem(1L, "Black", Unit, colorHex = "#000000"),
+    MultiSelectItem(2L, "White", Unit, colorHex = "#FFFFFF"),
+    MultiSelectItem(3L, "Navy", Unit, colorHex = "#001F5B"),
+    MultiSelectItem(4L, "Red", Unit, colorHex = "#CC0000"),
+    MultiSelectItem(5L, "Olive", Unit, colorHex = "#708238"),
+)
+
+private val previewLabelItems = listOf(
+    MultiSelectItem(1L, "Spring", Unit),
+    MultiSelectItem(2L, "Summer", Unit),
+    MultiSelectItem(3L, "Fall", Unit),
+    MultiSelectItem(4L, "Winter", Unit),
+)
+
+@Composable
+private fun MultiSelectSheetContentPreview(
+    title: String,
+    items: List<MultiSelectItem<Unit>>,
+    selectedIds: Set<Long>
+) {
+    // Render the inner sheet content directly (ModalBottomSheet not renderable in preview)
+    Surface(color = MaterialTheme.colorScheme.surface) {
+        Column(modifier = Modifier.fillMaxWidth()) {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp, vertical = 8.dp),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text(title, style = MaterialTheme.typography.titleLarge, fontWeight = FontWeight.Bold)
+                TextButton(onClick = {}) { Text("Save") }
+            }
+            HorizontalDivider()
+            items.forEach { item ->
+                MultiSelectRow(
+                    label = item.label,
+                    colorHex = item.colorHex,
+                    iconResId = item.iconResId,
+                    isSelected = item.id in selectedIds,
+                    onToggle = {}
+                )
+            }
+        }
+    }
+}
+
+@Preview(showBackground = true, name = "Color Picker - Light")
+@Preview(showBackground = true, uiMode = Configuration.UI_MODE_NIGHT_YES, name = "Color Picker - Dark")
+@Composable
+private fun MultiSelectSheetColorsPreview() {
+    ClosetTheme {
+        MultiSelectSheetContentPreview(
+            title = "Colors",
+            items = previewColorItems,
+            selectedIds = setOf(1L, 3L)
+        )
+    }
+}
+
+@Preview(showBackground = true, name = "Label Picker - Partial Selection")
+@Composable
+private fun MultiSelectSheetLabelsPreview() {
+    ClosetTheme {
+        MultiSelectSheetContentPreview(
+            title = "Seasons",
+            items = previewLabelItems,
+            selectedIds = setOf(2L)
+        )
+    }
+}
+
+@Preview(showBackground = true, name = "Empty State")
+@Composable
+private fun MultiSelectSheetEmptyPreview() {
+    ClosetTheme {
+        MultiSelectSheetContentPreview(
+            title = "Materials",
+            items = emptyList(),
+            selectedIds = emptySet()
+        )
+    }
+}
+
+// endregion

--- a/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/WardrobeNavigation.kt
+++ b/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/WardrobeNavigation.kt
@@ -3,19 +3,26 @@ package com.closet.features.wardrobe
 import kotlinx.serialization.Serializable
 
 /**
- * Type-Safe Navigation Destinations for the Wardrobe feature.
+ * Type-safe navigation destinations for the Wardrobe feature.
+ * All destinations are `@Serializable` for use with Compose Navigation 2.9.7+ type-safe routes.
  */
+
+/** Route for the main Closet screen (item grid/list). */
 @Serializable
 object ClosetDestination
 
+/** Route for the Clothing Detail screen, parameterised by [itemId]. */
 @Serializable
 data class ClothingDetailDestination(val itemId: Long)
 
+/** Route for the Add Clothing form (no pre-populated item ID). */
 @Serializable
 object AddClothingDestination
 
+/** Route for the Edit Clothing form, parameterised by [itemId]. */
 @Serializable
 data class EditClothingDestination(val itemId: Long)
 
+/** Route for the Brand Management screen. */
 @Serializable
 object BrandManagementDestination

--- a/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/WardrobeNavigation.kt
+++ b/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/WardrobeNavigation.kt
@@ -16,3 +16,6 @@ object AddClothingDestination
 
 @Serializable
 data class EditClothingDestination(val itemId: Long)
+
+@Serializable
+object BrandManagementDestination

--- a/app-android/features/wardrobe/src/main/res/values/strings.xml
+++ b/app-android/features/wardrobe/src/main/res/values/strings.xml
@@ -62,6 +62,8 @@
     <string name="wardrobe_discard_changes_title">Discard Changes?</string>
     <string name="wardrobe_discard_changes_message">You have unsaved changes. Are you sure you want to discard them?</string>
     <string name="wardrobe_discard">Discard</string>
+    <string name="wardrobe_error_brand_duplicate">A brand with that name already exists.</string>
+    <string name="wardrobe_error_brand_save_failed">Failed to save brand. Please try again.</string>
     <string name="wardrobe_error_save_failed">Failed to save item. Please try again.</string>
     <string name="wardrobe_error_load_failed">Failed to load item. Please try again.</string>
     <string name="wardrobe_error_image_failed">Failed to save photo. Please try again.</string>
@@ -89,8 +91,11 @@
     <string name="brand_management_delete_confirm_message">Delete \"%1$s\"? This cannot be undone.</string>
     <!-- Title of the dialog shown when the user tries to delete a brand that is still in use -->
     <string name="brand_management_delete_blocked_title">Cannot Delete Brand</string>
-    <!-- Body of the blocked-delete dialog. %1$s is the brand name; %2$d is the number of items still assigned to it. -->
-    <string name="brand_management_delete_blocked_message">\"%1$s\" is used by %2$d item(s). Reassign them before deleting.</string>
+    <!-- Body of the blocked-delete dialog. %1$s is the brand name; %2$d is the item count (other only). -->
+    <plurals name="brand_management_delete_blocked_message">
+        <item quantity="one">\"%1$s\" is used by 1 item. Reassign it before deleting.</item>
+        <item quantity="other">\"%1$s\" is used by %2$d items. Reassign them before deleting.</item>
+    </plurals>
     <!-- Destructive action button label in the delete-confirmation dialog -->
     <string name="brand_management_confirm_delete">Delete</string>
     <!-- Content description for the FAB that opens the add-brand inline row -->

--- a/app-android/features/wardrobe/src/main/res/values/strings.xml
+++ b/app-android/features/wardrobe/src/main/res/values/strings.xml
@@ -42,6 +42,7 @@
     <string name="wardrobe_brand">Brand</string>
     <string name="wardrobe_field_name">Name</string>
     <string name="wardrobe_field_brand">Brand</string>
+    <string name="wardrobe_brand_add">Add \"%1$s\" as new brand</string>
     <string name="wardrobe_field_category">Category</string>
     <string name="wardrobe_field_subcategory">Subcategory</string>
     <string name="wardrobe_field_price">Purchase Price</string>

--- a/app-android/features/wardrobe/src/main/res/values/strings.xml
+++ b/app-android/features/wardrobe/src/main/res/values/strings.xml
@@ -73,4 +73,33 @@
     <string name="wardrobe_date_confirm">OK</string>
     <string name="wardrobe_date_cancel">Cancel</string>
     <string name="wardrobe_date_clear">Clear</string>
+
+    <!-- Brand Management — screen for viewing, adding, editing, and deleting clothing brands -->
+    <!-- Title shown in the top app bar of the brand management screen -->
+    <string name="brand_management_title">Manage Brands</string>
+    <!-- Floating label on the text field used to enter a new brand name -->
+    <string name="brand_management_new_brand_hint">New brand name</string>
+    <!-- Floating label on the inline text field when editing an existing brand name -->
+    <string name="brand_management_edit_hint">Brand name</string>
+    <!-- Shown in the centre of the screen when no brands have been added yet -->
+    <string name="brand_management_empty">No brands yet. Tap + to add one.</string>
+    <!-- Title of the confirmation dialog before deleting a brand that has no items assigned to it -->
+    <string name="brand_management_delete_confirm_title">Delete Brand</string>
+    <!-- Body of the confirmation dialog. %1$s is the brand name. -->
+    <string name="brand_management_delete_confirm_message">Delete \"%1$s\"? This cannot be undone.</string>
+    <!-- Title of the dialog shown when the user tries to delete a brand that is still in use -->
+    <string name="brand_management_delete_blocked_title">Cannot Delete Brand</string>
+    <!-- Body of the blocked-delete dialog. %1$s is the brand name; %2$d is the number of items still assigned to it. -->
+    <string name="brand_management_delete_blocked_message">\"%1$s\" is used by %2$d item(s). Reassign them before deleting.</string>
+    <!-- Destructive action button label in the delete-confirmation dialog -->
+    <string name="brand_management_confirm_delete">Delete</string>
+    <!-- Content description for the FAB that opens the add-brand inline row -->
+    <string name="brand_management_add_brand">Add brand</string>
+    <!-- Content description for the icon button next to the brand field that opens the brand management screen -->
+    <string name="brand_management_manage_brands">Manage brands</string>
+    <!-- Number of clothing items assigned to a brand. %d is the count. -->
+    <plurals name="brand_item_count">
+        <item quantity="one">%d item</item>
+        <item quantity="other">%d items</item>
+    </plurals>
 </resources>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Brand management screen (create/edit/delete) with navigation entry
  * Brand autocomplete in item form with “Add as new brand” flow; brands are selectable references
  * Deletion prevented when a brand is still used by items

* **Documentation**
  * Added brand-lookup roadmap and architecture roadmap

* **Database**
  * New brands table, seeding/backfill and migrations to migrate brand text into referenced brands
<!-- end of auto-generated comment: release notes by coderabbit.ai -->