### PR TITLE
Add weather forecasting system with service integrations

### DIFF
--- a/app-android/app/src/main/AndroidManifest.xml
+++ b/app-android/app/src/main/AndroidManifest.xml
@@ -3,6 +3,7 @@
     package="com.closet">
 
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
 
     <application
         android:name=".ClosetApp"

--- a/app-android/app/src/main/AndroidManifest.xml
+++ b/app-android/app/src/main/AndroidManifest.xml
@@ -2,6 +2,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.closet">
 
+    <uses-permission android:name="android.permission.INTERNET" />
+
     <application
         android:name=".ClosetApp"
         android:allowBackup="true"

--- a/app-android/core/data/build.gradle.kts
+++ b/app-android/core/data/build.gradle.kts
@@ -48,6 +48,9 @@ dependencies {
     // Palette
     implementation(libs.androidx.palette.ktx)
 
+    // DataStore
+    implementation(libs.androidx.datastore.preferences)
+
     // Logging
     implementation(libs.timber)
 

--- a/app-android/core/data/build.gradle.kts
+++ b/app-android/core/data/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     alias(libs.plugins.android.library)
     alias(libs.plugins.kotlin.android)
+    alias(libs.plugins.kotlin.serialization)
     alias(libs.plugins.ksp)
     alias(libs.plugins.hilt)
 }
@@ -54,6 +55,9 @@ dependencies {
 
     // DataStore
     implementation(libs.androidx.datastore.preferences)
+
+    // Serialization (for cache DTOs + service response parsing)
+    implementation(libs.kotlinx.serialization.json)
 
     // Ktor HTTP client
     implementation(libs.ktor.client.okhttp)

--- a/app-android/core/data/build.gradle.kts
+++ b/app-android/core/data/build.gradle.kts
@@ -18,6 +18,10 @@ android {
         getByName("androidTest").assets.srcDirs("$projectDir/schemas")
     }
 
+    buildFeatures {
+        buildConfig = true
+    }
+
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17
@@ -50,6 +54,12 @@ dependencies {
 
     // DataStore
     implementation(libs.androidx.datastore.preferences)
+
+    // Ktor HTTP client
+    implementation(libs.ktor.client.okhttp)
+    implementation(libs.ktor.client.content.negotiation)
+    implementation(libs.ktor.serialization.kotlinx.json)
+    implementation(libs.ktor.client.logging)
 
     // Logging
     implementation(libs.timber)

--- a/app-android/core/data/schemas/com.closet.core.data.ClothingDatabase/2.json
+++ b/app-android/core/data/schemas/com.closet.core.data.ClothingDatabase/2.json
@@ -1,0 +1,1224 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 2,
+    "identityHash": "62fb5d004ac2c2ab993a8ae757a34b8b",
+    "entities": [
+      {
+        "tableName": "clothing_items",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `brand` TEXT, `brand_id` INTEGER, `category_id` INTEGER, `subcategory_id` INTEGER, `size_value_id` INTEGER, `waist` REAL, `inseam` REAL, `purchase_price` REAL, `purchase_date` TEXT, `purchase_location` TEXT, `image_path` TEXT, `notes` TEXT, `status` TEXT NOT NULL DEFAULT 'Active', `wash_status` TEXT NOT NULL DEFAULT 'Clean', `is_favorite` INTEGER NOT NULL, `created_at` TEXT NOT NULL, `updated_at` TEXT NOT NULL, FOREIGN KEY(`category_id`) REFERENCES `categories`(`id`) ON UPDATE NO ACTION ON DELETE SET NULL , FOREIGN KEY(`subcategory_id`) REFERENCES `subcategories`(`id`) ON UPDATE NO ACTION ON DELETE SET NULL , FOREIGN KEY(`size_value_id`) REFERENCES `size_values`(`id`) ON UPDATE NO ACTION ON DELETE SET NULL , FOREIGN KEY(`brand_id`) REFERENCES `brands`(`id`) ON UPDATE NO ACTION ON DELETE SET NULL )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "brand",
+            "columnName": "brand",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "brandId",
+            "columnName": "brand_id",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "categoryId",
+            "columnName": "category_id",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "subcategoryId",
+            "columnName": "subcategory_id",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "sizeValueId",
+            "columnName": "size_value_id",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "waist",
+            "columnName": "waist",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "inseam",
+            "columnName": "inseam",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "purchasePrice",
+            "columnName": "purchase_price",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "purchaseDate",
+            "columnName": "purchase_date",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "purchaseLocation",
+            "columnName": "purchase_location",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "imagePath",
+            "columnName": "image_path",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "notes",
+            "columnName": "notes",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'Active'"
+          },
+          {
+            "fieldPath": "washStatus",
+            "columnName": "wash_status",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'Clean'"
+          },
+          {
+            "fieldPath": "isFavorite",
+            "columnName": "is_favorite",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_clothing_items_category_id",
+            "unique": false,
+            "columnNames": [
+              "category_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_clothing_items_category_id` ON `${TABLE_NAME}` (`category_id`)"
+          },
+          {
+            "name": "index_clothing_items_subcategory_id",
+            "unique": false,
+            "columnNames": [
+              "subcategory_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_clothing_items_subcategory_id` ON `${TABLE_NAME}` (`subcategory_id`)"
+          },
+          {
+            "name": "index_clothing_items_size_value_id",
+            "unique": false,
+            "columnNames": [
+              "size_value_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_clothing_items_size_value_id` ON `${TABLE_NAME}` (`size_value_id`)"
+          },
+          {
+            "name": "index_clothing_items_brand_id",
+            "unique": false,
+            "columnNames": [
+              "brand_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_clothing_items_brand_id` ON `${TABLE_NAME}` (`brand_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "categories",
+            "onDelete": "SET NULL",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "category_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "subcategories",
+            "onDelete": "SET NULL",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "subcategory_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "size_values",
+            "onDelete": "SET NULL",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "size_value_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "brands",
+            "onDelete": "SET NULL",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "brand_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "brands",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `normalized_name` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "normalizedName",
+            "columnName": "normalized_name",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_brands_normalized_name",
+            "unique": true,
+            "columnNames": [
+              "normalized_name"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_brands_normalized_name` ON `${TABLE_NAME}` (`normalized_name`)"
+          }
+        ]
+      },
+      {
+        "tableName": "categories",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `icon` TEXT, `sort_order` INTEGER NOT NULL, `warmth_layer` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "icon",
+            "columnName": "icon",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sortOrder",
+            "columnName": "sort_order",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "warmthLayer",
+            "columnName": "warmth_layer",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "subcategories",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `category_id` INTEGER NOT NULL, `name` TEXT NOT NULL, `sort_order` INTEGER NOT NULL, FOREIGN KEY(`category_id`) REFERENCES `categories`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "categoryId",
+            "columnName": "category_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sortOrder",
+            "columnName": "sort_order",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_subcategories_category_id",
+            "unique": false,
+            "columnNames": [
+              "category_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_subcategories_category_id` ON `${TABLE_NAME}` (`category_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "categories",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "category_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "seasons",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `icon` TEXT, `temp_low_c` REAL, `temp_high_c` REAL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "icon",
+            "columnName": "icon",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "tempLowC",
+            "columnName": "temp_low_c",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "tempHighC",
+            "columnName": "temp_high_c",
+            "affinity": "REAL"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "occasions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `icon` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "icon",
+            "columnName": "icon",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "colors",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `hex` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hex",
+            "columnName": "hex",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "materials",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "patterns",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `icon` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "icon",
+            "columnName": "icon",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "size_systems",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "size_values",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `size_system_id` INTEGER NOT NULL, `value` TEXT NOT NULL, `sort_order` INTEGER NOT NULL, FOREIGN KEY(`size_system_id`) REFERENCES `size_systems`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sizeSystemId",
+            "columnName": "size_system_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "value",
+            "columnName": "value",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sortOrder",
+            "columnName": "sort_order",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_size_values_size_system_id",
+            "unique": false,
+            "columnNames": [
+              "size_system_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_size_values_size_system_id` ON `${TABLE_NAME}` (`size_system_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "size_systems",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "size_system_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "outfits",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT, `notes` TEXT, `created_at` TEXT NOT NULL, `updated_at` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "notes",
+            "columnName": "notes",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "outfit_items",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`outfit_id` INTEGER NOT NULL, `clothing_item_id` INTEGER NOT NULL, `pos_x` REAL, `pos_y` REAL, `scale` REAL, `z_index` INTEGER, PRIMARY KEY(`outfit_id`, `clothing_item_id`), FOREIGN KEY(`outfit_id`) REFERENCES `outfits`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`clothing_item_id`) REFERENCES `clothing_items`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "outfitId",
+            "columnName": "outfit_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "clothingItemId",
+            "columnName": "clothing_item_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "posX",
+            "columnName": "pos_x",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "posY",
+            "columnName": "pos_y",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "scale",
+            "columnName": "scale",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "zIndex",
+            "columnName": "z_index",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "outfit_id",
+            "clothing_item_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_outfit_items_clothing_item_id",
+            "unique": false,
+            "columnNames": [
+              "clothing_item_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_outfit_items_clothing_item_id` ON `${TABLE_NAME}` (`clothing_item_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "outfits",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "outfit_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "clothing_items",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "clothing_item_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "outfit_logs",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `outfit_id` INTEGER, `date` TEXT NOT NULL, `is_ootd` INTEGER NOT NULL, `notes` TEXT, `temperature_low` REAL, `temperature_high` REAL, `weather_condition` TEXT, `precipitation_mm` REAL, `wind_speed_kmh` REAL, `created_at` TEXT NOT NULL, FOREIGN KEY(`outfit_id`) REFERENCES `outfits`(`id`) ON UPDATE NO ACTION ON DELETE SET NULL )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "outfitId",
+            "columnName": "outfit_id",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "date",
+            "columnName": "date",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isOotd",
+            "columnName": "is_ootd",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "notes",
+            "columnName": "notes",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "temperatureLow",
+            "columnName": "temperature_low",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "temperatureHigh",
+            "columnName": "temperature_high",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "weatherCondition",
+            "columnName": "weather_condition",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "precipitationMm",
+            "columnName": "precipitation_mm",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "windSpeedKmh",
+            "columnName": "wind_speed_kmh",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_outfit_logs_outfit_id",
+            "unique": false,
+            "columnNames": [
+              "outfit_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_outfit_logs_outfit_id` ON `${TABLE_NAME}` (`outfit_id`)"
+          },
+          {
+            "name": "index_outfit_logs_date",
+            "unique": false,
+            "columnNames": [
+              "date"
+            ],
+            "orders": [
+              "ASC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_outfit_logs_date` ON `${TABLE_NAME}` (`date` ASC)"
+          },
+          {
+            "name": "index_outfit_logs_outfit_id_date",
+            "unique": true,
+            "columnNames": [
+              "outfit_id",
+              "date"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_outfit_logs_outfit_id_date` ON `${TABLE_NAME}` (`outfit_id`, `date`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "outfits",
+            "onDelete": "SET NULL",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "outfit_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "outfit_log_items",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`outfit_log_id` INTEGER NOT NULL, `clothing_item_id` INTEGER NOT NULL, `outfit_name` TEXT, PRIMARY KEY(`outfit_log_id`, `clothing_item_id`), FOREIGN KEY(`outfit_log_id`) REFERENCES `outfit_logs`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "outfitLogId",
+            "columnName": "outfit_log_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "clothingItemId",
+            "columnName": "clothing_item_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "outfitName",
+            "columnName": "outfit_name",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "outfit_log_id",
+            "clothing_item_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_outfit_log_items_clothing_item_id",
+            "unique": false,
+            "columnNames": [
+              "clothing_item_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_outfit_log_items_clothing_item_id` ON `${TABLE_NAME}` (`clothing_item_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "outfit_logs",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "outfit_log_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "clothing_item_colors",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`clothing_item_id` INTEGER NOT NULL, `color_id` INTEGER NOT NULL, PRIMARY KEY(`clothing_item_id`, `color_id`), FOREIGN KEY(`clothing_item_id`) REFERENCES `clothing_items`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`color_id`) REFERENCES `colors`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "clothingItemId",
+            "columnName": "clothing_item_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "colorId",
+            "columnName": "color_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "clothing_item_id",
+            "color_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_clothing_item_colors_color_id",
+            "unique": false,
+            "columnNames": [
+              "color_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_clothing_item_colors_color_id` ON `${TABLE_NAME}` (`color_id`)"
+          },
+          {
+            "name": "index_clothing_item_colors_clothing_item_id",
+            "unique": false,
+            "columnNames": [
+              "clothing_item_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_clothing_item_colors_clothing_item_id` ON `${TABLE_NAME}` (`clothing_item_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "clothing_items",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "clothing_item_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "colors",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "color_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "clothing_item_materials",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`clothing_item_id` INTEGER NOT NULL, `material_id` INTEGER NOT NULL, PRIMARY KEY(`clothing_item_id`, `material_id`), FOREIGN KEY(`clothing_item_id`) REFERENCES `clothing_items`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`material_id`) REFERENCES `materials`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "clothingItemId",
+            "columnName": "clothing_item_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "materialId",
+            "columnName": "material_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "clothing_item_id",
+            "material_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_clothing_item_materials_material_id",
+            "unique": false,
+            "columnNames": [
+              "material_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_clothing_item_materials_material_id` ON `${TABLE_NAME}` (`material_id`)"
+          },
+          {
+            "name": "index_clothing_item_materials_clothing_item_id",
+            "unique": false,
+            "columnNames": [
+              "clothing_item_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_clothing_item_materials_clothing_item_id` ON `${TABLE_NAME}` (`clothing_item_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "clothing_items",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "clothing_item_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "materials",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "material_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "clothing_item_seasons",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`clothing_item_id` INTEGER NOT NULL, `season_id` INTEGER NOT NULL, PRIMARY KEY(`clothing_item_id`, `season_id`), FOREIGN KEY(`clothing_item_id`) REFERENCES `clothing_items`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`season_id`) REFERENCES `seasons`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "clothingItemId",
+            "columnName": "clothing_item_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "seasonId",
+            "columnName": "season_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "clothing_item_id",
+            "season_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_clothing_item_seasons_season_id",
+            "unique": false,
+            "columnNames": [
+              "season_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_clothing_item_seasons_season_id` ON `${TABLE_NAME}` (`season_id`)"
+          },
+          {
+            "name": "index_clothing_item_seasons_clothing_item_id",
+            "unique": false,
+            "columnNames": [
+              "clothing_item_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_clothing_item_seasons_clothing_item_id` ON `${TABLE_NAME}` (`clothing_item_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "clothing_items",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "clothing_item_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "seasons",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "season_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "clothing_item_occasions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`clothing_item_id` INTEGER NOT NULL, `occasion_id` INTEGER NOT NULL, PRIMARY KEY(`clothing_item_id`, `occasion_id`), FOREIGN KEY(`clothing_item_id`) REFERENCES `clothing_items`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`occasion_id`) REFERENCES `occasions`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "clothingItemId",
+            "columnName": "clothing_item_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "occasionId",
+            "columnName": "occasion_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "clothing_item_id",
+            "occasion_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_clothing_item_occasions_occasion_id",
+            "unique": false,
+            "columnNames": [
+              "occasion_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_clothing_item_occasions_occasion_id` ON `${TABLE_NAME}` (`occasion_id`)"
+          },
+          {
+            "name": "index_clothing_item_occasions_clothing_item_id",
+            "unique": false,
+            "columnNames": [
+              "clothing_item_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_clothing_item_occasions_clothing_item_id` ON `${TABLE_NAME}` (`clothing_item_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "clothing_items",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "clothing_item_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "occasions",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "occasion_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "clothing_item_patterns",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`clothing_item_id` INTEGER NOT NULL, `pattern_id` INTEGER NOT NULL, PRIMARY KEY(`clothing_item_id`, `pattern_id`), FOREIGN KEY(`clothing_item_id`) REFERENCES `clothing_items`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`pattern_id`) REFERENCES `patterns`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "clothingItemId",
+            "columnName": "clothing_item_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "patternId",
+            "columnName": "pattern_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "clothing_item_id",
+            "pattern_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_clothing_item_patterns_pattern_id",
+            "unique": false,
+            "columnNames": [
+              "pattern_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_clothing_item_patterns_pattern_id` ON `${TABLE_NAME}` (`pattern_id`)"
+          },
+          {
+            "name": "index_clothing_item_patterns_clothing_item_id",
+            "unique": false,
+            "columnNames": [
+              "clothing_item_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_clothing_item_patterns_clothing_item_id` ON `${TABLE_NAME}` (`clothing_item_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "clothing_items",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "clothing_item_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "patterns",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "pattern_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '62fb5d004ac2c2ab993a8ae757a34b8b')"
+    ]
+  }
+}

--- a/app-android/core/data/schemas/com.closet.core.data.ClothingDatabase/2.json
+++ b/app-android/core/data/schemas/com.closet.core.data.ClothingDatabase/2.json
@@ -276,7 +276,8 @@
             "fieldPath": "warmthLayer",
             "columnName": "warmth_layer",
             "affinity": "TEXT",
-            "notNull": true
+            "notNull": true,
+            "defaultValue": "None"
           }
         ],
         "primaryKey": {

--- a/app-android/core/data/src/androidTest/kotlin/com/closet/core/data/MigrationTest.kt
+++ b/app-android/core/data/src/androidTest/kotlin/com/closet/core/data/MigrationTest.kt
@@ -3,6 +3,7 @@ package com.closet.core.data
 import androidx.room.testing.MigrationTestHelper
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
+import com.closet.core.data.migrations.MIGRATION_1_2
 import com.closet.core.data.migrations.columnExists
 import org.junit.Assert.assertTrue
 import org.junit.Rule
@@ -21,12 +22,12 @@ class MigrationTest {
     )
 
     /**
-     * Verifies that a fresh install (version 1 onCreate) produces the correct full schema.
+     * Verifies that a fresh install (version 2 onCreate) produces the correct full schema.
      * Spot-checks every major structural element so regressions are caught early.
      */
     @Test
     fun freshInstallCreatesCorrectSchema() {
-        val db = helper.createDatabase(TEST_DB, 1)
+        val db = helper.createDatabase(TEST_DB, 2)
 
         // Clothing items
         assertTrue(columnExists(db, "clothing_items", "id"))
@@ -39,13 +40,16 @@ class MigrationTest {
         assertTrue(columnExists(db, "brands", "name"))
         assertTrue(columnExists(db, "brands", "normalized_name"))
 
-        // Lookup tables
+        // Lookup tables — including v2 additions
         assertTrue(columnExists(db, "categories", "id"))
+        assertTrue(columnExists(db, "categories", "warmth_layer"))
         assertTrue(columnExists(db, "subcategories", "category_id"))
         assertTrue(columnExists(db, "colors", "hex"))
         assertTrue(columnExists(db, "materials", "id"))
         assertTrue(columnExists(db, "patterns", "icon"))
         assertTrue(columnExists(db, "seasons", "id"))
+        assertTrue(columnExists(db, "seasons", "temp_low_c"))
+        assertTrue(columnExists(db, "seasons", "temp_high_c"))
         assertTrue(columnExists(db, "occasions", "id"))
 
         // Outfits
@@ -53,12 +57,42 @@ class MigrationTest {
         assertTrue(columnExists(db, "outfit_items", "pos_x"))
         assertTrue(columnExists(db, "outfit_items", "z_index"))
 
-        // Logs and snapshot table
+        // Logs and snapshot table — including v2 additions
         assertTrue(columnExists(db, "outfit_logs", "is_ootd"))
         assertTrue(columnExists(db, "outfit_logs", "weather_condition"))
+        assertTrue(columnExists(db, "outfit_logs", "precipitation_mm"))
+        assertTrue(columnExists(db, "outfit_logs", "wind_speed_kmh"))
         assertTrue(columnExists(db, "outfit_log_items", "outfit_log_id"))
         assertTrue(columnExists(db, "outfit_log_items", "clothing_item_id"))
         assertTrue(columnExists(db, "outfit_log_items", "outfit_name"))
+
+        db.close()
+    }
+
+    /**
+     * Verifies that migrating from version 1 to 2 adds all expected columns and
+     * the resulting schema matches the live entity definitions.
+     */
+    @Test
+    fun migrate1To2() {
+        // Build a v1 database, dropping the partial index first (AGENTS.md convention)
+        var db = helper.createDatabase(TEST_DB, 1)
+        db.execSQL("DROP INDEX IF EXISTS one_ootd_per_day")
+        db.close()
+
+        // Run the migration and validate against current entity definitions
+        db = helper.runMigrationsAndValidate(TEST_DB, 2, true, MIGRATION_1_2)
+
+        // seasons — temperature bands
+        assertTrue(columnExists(db, "seasons", "temp_low_c"))
+        assertTrue(columnExists(db, "seasons", "temp_high_c"))
+
+        // categories — warmth layer
+        assertTrue(columnExists(db, "categories", "warmth_layer"))
+
+        // outfit_logs — precip + wind
+        assertTrue(columnExists(db, "outfit_logs", "precipitation_mm"))
+        assertTrue(columnExists(db, "outfit_logs", "wind_speed_kmh"))
 
         db.close()
     }

--- a/app-android/core/data/src/main/kotlin/com/closet/core/data/ClothingDatabase.kt
+++ b/app-android/core/data/src/main/kotlin/com/closet/core/data/ClothingDatabase.kt
@@ -7,6 +7,7 @@ import androidx.room.RoomDatabase
 import androidx.room.TypeConverters
 import androidx.sqlite.db.SupportSQLiteDatabase
 import com.closet.core.data.dao.*
+import com.closet.core.data.migrations.MIGRATION_1_2
 import com.closet.core.data.model.*
 
 /**
@@ -37,7 +38,7 @@ import com.closet.core.data.model.*
         ClothingItemOccasionEntity::class,
         ClothingItemPatternEntity::class
     ],
-    version = 1,
+    version = 2,
     exportSchema = true
 )
 @TypeConverters(Converters::class)
@@ -89,6 +90,7 @@ abstract class ClothingDatabase : RoomDatabase() {
                         db.execSQL("CREATE UNIQUE INDEX IF NOT EXISTS one_ootd_per_day ON outfit_logs(date) WHERE is_ootd = 1")
                     }
                 })
+                .addMigrations(MIGRATION_1_2)
                 .build()
                 INSTANCE = instance
                 instance

--- a/app-android/core/data/src/main/kotlin/com/closet/core/data/DatabaseSeeder.kt
+++ b/app-android/core/data/src/main/kotlin/com/closet/core/data/DatabaseSeeder.kt
@@ -35,22 +35,23 @@ object DatabaseSeeder {
 
     /** Seeds the 10 top-level clothing categories with stable IDs (1–10). */
     private fun seedCategories(db: SupportSQLiteDatabase) {
+        // name, icon, sort_order, warmth_layer
         val categories = listOf(
-            Triple("Tops", "t-shirt", 1),
-            Triple("Bottoms", "pants", 2),
-            Triple("Outerwear", "hoodie", 3),
-            Triple("Dresses & Jumpsuits", "dress", 4),
-            Triple("Footwear", "sneaker", 5),
-            Triple("Accessories", "watch", 6),
-            Triple("Bags", "handbag", 7),
-            Triple("Activewear", "person-simple-running", 8),
-            Triple("Underwear & Intimates", "sock", 9),
-            Triple("Swimwear", "goggles", 10)
+            listOf("Tops",                  "t-shirt",               1, "None"),
+            listOf("Bottoms",               "pants",                 2, "None"),
+            listOf("Outerwear",             "hoodie",                3, "Outer"),
+            listOf("Dresses & Jumpsuits",   "dress",                 4, "None"),
+            listOf("Footwear",              "sneaker",               5, "None"),
+            listOf("Accessories",           "watch",                 6, "None"),
+            listOf("Bags",                  "handbag",               7, "None"),
+            listOf("Activewear",            "person-simple-running", 8, "None"),
+            listOf("Underwear & Intimates", "sock",                  9, "Base"),
+            listOf("Swimwear",              "goggles",               10, "None"),
         )
-        categories.forEachIndexed { index, (name, icon, order) ->
+        categories.forEachIndexed { index, row ->
             db.execSQL(
-                "INSERT OR IGNORE INTO categories (id, name, icon, sort_order) VALUES (?, ?, ?, ?)",
-                arrayOf<Any>(index + 1, name, icon, order)
+                "INSERT OR IGNORE INTO categories (id, name, icon, sort_order, warmth_layer) VALUES (?, ?, ?, ?, ?)",
+                arrayOf<Any>(index + 1, row[0], row[1], row[2], row[3])
             )
         }
     }
@@ -79,19 +80,20 @@ object DatabaseSeeder {
         }
     }
 
-    /** Seeds the 5 seasons (Spring, Summer, Fall, Winter, All Season) with Phosphor icons. */
+    /** Seeds the 5 seasons with Phosphor icons and temperature bands (°C). All Season has null bounds. */
     private fun seedSeasons(db: SupportSQLiteDatabase) {
+        // name, icon, temp_low_c, temp_high_c — All Season intentionally null (always applicable)
         val seasons = listOf(
-            "Spring" to "flower",
-            "Summer" to "sun",
-            "Fall" to "leaf",
-            "Winter" to "snowflake",
-            "All Season" to "thermometer"
+            listOf<Any?>("Spring",     "flower",      10.0,  20.0),
+            listOf<Any?>("Summer",     "sun",         22.0,  35.0),
+            listOf<Any?>("Fall",       "leaf",         5.0,  18.0),
+            listOf<Any?>("Winter",     "snowflake",  -10.0,   5.0),
+            listOf<Any?>("All Season", "thermometer",  null,  null),
         )
-        seasons.forEach { (name, icon) ->
+        seasons.forEach { row ->
             db.execSQL(
-                "INSERT OR IGNORE INTO seasons (name, icon) VALUES (?, ?)",
-                arrayOf<Any>(name, icon)
+                "INSERT OR IGNORE INTO seasons (name, icon, temp_low_c, temp_high_c) VALUES (?, ?, ?, ?)",
+                arrayOf<Any?>(row[0], row[1], row[2], row[3])
             )
         }
     }

--- a/app-android/core/data/src/main/kotlin/com/closet/core/data/dao/LogDao.kt
+++ b/app-android/core/data/src/main/kotlin/com/closet/core/data/dao/LogDao.kt
@@ -163,6 +163,20 @@ interface LogDao {
         }
         return logId
     }
+
+    /**
+     * Atomically returns the existing log ID for [outfitId] + [date], or inserts a new
+     * log (with optional weather fields) and returns its row ID. The check-then-insert
+     * runs inside a single transaction to avoid a TOCTOU race.
+     *
+     * @return The existing or newly created log row ID.
+     */
+    @Transaction
+    suspend fun getOrCreateLog(log: OutfitLogEntity): Long {
+        val existing = log.outfitId?.let { getLogIdByOutfitAndDate(it, log.date) }
+        if (existing != null) return existing
+        return insertLogAndSnapshot(log)
+    }
 }
 
 /**

--- a/app-android/core/data/src/main/kotlin/com/closet/core/data/dao/LogDao.kt
+++ b/app-android/core/data/src/main/kotlin/com/closet/core/data/dao/LogDao.kt
@@ -178,6 +178,8 @@ data class OutfitLogWithMeta(
     @ColumnInfo(name = "temperature_low") val temperatureLow: Double?,
     @ColumnInfo(name = "temperature_high") val temperatureHigh: Double?,
     @ColumnInfo(name = "weather_condition") val weatherCondition: String?,
+    @ColumnInfo(name = "precipitation_mm") val precipitationMm: Double?,
+    @ColumnInfo(name = "wind_speed_kmh") val windSpeedKmh: Double?,
     @ColumnInfo(name = "created_at") val createdAt: String,
     @ColumnInfo(name = "outfit_name") val outfitName: String?,
     @ColumnInfo(name = "item_count") val itemCount: Int,

--- a/app-android/core/data/src/main/kotlin/com/closet/core/data/di/DataModule.kt
+++ b/app-android/core/data/src/main/kotlin/com/closet/core/data/di/DataModule.kt
@@ -1,6 +1,7 @@
 package com.closet.core.data.di
 
 import android.content.Context
+import com.closet.core.data.BuildConfig
 import com.closet.core.data.ClothingDatabase
 import com.closet.core.data.dao.*
 import com.closet.core.data.repository.WeatherPreferencesRepository
@@ -9,6 +10,15 @@ import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.okhttp.OkHttp
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.client.plugins.logging.LogLevel
+import io.ktor.client.plugins.logging.Logger
+import io.ktor.client.plugins.logging.Logging
+import io.ktor.serialization.kotlinx.json.json
+import kotlinx.serialization.json.Json
+import timber.log.Timber
 import javax.inject.Singleton
 
 /**
@@ -65,4 +75,30 @@ object DataModule {
     fun provideWeatherPreferencesRepository(
         @ApplicationContext context: Context,
     ): WeatherPreferencesRepository = WeatherPreferencesRepository(context)
+
+    /**
+     * Provides the shared [HttpClient] singleton used by all weather service clients.
+     *
+     * - Engine: OkHttp (recommended Android engine for Ktor 3.x).
+     * - ContentNegotiation: kotlinx-serialization JSON with unknown-key tolerance so
+     *   future API fields don't crash the parser.
+     * - Logging: Timber-backed, bodies only in debug builds to avoid leaking API keys
+     *   or location data in release logs.
+     */
+    @Provides
+    @Singleton
+    fun provideHttpClient(): HttpClient = HttpClient(OkHttp) {
+        install(ContentNegotiation) {
+            json(Json {
+                ignoreUnknownKeys = true
+                coerceInputValues = true
+            })
+        }
+        install(Logging) {
+            logger = object : Logger {
+                override fun log(message: String) = Timber.tag("Ktor").d(message)
+            }
+            level = if (BuildConfig.DEBUG) LogLevel.BODY else LogLevel.NONE
+        }
+    }
 }

--- a/app-android/core/data/src/main/kotlin/com/closet/core/data/di/DataModule.kt
+++ b/app-android/core/data/src/main/kotlin/com/closet/core/data/di/DataModule.kt
@@ -3,6 +3,7 @@ package com.closet.core.data.di
 import android.content.Context
 import com.closet.core.data.ClothingDatabase
 import com.closet.core.data.dao.*
+import com.closet.core.data.repository.WeatherPreferencesRepository
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -11,7 +12,8 @@ import dagger.hilt.components.SingletonComponent
 import javax.inject.Singleton
 
 /**
- * Hilt module that provides the Room database and all DAO singletons.
+ * Hilt module that provides the Room database, all DAO singletons, and
+ * DataStore-backed repositories that live in the data layer.
  *
  * Installed in [dagger.hilt.components.SingletonComponent] so every DAO and
  * repository shares a single [ClothingDatabase] instance for the app's lifetime.
@@ -56,4 +58,11 @@ object DataModule {
     @Provides
     @Singleton
     fun provideBrandDao(db: ClothingDatabase): BrandDao = db.brandDao()
+
+    /** Provides the [WeatherPreferencesRepository] singleton backed by its own DataStore file. */
+    @Provides
+    @Singleton
+    fun provideWeatherPreferencesRepository(
+        @ApplicationContext context: Context,
+    ): WeatherPreferencesRepository = WeatherPreferencesRepository(context)
 }

--- a/app-android/core/data/src/main/kotlin/com/closet/core/data/di/DataModule.kt
+++ b/app-android/core/data/src/main/kotlin/com/closet/core/data/di/DataModule.kt
@@ -77,22 +77,30 @@ object DataModule {
     ): WeatherPreferencesRepository = WeatherPreferencesRepository(context)
 
     /**
+     * Provides the shared [Json] instance used for both HTTP content negotiation
+     * and DataStore cache serialization.
+     */
+    @Provides
+    @Singleton
+    fun provideJson(): Json = Json {
+        ignoreUnknownKeys = true
+        coerceInputValues = true
+    }
+
+    /**
      * Provides the shared [HttpClient] singleton used by all weather service clients.
      *
      * - Engine: OkHttp (recommended Android engine for Ktor 3.x).
-     * - ContentNegotiation: kotlinx-serialization JSON with unknown-key tolerance so
-     *   future API fields don't crash the parser.
+     * - ContentNegotiation: shares the [provideJson] instance so HTTP parsing and
+     *   cache serialization use the same config.
      * - Logging: Timber-backed, bodies only in debug builds to avoid leaking API keys
      *   or location data in release logs.
      */
     @Provides
     @Singleton
-    fun provideHttpClient(): HttpClient = HttpClient(OkHttp) {
+    fun provideHttpClient(json: Json): HttpClient = HttpClient(OkHttp) {
         install(ContentNegotiation) {
-            json(Json {
-                ignoreUnknownKeys = true
-                coerceInputValues = true
-            })
+            json(json)
         }
         install(Logging) {
             logger = object : Logger {

--- a/app-android/core/data/src/main/kotlin/com/closet/core/data/location/LocationProvider.kt
+++ b/app-android/core/data/src/main/kotlin/com/closet/core/data/location/LocationProvider.kt
@@ -1,0 +1,82 @@
+package com.closet.core.data.location
+
+import android.annotation.SuppressLint
+import android.content.Context
+import android.location.Location
+import android.location.LocationListener
+import android.location.LocationManager
+import android.os.Looper
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.withTimeoutOrNull
+import timber.log.Timber
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlin.coroutines.resume
+
+/**
+ * Provides a single passive location reading via [LocationManager]. No Play
+ * Services dependency — the app has none.
+ *
+ * Strategy:
+ * 1. Return [LocationManager.NETWORK_PROVIDER] last-known (instant, no battery).
+ * 2. Fall back to [LocationManager.GPS_PROVIDER] last-known.
+ * 3. If both caches are empty, request a single active [NETWORK_PROVIDER] update
+ *    with a [timeoutMs] deadline. Returns `null` on timeout or provider error.
+ *
+ * Callers must hold [android.Manifest.permission.ACCESS_COARSE_LOCATION] before
+ * invoking [getLocation] — this is guaranteed by the Settings toggle flow.
+ */
+@Singleton
+class LocationProvider @Inject constructor(
+    @ApplicationContext private val context: Context,
+) {
+    private val locationManager =
+        context.getSystemService(Context.LOCATION_SERVICE) as LocationManager
+
+    @SuppressLint("MissingPermission")
+    suspend fun getLocation(timeoutMs: Long = 10_000L): Pair<Double, Double>? {
+        lastKnownLocation()?.let { return it }
+        return withTimeoutOrNull(timeoutMs) { requestSingleUpdate() }
+    }
+
+    @SuppressLint("MissingPermission")
+    private fun lastKnownLocation(): Pair<Double, Double>? {
+        for (provider in listOf(LocationManager.NETWORK_PROVIDER, LocationManager.GPS_PROVIDER)) {
+            if (!locationManager.isProviderEnabled(provider)) continue
+            val loc = locationManager.getLastKnownLocation(provider) ?: continue
+            Timber.d("LocationProvider: cached fix from $provider (%.4f, %.4f)".format(loc.latitude, loc.longitude))
+            return Pair(loc.latitude, loc.longitude)
+        }
+        return null
+    }
+
+    @SuppressLint("MissingPermission")
+    private suspend fun requestSingleUpdate(): Pair<Double, Double>? =
+        suspendCancellableCoroutine { cont ->
+            val listener = object : LocationListener {
+                override fun onLocationChanged(location: Location) {
+                    locationManager.removeUpdates(this)
+                    Timber.d("LocationProvider: active fix (%.4f, %.4f)".format(location.latitude, location.longitude))
+                    cont.resume(Pair(location.latitude, location.longitude))
+                }
+
+                override fun onProviderDisabled(provider: String) {
+                    locationManager.removeUpdates(this)
+                    cont.resume(null)
+                }
+            }
+            try {
+                locationManager.requestLocationUpdates(
+                    LocationManager.NETWORK_PROVIDER,
+                    0L, 0f,
+                    listener,
+                    Looper.getMainLooper(),
+                )
+                cont.invokeOnCancellation { locationManager.removeUpdates(listener) }
+            } catch (e: Exception) {
+                Timber.e(e, "LocationProvider: requestLocationUpdates failed")
+                cont.resume(null)
+            }
+        }
+}

--- a/app-android/core/data/src/main/kotlin/com/closet/core/data/location/LocationProvider.kt
+++ b/app-android/core/data/src/main/kotlin/com/closet/core/data/location/LocationProvider.kt
@@ -45,7 +45,7 @@ class LocationProvider @Inject constructor(
         for (provider in listOf(LocationManager.NETWORK_PROVIDER, LocationManager.GPS_PROVIDER)) {
             if (!locationManager.isProviderEnabled(provider)) continue
             val loc = locationManager.getLastKnownLocation(provider) ?: continue
-            Timber.d("LocationProvider: cached fix from $provider (%.4f, %.4f)".format(loc.latitude, loc.longitude))
+            Timber.d("LocationProvider: cached fix from $provider")
             return Pair(loc.latitude, loc.longitude)
         }
         return null
@@ -57,13 +57,13 @@ class LocationProvider @Inject constructor(
             val listener = object : LocationListener {
                 override fun onLocationChanged(location: Location) {
                     locationManager.removeUpdates(this)
-                    Timber.d("LocationProvider: active fix (%.4f, %.4f)".format(location.latitude, location.longitude))
-                    cont.resume(Pair(location.latitude, location.longitude))
+                    Timber.d("LocationProvider: active fix received")
+                    if (cont.isActive) cont.resume(Pair(location.latitude, location.longitude))
                 }
 
                 override fun onProviderDisabled(provider: String) {
                     locationManager.removeUpdates(this)
-                    cont.resume(null)
+                    if (cont.isActive) cont.resume(null)
                 }
             }
             try {
@@ -76,7 +76,7 @@ class LocationProvider @Inject constructor(
                 cont.invokeOnCancellation { locationManager.removeUpdates(listener) }
             } catch (e: Exception) {
                 Timber.e(e, "LocationProvider: requestLocationUpdates failed")
-                cont.resume(null)
+                if (cont.isActive) cont.resume(null)
             }
         }
 }

--- a/app-android/core/data/src/main/kotlin/com/closet/core/data/migrations/Migration1To2.kt
+++ b/app-android/core/data/src/main/kotlin/com/closet/core/data/migrations/Migration1To2.kt
@@ -1,0 +1,43 @@
+package com.closet.core.data.migrations
+
+import androidx.room.migration.Migration
+import androidx.sqlite.db.SupportSQLiteDatabase
+
+/**
+ * Migration 1 → 2: Phase 5 schema additions (Gaps 4 and 5).
+ *
+ * Changes:
+ * - seasons: add temp_low_c / temp_high_c (°C) for temperature-band season matching.
+ *   Backfills sensible global defaults; All Season is left NULL (always applicable).
+ * - categories: add warmth_layer TEXT NOT NULL DEFAULT 'None'.
+ *   Values: None | Base | Mid | Outer. Backfills 'Outer' for Outerwear.
+ * - outfit_logs: add precipitation_mm / wind_speed_kmh for recommendation engine
+ *   data collection. Auto-populated on log creation via Phase 4.2 forecast hook.
+ */
+val MIGRATION_1_2 = object : Migration(1, 2) {
+    override fun migrate(db: SupportSQLiteDatabase) {
+        // ── Partial index — always drop first (AGENTS.md) ──────────────────────
+        db.execSQL("DROP INDEX IF EXISTS one_ootd_per_day")
+
+        // ── Gap 4: Temperature bands on seasons ────────────────────────────────
+        db.execSQL("ALTER TABLE seasons ADD COLUMN temp_low_c REAL")
+        db.execSQL("ALTER TABLE seasons ADD COLUMN temp_high_c REAL")
+
+        // Backfill defaults. All Season left NULL — it applies at any temperature.
+        db.execSQL("UPDATE seasons SET temp_low_c = 10.0,  temp_high_c = 20.0 WHERE name = 'Spring'")
+        db.execSQL("UPDATE seasons SET temp_low_c = 22.0,  temp_high_c = 35.0 WHERE name = 'Summer'")
+        db.execSQL("UPDATE seasons SET temp_low_c = 5.0,   temp_high_c = 18.0 WHERE name = 'Fall'")
+        db.execSQL("UPDATE seasons SET temp_low_c = -10.0, temp_high_c = 5.0  WHERE name = 'Winter'")
+
+        // ── Gap 4: Warmth layer on categories ──────────────────────────────────
+        db.execSQL("ALTER TABLE categories ADD COLUMN warmth_layer TEXT NOT NULL DEFAULT 'None'")
+
+        // Only Outerwear is unambiguously an outer layer at the category level.
+        // Users can update Mid/Base assignments via the UI when the engine ships.
+        db.execSQL("UPDATE categories SET warmth_layer = 'Outer' WHERE name = 'Outerwear'")
+
+        // ── Gap 5: Precipitation and wind on outfit_logs ───────────────────────
+        db.execSQL("ALTER TABLE outfit_logs ADD COLUMN precipitation_mm REAL")
+        db.execSQL("ALTER TABLE outfit_logs ADD COLUMN wind_speed_kmh REAL")
+    }
+}

--- a/app-android/core/data/src/main/kotlin/com/closet/core/data/migrations/Migration1To2.kt
+++ b/app-android/core/data/src/main/kotlin/com/closet/core/data/migrations/Migration1To2.kt
@@ -32,9 +32,10 @@ val MIGRATION_1_2 = object : Migration(1, 2) {
         // ── Gap 4: Warmth layer on categories ──────────────────────────────────
         db.execSQL("ALTER TABLE categories ADD COLUMN warmth_layer TEXT NOT NULL DEFAULT 'None'")
 
-        // Only Outerwear is unambiguously an outer layer at the category level.
+        // Backfill known warmth layers. Other categories default to 'None'.
         // Users can update Mid/Base assignments via the UI when the engine ships.
         db.execSQL("UPDATE categories SET warmth_layer = 'Outer' WHERE name = 'Outerwear'")
+        db.execSQL("UPDATE categories SET warmth_layer = 'Base'  WHERE name = 'Underwear & Intimates'")
 
         // ── Gap 5: Precipitation and wind on outfit_logs ───────────────────────
         db.execSQL("ALTER TABLE outfit_logs ADD COLUMN precipitation_mm REAL")

--- a/app-android/core/data/src/main/kotlin/com/closet/core/data/model/CachedForecastEntry.kt
+++ b/app-android/core/data/src/main/kotlin/com/closet/core/data/model/CachedForecastEntry.kt
@@ -1,0 +1,46 @@
+package com.closet.core.data.model
+
+import kotlinx.serialization.Serializable
+import java.time.LocalDate
+
+/**
+ * Serializable DTO used to persist a [DailyForecast] in the DataStore cache.
+ *
+ * Uses only primitive/String fields to avoid custom serializers for
+ * [java.time.LocalDate] and [WeatherCondition]. Condition is stored by
+ * [WeatherCondition.name] so it survives label renames.
+ */
+@Serializable
+data class CachedForecastEntry(
+    val dateStr: String,          // "YYYY-MM-DD"
+    val tempLowC: Double,
+    val tempHighC: Double,
+    val conditionName: String,    // WeatherCondition.name
+    val precipitationMm: Double,
+    val windSpeedKmh: Double,
+    val uvIndex: Int?,
+    val humidity: Int?,
+)
+
+fun CachedForecastEntry.toDomain(): DailyForecast = DailyForecast(
+    date = LocalDate.parse(dateStr),
+    tempLow = tempLowC,
+    tempHigh = tempHighC,
+    condition = WeatherCondition.entries.find { it.name == conditionName }
+        ?: WeatherCondition.Cloudy,
+    precipitationMm = precipitationMm,
+    windSpeedKmh = windSpeedKmh,
+    uvIndex = uvIndex,
+    humidity = humidity,
+)
+
+fun DailyForecast.toCached(): CachedForecastEntry = CachedForecastEntry(
+    dateStr = date.toString(),
+    tempLowC = tempLow,
+    tempHighC = tempHigh,
+    conditionName = condition.name,
+    precipitationMm = precipitationMm,
+    windSpeedKmh = windSpeedKmh,
+    uvIndex = uvIndex,
+    humidity = humidity,
+)

--- a/app-android/core/data/src/main/kotlin/com/closet/core/data/model/CachedForecastEntry.kt
+++ b/app-android/core/data/src/main/kotlin/com/closet/core/data/model/CachedForecastEntry.kt
@@ -16,7 +16,7 @@ data class CachedForecastEntry(
     val tempLowC: Double,
     val tempHighC: Double,
     val conditionName: String,    // WeatherCondition.name
-    val precipitationMm: Double,
+    val precipitationMm: Double?,
     val windSpeedKmh: Double,
     val uvIndex: Int?,
     val humidity: Int?,

--- a/app-android/core/data/src/main/kotlin/com/closet/core/data/model/DailyForecast.kt
+++ b/app-android/core/data/src/main/kotlin/com/closet/core/data/model/DailyForecast.kt
@@ -1,0 +1,20 @@
+package com.closet.core.data.model
+
+import java.time.LocalDate
+
+/**
+ * Domain model for a single day's weather forecast.
+ *
+ * All temperatures are stored in °C regardless of the user's display preference.
+ * Convert to °F at the UI layer using [com.closet.core.data.model.TemperatureUnit].
+ */
+data class DailyForecast(
+    val date: LocalDate,
+    val tempLow: Double,          // °C
+    val tempHigh: Double,         // °C
+    val condition: WeatherCondition,
+    val precipitationMm: Double,
+    val windSpeedKmh: Double,
+    val uvIndex: Int?,
+    val humidity: Int?,           // percent; null when not provided by the service
+)

--- a/app-android/core/data/src/main/kotlin/com/closet/core/data/model/DailyForecast.kt
+++ b/app-android/core/data/src/main/kotlin/com/closet/core/data/model/DailyForecast.kt
@@ -13,7 +13,7 @@ data class DailyForecast(
     val tempLow: Double,          // °C
     val tempHigh: Double,         // °C
     val condition: WeatherCondition,
-    val precipitationMm: Double,
+    val precipitationMm: Double?,     // null when not provided by the service
     val windSpeedKmh: Double,
     val uvIndex: Int?,
     val humidity: Int?,           // percent; null when not provided by the service

--- a/app-android/core/data/src/main/kotlin/com/closet/core/data/model/Enums.kt
+++ b/app-android/core/data/src/main/kotlin/com/closet/core/data/model/Enums.kt
@@ -31,6 +31,35 @@ enum class WashStatus(val label: String) {
 }
 
 /**
+ * Weather service provider options.
+ */
+enum class WeatherService(val label: String) {
+    OpenMeteo("Open-Meteo"),
+    Nws("NWS"),
+    Google("Google");
+
+    companion object {
+        fun fromString(value: String): WeatherService {
+            return entries.find { it.name == value } ?: OpenMeteo
+        }
+    }
+}
+
+/**
+ * Temperature display unit. Canonical storage is always °C; convert for display only.
+ */
+enum class TemperatureUnit(val label: String) {
+    Celsius("°C"),
+    Fahrenheit("°F");
+
+    companion object {
+        fun fromString(value: String): TemperatureUnit {
+            return entries.find { it.name == value } ?: Celsius
+        }
+    }
+}
+
+/**
  * Parity: Weather condition options.
  */
 enum class WeatherCondition(val label: String) {

--- a/app-android/core/data/src/main/kotlin/com/closet/core/data/model/Enums.kt
+++ b/app-android/core/data/src/main/kotlin/com/closet/core/data/model/Enums.kt
@@ -60,7 +60,10 @@ enum class TemperatureUnit(val label: String) {
 }
 
 /**
- * Parity: Weather condition options.
+ * Weather condition options. Stored in the DB as [label] strings — adding new
+ * entries is non-breaking for existing rows.
+ *
+ * Covers all WMO weather interpretation codes used by Open-Meteo; see [fromWmoCode].
  */
 enum class WeatherCondition(val label: String) {
     Sunny("Sunny"),
@@ -68,11 +71,35 @@ enum class WeatherCondition(val label: String) {
     Cloudy("Cloudy"),
     Rainy("Rainy"),
     Snowy("Snowy"),
-    Windy("Windy");
+    Windy("Windy"),
+    Thunderstorm("Thunderstorm"),
+    Foggy("Foggy"),
+    Drizzle("Drizzle"),
+    Sleet("Sleet"),
+    HeavySnow("Heavy Snow");
 
     companion object {
-        fun fromString(value: String?): WeatherCondition? {
-            return entries.find { it.label == value }
+        fun fromString(value: String?): WeatherCondition? =
+            entries.find { it.label == value }
+
+        /**
+         * Maps a WMO weather interpretation code (as used by Open-Meteo) to the
+         * nearest [WeatherCondition]. Returns [Cloudy] for any unrecognised code.
+         *
+         * Reference: https://open-meteo.com/en/docs#weathervariables
+         */
+        fun fromWmoCode(code: Int): WeatherCondition = when (code) {
+            0 -> Sunny
+            1, 2 -> PartlyCloudy
+            3 -> Cloudy
+            45, 48 -> Foggy
+            51, 53, 55, 56, 57 -> Drizzle
+            61, 63, 65, 80, 81, 82 -> Rainy
+            66, 67 -> Sleet
+            71, 73, 77, 85 -> Snowy
+            75, 86 -> HeavySnow
+            95, 96, 99 -> Thunderstorm
+            else -> Cloudy
         }
     }
 }

--- a/app-android/core/data/src/main/kotlin/com/closet/core/data/model/LookupEntities.kt
+++ b/app-android/core/data/src/main/kotlin/com/closet/core/data/model/LookupEntities.kt
@@ -23,7 +23,9 @@ data class CategoryEntity(
     @PrimaryKey(autoGenerate = true) val id: Long = 0,
     val name: String,
     val icon: String? = null,
-    @ColumnInfo(name = "sort_order") val sortOrder: Int
+    @ColumnInfo(name = "sort_order") val sortOrder: Int,
+    /** Thermal role of this category. Values: None | Base | Mid | Outer. */
+    @ColumnInfo(name = "warmth_layer") val warmthLayer: String = "None",
 )
 
 /** Clothing subcategory (e.g. T-Shirt, Jeans) belonging to a parent [CategoryEntity]. */
@@ -51,7 +53,11 @@ data class SubcategoryEntity(
 data class SeasonEntity(
     @PrimaryKey(autoGenerate = true) val id: Long = 0,
     val name: String,
-    val icon: String? = null
+    val icon: String? = null,
+    /** Lower bound of this season's typical temperature range (°C). Null = no lower bound. */
+    @ColumnInfo(name = "temp_low_c") val tempLowC: Double? = null,
+    /** Upper bound of this season's typical temperature range (°C). Null = no upper bound. */
+    @ColumnInfo(name = "temp_high_c") val tempHighC: Double? = null,
 )
 
 /** Occasion lookup value (e.g. Casual, Formal). Stored with a Phosphor icon name for display. */

--- a/app-android/core/data/src/main/kotlin/com/closet/core/data/model/LookupEntities.kt
+++ b/app-android/core/data/src/main/kotlin/com/closet/core/data/model/LookupEntities.kt
@@ -25,7 +25,7 @@ data class CategoryEntity(
     val icon: String? = null,
     @ColumnInfo(name = "sort_order") val sortOrder: Int,
     /** Thermal role of this category. Values: None | Base | Mid | Outer. */
-    @ColumnInfo(name = "warmth_layer") val warmthLayer: String = "None",
+    @ColumnInfo(name = "warmth_layer", defaultValue = "None") val warmthLayer: String = "None",
 )
 
 /** Clothing subcategory (e.g. T-Shirt, Jeans) belonging to a parent [CategoryEntity]. */

--- a/app-android/core/data/src/main/kotlin/com/closet/core/data/model/OutfitEntities.kt
+++ b/app-android/core/data/src/main/kotlin/com/closet/core/data/model/OutfitEntities.kt
@@ -77,6 +77,8 @@ data class OutfitItemEntity(
  * @property temperatureLow Optional low temperature recorded for the day.
  * @property temperatureHigh Optional high temperature recorded for the day.
  * @property weatherCondition Optional weather condition tag for the day.
+ * @property precipitationMm Optional precipitation amount (mm) recorded for the day.
+ * @property windSpeedKmh Optional wind speed (km/h) recorded for the day.
  * @property createdAt Timestamp of when this log entry was created.
  */
 @Entity(
@@ -104,6 +106,8 @@ data class OutfitLogEntity(
     @ColumnInfo(name = "temperature_low") val temperatureLow: Double? = null,
     @ColumnInfo(name = "temperature_high") val temperatureHigh: Double? = null,
     @ColumnInfo(name = "weather_condition") val weatherCondition: WeatherCondition? = null,
+    @ColumnInfo(name = "precipitation_mm") val precipitationMm: Double? = null,
+    @ColumnInfo(name = "wind_speed_kmh") val windSpeedKmh: Double? = null,
     @ColumnInfo(name = "created_at") val createdAt: Instant = Instant.now()
 )
 

--- a/app-android/core/data/src/main/kotlin/com/closet/core/data/repository/LogRepository.kt
+++ b/app-android/core/data/src/main/kotlin/com/closet/core/data/repository/LogRepository.kt
@@ -5,6 +5,7 @@ import com.closet.core.data.dao.ItemWearLog
 import com.closet.core.data.dao.LogDao
 import com.closet.core.data.dao.OutfitLogWithMeta
 import com.closet.core.data.model.OutfitLogEntity
+import com.closet.core.data.model.WeatherCondition
 import com.closet.core.data.util.AppError
 import com.closet.core.data.util.DataResult
 import kotlinx.coroutines.CancellationException
@@ -54,16 +55,34 @@ class LogRepository @Inject constructor(
 
     /**
      * Logs an outfit as worn on [date] (YYYY-MM-DD). Idempotent — returns the existing
-     * log ID if the outfit was already logged for that date.
+     * log ID if the outfit was already logged for that date (weather fields are not
+     * overwritten on the existing row).
      *
      * @param outfitId The ID of the outfit that was worn.
      * @param date The date to log, in YYYY-MM-DD format.
+     * @param temperatureLow Optional low temperature (°C) to pre-populate from forecast.
+     * @param temperatureHigh Optional high temperature (°C) to pre-populate from forecast.
+     * @param weatherCondition Optional weather condition to pre-populate from forecast.
      * @return The log row ID in [DataResult.Success], or [DataResult.Error].
      */
-    suspend fun wearOutfitOnDate(outfitId: Long, date: String): DataResult<Long> = try {
+    suspend fun wearOutfitOnDate(
+        outfitId: Long,
+        date: String,
+        temperatureLow: Double? = null,
+        temperatureHigh: Double? = null,
+        weatherCondition: WeatherCondition? = null,
+    ): DataResult<Long> = try {
         val existingId = logDao.getLogIdByOutfitAndDate(outfitId, date)
         if (existingId != null) return DataResult.Success(existingId)
-        val logId = logDao.insertLogAndSnapshot(OutfitLogEntity(outfitId = outfitId, date = date))
+        val logId = logDao.insertLogAndSnapshot(
+            OutfitLogEntity(
+                outfitId = outfitId,
+                date = date,
+                temperatureLow = temperatureLow,
+                temperatureHigh = temperatureHigh,
+                weatherCondition = weatherCondition,
+            )
+        )
         DataResult.Success(logId)
     } catch (e: Exception) {
         if (e is CancellationException) throw e

--- a/app-android/core/data/src/main/kotlin/com/closet/core/data/repository/LogRepository.kt
+++ b/app-android/core/data/src/main/kotlin/com/closet/core/data/repository/LogRepository.kt
@@ -63,6 +63,8 @@ class LogRepository @Inject constructor(
      * @param temperatureLow Optional low temperature (°C) to pre-populate from forecast.
      * @param temperatureHigh Optional high temperature (°C) to pre-populate from forecast.
      * @param weatherCondition Optional weather condition to pre-populate from forecast.
+     * @param precipitationMm Optional precipitation amount (mm) to pre-populate from forecast.
+     * @param windSpeedKmh Optional wind speed (km/h) to pre-populate from forecast.
      * @return The log row ID in [DataResult.Success], or [DataResult.Error].
      */
     suspend fun wearOutfitOnDate(
@@ -71,6 +73,8 @@ class LogRepository @Inject constructor(
         temperatureLow: Double? = null,
         temperatureHigh: Double? = null,
         weatherCondition: WeatherCondition? = null,
+        precipitationMm: Double? = null,
+        windSpeedKmh: Double? = null,
     ): DataResult<Long> = try {
         val existingId = logDao.getLogIdByOutfitAndDate(outfitId, date)
         if (existingId != null) return DataResult.Success(existingId)
@@ -81,6 +85,8 @@ class LogRepository @Inject constructor(
                 temperatureLow = temperatureLow,
                 temperatureHigh = temperatureHigh,
                 weatherCondition = weatherCondition,
+                precipitationMm = precipitationMm,
+                windSpeedKmh = windSpeedKmh,
             )
         )
         DataResult.Success(logId)

--- a/app-android/core/data/src/main/kotlin/com/closet/core/data/repository/LogRepository.kt
+++ b/app-android/core/data/src/main/kotlin/com/closet/core/data/repository/LogRepository.kt
@@ -76,9 +76,7 @@ class LogRepository @Inject constructor(
         precipitationMm: Double? = null,
         windSpeedKmh: Double? = null,
     ): DataResult<Long> = try {
-        val existingId = logDao.getLogIdByOutfitAndDate(outfitId, date)
-        if (existingId != null) return DataResult.Success(existingId)
-        val logId = logDao.insertLogAndSnapshot(
+        val logId = logDao.getOrCreateLog(
             OutfitLogEntity(
                 outfitId = outfitId,
                 date = date,

--- a/app-android/core/data/src/main/kotlin/com/closet/core/data/repository/WeatherPreferencesRepository.kt
+++ b/app-android/core/data/src/main/kotlin/com/closet/core/data/repository/WeatherPreferencesRepository.kt
@@ -42,6 +42,7 @@ class WeatherPreferencesRepository @Inject constructor(
     private val cachedForecastTimestampKey = longPreferencesKey("cached_forecast_timestamp")
     private val cachedLatitudeKey = doublePreferencesKey("cached_latitude")
     private val cachedLongitudeKey = doublePreferencesKey("cached_longitude")
+    private val cachedForecastServiceKey = stringPreferencesKey("cached_forecast_service")
 
     // ── Weather enabled ──────────────────────────────────────────────────────
 
@@ -109,8 +110,13 @@ class WeatherPreferencesRepository @Inject constructor(
         prefs[cachedLongitudeKey] ?: 0.0
     }
 
+    /** Returns the [WeatherService] that produced the current cached forecast, or null if no cache. */
+    fun getCachedForecastService(): Flow<WeatherService?> = context.weatherDataStore.data.map { prefs ->
+        prefs[cachedForecastServiceKey]?.let { WeatherService.fromString(it) }
+    }
+
     /**
-     * Writes all four cache fields atomically in a single DataStore transaction.
+     * Writes all cache fields atomically in a single DataStore transaction.
      * Call this after a successful forecast fetch.
      */
     suspend fun saveCache(
@@ -118,12 +124,14 @@ class WeatherPreferencesRepository @Inject constructor(
         timestamp: Long,
         latitude: Double,
         longitude: Double,
+        service: WeatherService,
     ) {
         context.weatherDataStore.edit { prefs ->
             prefs[cachedForecastJsonKey] = forecastJson
             prefs[cachedForecastTimestampKey] = timestamp
             prefs[cachedLatitudeKey] = latitude
             prefs[cachedLongitudeKey] = longitude
+            prefs[cachedForecastServiceKey] = service.name
         }
     }
 
@@ -137,6 +145,7 @@ class WeatherPreferencesRepository @Inject constructor(
             prefs.remove(cachedForecastTimestampKey)
             prefs.remove(cachedLatitudeKey)
             prefs.remove(cachedLongitudeKey)
+            prefs.remove(cachedForecastServiceKey)
         }
     }
 }

--- a/app-android/core/data/src/main/kotlin/com/closet/core/data/repository/WeatherPreferencesRepository.kt
+++ b/app-android/core/data/src/main/kotlin/com/closet/core/data/repository/WeatherPreferencesRepository.kt
@@ -1,0 +1,142 @@
+package com.closet.core.data.repository
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.booleanPreferencesKey
+import androidx.datastore.preferences.core.doublePreferencesKey
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.longPreferencesKey
+import androidx.datastore.preferences.core.stringPreferencesKey
+import androidx.datastore.preferences.preferencesDataStore
+import com.closet.core.data.model.TemperatureUnit
+import com.closet.core.data.model.WeatherService
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import javax.inject.Inject
+import javax.inject.Singleton
+
+private val Context.weatherDataStore: DataStore<Preferences> by preferencesDataStore(name = "weather_prefs")
+
+/**
+ * Repository for persisting weather feature preferences via [DataStore].
+ *
+ * Backed by a separate DataStore file (`weather_prefs`) from the main app prefs,
+ * keeping weather/network concerns isolated in [com.closet.core.data].
+ *
+ * All temperature values stored in the DB are canonical °C. [TemperatureUnit]
+ * controls display conversion only — never stored values.
+ *
+ * Provided as a [Singleton] — inject anywhere via Hilt.
+ */
+@Singleton
+class WeatherPreferencesRepository @Inject constructor(
+    @ApplicationContext private val context: Context,
+) {
+    private val weatherEnabledKey = booleanPreferencesKey("weather_enabled")
+    private val weatherServiceKey = stringPreferencesKey("weather_service")
+    private val googleApiKeyKey = stringPreferencesKey("google_api_key")
+    private val temperatureUnitKey = stringPreferencesKey("temperature_unit")
+    private val cachedForecastJsonKey = stringPreferencesKey("cached_forecast_json")
+    private val cachedForecastTimestampKey = longPreferencesKey("cached_forecast_timestamp")
+    private val cachedLatitudeKey = doublePreferencesKey("cached_latitude")
+    private val cachedLongitudeKey = doublePreferencesKey("cached_longitude")
+
+    // ── Weather enabled ──────────────────────────────────────────────────────
+
+    fun getWeatherEnabled(): Flow<Boolean> = context.weatherDataStore.data.map { prefs ->
+        prefs[weatherEnabledKey] ?: false
+    }
+
+    suspend fun setWeatherEnabled(enabled: Boolean) {
+        context.weatherDataStore.edit { prefs ->
+            prefs[weatherEnabledKey] = enabled
+        }
+    }
+
+    // ── Service selection ────────────────────────────────────────────────────
+
+    fun getWeatherService(): Flow<WeatherService> = context.weatherDataStore.data.map { prefs ->
+        WeatherService.fromString(prefs[weatherServiceKey] ?: WeatherService.OpenMeteo.name)
+    }
+
+    suspend fun setWeatherService(service: WeatherService) {
+        context.weatherDataStore.edit { prefs ->
+            prefs[weatherServiceKey] = service.name
+        }
+    }
+
+    // ── Google API key ───────────────────────────────────────────────────────
+
+    fun getGoogleApiKey(): Flow<String> = context.weatherDataStore.data.map { prefs ->
+        prefs[googleApiKeyKey] ?: ""
+    }
+
+    suspend fun setGoogleApiKey(key: String) {
+        context.weatherDataStore.edit { prefs ->
+            prefs[googleApiKeyKey] = key
+        }
+    }
+
+    // ── Temperature unit ─────────────────────────────────────────────────────
+
+    fun getTemperatureUnit(): Flow<TemperatureUnit> = context.weatherDataStore.data.map { prefs ->
+        TemperatureUnit.fromString(prefs[temperatureUnitKey] ?: TemperatureUnit.Celsius.name)
+    }
+
+    suspend fun setTemperatureUnit(unit: TemperatureUnit) {
+        context.weatherDataStore.edit { prefs ->
+            prefs[temperatureUnitKey] = unit.name
+        }
+    }
+
+    // ── Forecast cache ───────────────────────────────────────────────────────
+
+    fun getCachedForecastJson(): Flow<String> = context.weatherDataStore.data.map { prefs ->
+        prefs[cachedForecastJsonKey] ?: ""
+    }
+
+    fun getCachedForecastTimestamp(): Flow<Long> = context.weatherDataStore.data.map { prefs ->
+        prefs[cachedForecastTimestampKey] ?: 0L
+    }
+
+    fun getCachedLatitude(): Flow<Double> = context.weatherDataStore.data.map { prefs ->
+        prefs[cachedLatitudeKey] ?: 0.0
+    }
+
+    fun getCachedLongitude(): Flow<Double> = context.weatherDataStore.data.map { prefs ->
+        prefs[cachedLongitudeKey] ?: 0.0
+    }
+
+    /**
+     * Writes all four cache fields atomically in a single DataStore transaction.
+     * Call this after a successful forecast fetch.
+     */
+    suspend fun saveCache(
+        forecastJson: String,
+        timestamp: Long,
+        latitude: Double,
+        longitude: Double,
+    ) {
+        context.weatherDataStore.edit { prefs ->
+            prefs[cachedForecastJsonKey] = forecastJson
+            prefs[cachedForecastTimestampKey] = timestamp
+            prefs[cachedLatitudeKey] = latitude
+            prefs[cachedLongitudeKey] = longitude
+        }
+    }
+
+    /**
+     * Removes all cached forecast data. Called from the "Clear cached forecast"
+     * action in Settings.
+     */
+    suspend fun clearCache() {
+        context.weatherDataStore.edit { prefs ->
+            prefs.remove(cachedForecastJsonKey)
+            prefs.remove(cachedForecastTimestampKey)
+            prefs.remove(cachedLatitudeKey)
+            prefs.remove(cachedLongitudeKey)
+        }
+    }
+}

--- a/app-android/core/data/src/main/kotlin/com/closet/core/data/repository/WeatherPreferencesRepository.kt
+++ b/app-android/core/data/src/main/kotlin/com/closet/core/data/repository/WeatherPreferencesRepository.kt
@@ -13,6 +13,7 @@ import com.closet.core.data.model.TemperatureUnit
 import com.closet.core.data.model.WeatherService
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import javax.inject.Inject
 import javax.inject.Singleton

--- a/app-android/core/data/src/main/kotlin/com/closet/core/data/repository/WeatherPreferencesRepository.kt
+++ b/app-android/core/data/src/main/kotlin/com/closet/core/data/repository/WeatherPreferencesRepository.kt
@@ -102,17 +102,41 @@ class WeatherPreferencesRepository @Inject constructor(
         prefs[cachedForecastTimestampKey] ?: 0L
     }
 
-    fun getCachedLatitude(): Flow<Double> = context.weatherDataStore.data.map { prefs ->
-        prefs[cachedLatitudeKey] ?: 0.0
+    fun getCachedLatitude(): Flow<Double?> = context.weatherDataStore.data.map { prefs ->
+        prefs[cachedLatitudeKey]
     }
 
-    fun getCachedLongitude(): Flow<Double> = context.weatherDataStore.data.map { prefs ->
-        prefs[cachedLongitudeKey] ?: 0.0
+    fun getCachedLongitude(): Flow<Double?> = context.weatherDataStore.data.map { prefs ->
+        prefs[cachedLongitudeKey]
     }
 
     /** Returns the [WeatherService] that produced the current cached forecast, or null if no cache. */
     fun getCachedForecastService(): Flow<WeatherService?> = context.weatherDataStore.data.map { prefs ->
         prefs[cachedForecastServiceKey]?.let { WeatherService.fromString(it) }
+    }
+
+    /**
+     * Reads all cache-related keys in a single atomic DataStore snapshot.
+     * Use this instead of multiple individual [first] calls to avoid observing
+     * a partially-cleared or partially-written cache state.
+     */
+    data class CacheSnapshot(
+        val forecastJson: String,
+        val timestamp: Long,
+        val service: WeatherService?,
+        val latitude: Double?,
+        val longitude: Double?,
+    )
+
+    suspend fun getCacheSnapshot(): CacheSnapshot {
+        val prefs = context.weatherDataStore.data.first()
+        return CacheSnapshot(
+            forecastJson = prefs[cachedForecastJsonKey] ?: "",
+            timestamp = prefs[cachedForecastTimestampKey] ?: 0L,
+            service = prefs[cachedForecastServiceKey]?.let { WeatherService.fromString(it) },
+            latitude = prefs[cachedLatitudeKey],
+            longitude = prefs[cachedLongitudeKey],
+        )
     }
 
     /**

--- a/app-android/core/data/src/main/kotlin/com/closet/core/data/repository/WeatherRepository.kt
+++ b/app-android/core/data/src/main/kotlin/com/closet/core/data/repository/WeatherRepository.kt
@@ -6,9 +6,12 @@ import com.closet.core.data.model.DailyForecast
 import com.closet.core.data.model.WeatherService
 import com.closet.core.data.model.toCached
 import com.closet.core.data.model.toDomain
+import com.closet.core.data.util.AppError
+import com.closet.core.data.util.DataResult
 import com.closet.core.data.weather.GoogleWeatherClient
 import com.closet.core.data.weather.NwsClient
 import com.closet.core.data.weather.OpenMeteoClient
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.first
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
@@ -23,7 +26,8 @@ private const val FORECAST_CACHE_TTL_MS = 3L * 60 * 60 * 1000   // 3 hours
  * Orchestrates weather forecast retrieval with a 3-hour DataStore cache.
  *
  * On each [getForecast] call:
- * 1. If a cached forecast exists and is < [FORECAST_CACHE_TTL_MS] old, return it.
+ * 1. If a cached forecast exists, is < [FORECAST_CACHE_TTL_MS] old, and was
+ *    produced by the currently-selected service, return it.
  * 2. Otherwise, get the device location via [LocationProvider] (falls back to the
  *    last-cached lat/lon if the device has no fix).
  * 3. Delegate to the active [WeatherService] client.
@@ -47,33 +51,36 @@ class WeatherRepository @Inject constructor(
      * Returns a 7-day forecast (today + 6 days), respecting the 3-hour cache.
      * Always succeeds with cached data when a fresh fetch fails and a cache exists.
      */
-    suspend fun getForecast(): Result<List<DailyForecast>> {
-        val cachedJson = weatherPrefsRepo.getCachedForecastJson().first()
-        val cachedTimestamp = weatherPrefsRepo.getCachedForecastTimestamp().first()
-        val age = System.currentTimeMillis() - cachedTimestamp
+    suspend fun getForecast(): DataResult<List<DailyForecast>> {
+        return try {
+            val cachedJson = weatherPrefsRepo.getCachedForecastJson().first()
+            val cachedTimestamp = weatherPrefsRepo.getCachedForecastTimestamp().first()
+            val cachedService = weatherPrefsRepo.getCachedForecastService().first()
+            val currentService = weatherPrefsRepo.getWeatherService().first()
+            val age = System.currentTimeMillis() - cachedTimestamp
 
-        if (cachedJson.isNotEmpty() && age < FORECAST_CACHE_TTL_MS) {
-            return parseCached(cachedJson)
-                .onFailure { Timber.w(it, "WeatherRepository: stale cache unreadable, fetching fresh") }
-                .recoverCatching { fetchFresh().getOrThrow() }
-        }
-
-        return fetchFresh().recoverCatching { error ->
-            // Fetch failed — return stale cache rather than an error if we have one.
-            if (cachedJson.isNotEmpty()) {
-                Timber.w(error, "WeatherRepository: fetch failed, returning stale cache")
-                parseCached(cachedJson).getOrThrow()
-            } else {
-                throw error
+            if (cachedJson.isNotEmpty() && age < FORECAST_CACHE_TTL_MS && cachedService == currentService) {
+                val parsed = parseCached(cachedJson)
+                if (parsed != null) return DataResult.Success(parsed)
+                Timber.w("WeatherRepository: stale cache unreadable, fetching fresh")
             }
+
+            fetchFresh(cachedJson)
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            Timber.e(e, "WeatherRepository: unexpected error")
+            DataResult.Error(AppError.Unexpected(e))
         }
     }
 
-    private fun parseCached(json: String): Result<List<DailyForecast>> = runCatching {
+    private fun parseCached(json: String): List<DailyForecast>? = try {
         this.json.decodeFromString<List<CachedForecastEntry>>(json).map { it.toDomain() }
+    } catch (e: Exception) {
+        null
     }
 
-    private suspend fun fetchFresh(): Result<List<DailyForecast>> {
+    private suspend fun fetchFresh(cachedJson: String): DataResult<List<DailyForecast>> {
         // ── 1. Resolve location ───────────────────────────────────────────────
         val location = locationProvider.getLocation()
             ?: run {
@@ -81,7 +88,9 @@ class WeatherRepository @Inject constructor(
                 val cachedLon = weatherPrefsRepo.getCachedLongitude().first()
                 if (cachedLat != 0.0 || cachedLon != 0.0) Pair(cachedLat, cachedLon) else null
             }
-            ?: return Result.failure(IllegalStateException("No location available — grant location permission and try again."))
+            ?: return DataResult.Error(
+                AppError.Unexpected(IllegalStateException("No location available — grant location permission and try again."))
+            )
 
         val (lat, lon) = location
 
@@ -90,7 +99,9 @@ class WeatherRepository @Inject constructor(
         if (service == WeatherService.Google) {
             val key = weatherPrefsRepo.getGoogleApiKey().first()
             if (key.isBlank()) {
-                return Result.failure(IllegalStateException("Google Weather API key is not set. Add it in Settings → Weather."))
+                return DataResult.Error(
+                    AppError.Unexpected(IllegalStateException("Google Weather API key is not set. Add it in Settings → Weather."))
+                )
             }
         }
 
@@ -106,12 +117,29 @@ class WeatherRepository @Inject constructor(
 
         // ── 4. Cache on success ───────────────────────────────────────────────
         result.onSuccess { forecasts ->
-            runCatching {
+            try {
                 val entriesJson = json.encodeToString(forecasts.map { it.toCached() })
-                weatherPrefsRepo.saveCache(entriesJson, System.currentTimeMillis(), lat, lon)
-            }.onFailure { Timber.w(it, "WeatherRepository: failed to write forecast cache") }
+                weatherPrefsRepo.saveCache(entriesJson, System.currentTimeMillis(), lat, lon, service)
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                Timber.w(e, "WeatherRepository: failed to write forecast cache")
+            }
         }
 
-        return result
+        return result.fold(
+            onSuccess = { DataResult.Success(it) },
+            onFailure = { error ->
+                // Fetch failed — return stale cache rather than an error if we have one.
+                if (cachedJson.isNotEmpty()) {
+                    val parsed = parseCached(cachedJson)
+                    if (parsed != null) {
+                        Timber.w(error, "WeatherRepository: fetch failed, returning stale cache")
+                        return DataResult.Success(parsed)
+                    }
+                }
+                DataResult.Error(AppError.Unexpected(error))
+            }
+        )
     }
 }

--- a/app-android/core/data/src/main/kotlin/com/closet/core/data/repository/WeatherRepository.kt
+++ b/app-android/core/data/src/main/kotlin/com/closet/core/data/repository/WeatherRepository.kt
@@ -106,8 +106,10 @@ class WeatherRepository @Inject constructor(
 
         // ── 4. Cache on success ───────────────────────────────────────────────
         result.onSuccess { forecasts ->
-            val entriesJson = json.encodeToString(forecasts.map { it.toCached() })
-            weatherPrefsRepo.saveCache(entriesJson, System.currentTimeMillis(), lat, lon)
+            runCatching {
+                val entriesJson = json.encodeToString(forecasts.map { it.toCached() })
+                weatherPrefsRepo.saveCache(entriesJson, System.currentTimeMillis(), lat, lon)
+            }.onFailure { Timber.w(it, "WeatherRepository: failed to write forecast cache") }
         }
 
         return result

--- a/app-android/core/data/src/main/kotlin/com/closet/core/data/repository/WeatherRepository.kt
+++ b/app-android/core/data/src/main/kotlin/com/closet/core/data/repository/WeatherRepository.kt
@@ -53,19 +53,18 @@ class WeatherRepository @Inject constructor(
      */
     suspend fun getForecast(): DataResult<List<DailyForecast>> {
         return try {
-            val cachedJson = weatherPrefsRepo.getCachedForecastJson().first()
-            val cachedTimestamp = weatherPrefsRepo.getCachedForecastTimestamp().first()
-            val cachedService = weatherPrefsRepo.getCachedForecastService().first()
+            // Read all cache keys in one atomic snapshot to avoid observing partially-cleared state.
+            val cache = weatherPrefsRepo.getCacheSnapshot()
             val currentService = weatherPrefsRepo.getWeatherService().first()
-            val age = System.currentTimeMillis() - cachedTimestamp
+            val age = System.currentTimeMillis() - cache.timestamp
 
-            if (cachedJson.isNotEmpty() && age < FORECAST_CACHE_TTL_MS && cachedService == currentService) {
-                val parsed = parseCached(cachedJson)
+            if (cache.forecastJson.isNotEmpty() && age < FORECAST_CACHE_TTL_MS && cache.service == currentService) {
+                val parsed = parseCached(cache.forecastJson)
                 if (parsed != null) return DataResult.Success(parsed)
                 Timber.w("WeatherRepository: stale cache unreadable, fetching fresh")
             }
 
-            fetchFresh(cachedJson)
+            fetchFresh(cache.forecastJson)
         } catch (e: CancellationException) {
             throw e
         } catch (e: Exception) {
@@ -86,10 +85,10 @@ class WeatherRepository @Inject constructor(
             ?: run {
                 val cachedLat = weatherPrefsRepo.getCachedLatitude().first()
                 val cachedLon = weatherPrefsRepo.getCachedLongitude().first()
-                if (cachedLat != 0.0 || cachedLon != 0.0) Pair(cachedLat, cachedLon) else null
+                if (cachedLat != null && cachedLon != null) Pair(cachedLat, cachedLon) else null
             }
             ?: return DataResult.Error(
-                AppError.Unexpected(IllegalStateException("No location available — grant location permission and try again."))
+                AppError.ValidationError.InvalidInput("No location available — grant location permission and try again.")
             )
 
         val (lat, lon) = location
@@ -100,7 +99,7 @@ class WeatherRepository @Inject constructor(
             val key = weatherPrefsRepo.getGoogleApiKey().first()
             if (key.isBlank()) {
                 return DataResult.Error(
-                    AppError.Unexpected(IllegalStateException("Google Weather API key is not set. Add it in Settings → Weather."))
+                    AppError.ValidationError.InvalidInput("Google Weather API key is not set. Add it in Settings → Weather.")
                 )
             }
         }
@@ -130,6 +129,7 @@ class WeatherRepository @Inject constructor(
         return result.fold(
             onSuccess = { DataResult.Success(it) },
             onFailure = { error ->
+                if (error is CancellationException) throw error
                 // Fetch failed — return stale cache rather than an error if we have one.
                 if (cachedJson.isNotEmpty()) {
                     val parsed = parseCached(cachedJson)

--- a/app-android/core/data/src/main/kotlin/com/closet/core/data/repository/WeatherRepository.kt
+++ b/app-android/core/data/src/main/kotlin/com/closet/core/data/repository/WeatherRepository.kt
@@ -1,0 +1,115 @@
+package com.closet.core.data.repository
+
+import com.closet.core.data.location.LocationProvider
+import com.closet.core.data.model.CachedForecastEntry
+import com.closet.core.data.model.DailyForecast
+import com.closet.core.data.model.WeatherService
+import com.closet.core.data.model.toCached
+import com.closet.core.data.model.toDomain
+import com.closet.core.data.weather.GoogleWeatherClient
+import com.closet.core.data.weather.NwsClient
+import com.closet.core.data.weather.OpenMeteoClient
+import kotlinx.coroutines.flow.first
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import timber.log.Timber
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/** Cache is considered fresh for this many milliseconds after it was written. */
+private const val FORECAST_CACHE_TTL_MS = 3L * 60 * 60 * 1000   // 3 hours
+
+/**
+ * Orchestrates weather forecast retrieval with a 3-hour DataStore cache.
+ *
+ * On each [getForecast] call:
+ * 1. If a cached forecast exists and is < [FORECAST_CACHE_TTL_MS] old, return it.
+ * 2. Otherwise, get the device location via [LocationProvider] (falls back to the
+ *    last-cached lat/lon if the device has no fix).
+ * 3. Delegate to the active [WeatherService] client.
+ * 4. On success, serialize the result and write it to DataStore.
+ * 5. On failure, return cached data if present; otherwise propagate the error.
+ *
+ * [GoogleWeatherClient] is injected as a concrete type (not via the
+ * [com.closet.core.data.weather.WeatherServiceClient] interface) because it
+ * requires an API key parameter that the interface contract doesn't carry.
+ */
+@Singleton
+class WeatherRepository @Inject constructor(
+    private val openMeteoClient: OpenMeteoClient,
+    private val nwsClient: NwsClient,
+    private val googleClient: GoogleWeatherClient,
+    private val weatherPrefsRepo: WeatherPreferencesRepository,
+    private val locationProvider: LocationProvider,
+    private val json: Json,
+) {
+    /**
+     * Returns a 7-day forecast (today + 6 days), respecting the 3-hour cache.
+     * Always succeeds with cached data when a fresh fetch fails and a cache exists.
+     */
+    suspend fun getForecast(): Result<List<DailyForecast>> {
+        val cachedJson = weatherPrefsRepo.getCachedForecastJson().first()
+        val cachedTimestamp = weatherPrefsRepo.getCachedForecastTimestamp().first()
+        val age = System.currentTimeMillis() - cachedTimestamp
+
+        if (cachedJson.isNotEmpty() && age < FORECAST_CACHE_TTL_MS) {
+            return parseCached(cachedJson)
+                .onFailure { Timber.w(it, "WeatherRepository: stale cache unreadable, fetching fresh") }
+                .recoverCatching { fetchFresh().getOrThrow() }
+        }
+
+        return fetchFresh().recoverCatching { error ->
+            // Fetch failed — return stale cache rather than an error if we have one.
+            if (cachedJson.isNotEmpty()) {
+                Timber.w(error, "WeatherRepository: fetch failed, returning stale cache")
+                parseCached(cachedJson).getOrThrow()
+            } else {
+                throw error
+            }
+        }
+    }
+
+    private fun parseCached(json: String): Result<List<DailyForecast>> = runCatching {
+        this.json.decodeFromString<List<CachedForecastEntry>>(json).map { it.toDomain() }
+    }
+
+    private suspend fun fetchFresh(): Result<List<DailyForecast>> {
+        // ── 1. Resolve location ───────────────────────────────────────────────
+        val location = locationProvider.getLocation()
+            ?: run {
+                val cachedLat = weatherPrefsRepo.getCachedLatitude().first()
+                val cachedLon = weatherPrefsRepo.getCachedLongitude().first()
+                if (cachedLat != 0.0 || cachedLon != 0.0) Pair(cachedLat, cachedLon) else null
+            }
+            ?: return Result.failure(IllegalStateException("No location available — grant location permission and try again."))
+
+        val (lat, lon) = location
+
+        // ── 2. Select client ──────────────────────────────────────────────────
+        val service = weatherPrefsRepo.getWeatherService().first()
+        if (service == WeatherService.Google) {
+            val key = weatherPrefsRepo.getGoogleApiKey().first()
+            if (key.isBlank()) {
+                return Result.failure(IllegalStateException("Google Weather API key is not set. Add it in Settings → Weather."))
+            }
+        }
+
+        // ── 3. Fetch ──────────────────────────────────────────────────────────
+        val result = when (service) {
+            WeatherService.OpenMeteo -> openMeteoClient.fetchDailyForecast(lat, lon)
+            WeatherService.Nws -> nwsClient.fetchDailyForecast(lat, lon)
+            WeatherService.Google -> {
+                val key = weatherPrefsRepo.getGoogleApiKey().first()
+                googleClient.fetchDailyForecast(lat, lon, key)
+            }
+        }
+
+        // ── 4. Cache on success ───────────────────────────────────────────────
+        result.onSuccess { forecasts ->
+            val entriesJson = json.encodeToString(forecasts.map { it.toCached() })
+            weatherPrefsRepo.saveCache(entriesJson, System.currentTimeMillis(), lat, lon)
+        }
+
+        return result
+    }
+}

--- a/app-android/core/data/src/main/kotlin/com/closet/core/data/weather/GoogleWeatherClient.kt
+++ b/app-android/core/data/src/main/kotlin/com/closet/core/data/weather/GoogleWeatherClient.kt
@@ -57,19 +57,21 @@ class GoogleWeatherClient @Inject constructor(
     private data class GoogleForecastResponse(
         @SerialName("forecastDays") val forecastDays: List<GoogleForecastDay> = emptyList(),
     ) {
-        fun toForecasts(): List<DailyForecast> = forecastDays.mapIndexed { i, day ->
-            val date = day.displayDate?.toLocalDate()
-                ?: LocalDate.now().plusDays(i.toLong())
-            DailyForecast(
-                date = date,
-                tempLow = day.minTemperature?.toCelsius() ?: 0.0,
-                tempHigh = day.maxTemperature?.toCelsius() ?: 0.0,
-                condition = mapConditionType(day.daytimeForecast?.weatherCondition?.type),
-                precipitationMm = day.daytimeForecast?.precipitation?.qpf?.quantity ?: 0.0,
-                windSpeedKmh = day.daytimeForecast?.wind?.speed?.toKmh() ?: 0.0,
-                uvIndex = day.daytimeForecast?.uvIndex,
-                humidity = day.daytimeForecast?.relativeHumidity,
-            )
+        fun toForecasts(): List<DailyForecast> {
+            val baseDate = LocalDate.now()
+            return forecastDays.mapIndexed { i, day ->
+                val date = day.displayDate?.toLocalDate() ?: baseDate.plusDays(i.toLong())
+                DailyForecast(
+                    date = date,
+                    tempLow = day.minTemperature?.toCelsius() ?: 0.0,
+                    tempHigh = day.maxTemperature?.toCelsius() ?: 0.0,
+                    condition = mapConditionType(day.daytimeForecast?.weatherCondition?.type),
+                    precipitationMm = day.daytimeForecast?.precipitation?.qpf?.quantity ?: 0.0,
+                    windSpeedKmh = day.daytimeForecast?.wind?.speed?.toKmh() ?: 0.0,
+                    uvIndex = day.daytimeForecast?.uvIndex,
+                    humidity = day.daytimeForecast?.relativeHumidity,
+                )
+            }
         }
     }
 

--- a/app-android/core/data/src/main/kotlin/com/closet/core/data/weather/GoogleWeatherClient.kt
+++ b/app-android/core/data/src/main/kotlin/com/closet/core/data/weather/GoogleWeatherClient.kt
@@ -1,0 +1,126 @@
+package com.closet.core.data.weather
+
+import com.closet.core.data.model.DailyForecast
+import com.closet.core.data.model.WeatherCondition
+import io.ktor.client.HttpClient
+import io.ktor.client.call.body
+import io.ktor.client.request.get
+import io.ktor.client.request.parameter
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import timber.log.Timber
+import java.time.LocalDate
+import javax.inject.Inject
+import javax.inject.Singleton
+
+private const val BASE_URL = "https://weather.googleapis.com/v1/forecast/days:lookup"
+
+/**
+ * Google Weather API client. Requires a valid API key.
+ *
+ * Does **not** implement [WeatherServiceClient] because it requires an API key
+ * parameter that the interface contract doesn't carry. [WeatherRepository] calls
+ * this client directly after reading and validating the key from
+ * [com.closet.core.data.repository.WeatherPreferencesRepository].
+ *
+ * IMPORTANT: The response DTOs below are based on the Google Weather API design
+ * as of early 2025. Verify field names and endpoint against current Google
+ * Weather API documentation if responses are empty or parsing fails. The
+ * `ignoreUnknownKeys = true` JSON config means extra fields won't cause crashes,
+ * but renamed/removed fields will silently default to null/0.
+ *
+ * Reference: https://developers.google.com/maps/documentation/weather
+ */
+@Singleton
+class GoogleWeatherClient @Inject constructor(
+    private val client: HttpClient,
+) {
+    suspend fun fetchDailyForecast(
+        lat: Double,
+        lon: Double,
+        apiKey: String,
+    ): Result<List<DailyForecast>> =
+        runCatching {
+            val response: GoogleForecastResponse = client.get(BASE_URL) {
+                parameter("key", apiKey)
+                parameter("location.latitude", lat)
+                parameter("location.longitude", lon)
+                parameter("days", 7)
+                parameter("unitsSystem", "METRIC")
+            }.body()
+            response.toForecasts()
+        }.onFailure { Timber.e(it, "GoogleWeatherClient: fetch failed") }
+
+    // ── Response DTOs ─────────────────────────────────────────────────────────
+
+    @Serializable
+    private data class GoogleForecastResponse(
+        @SerialName("forecastDays") val forecastDays: List<GoogleForecastDay> = emptyList(),
+    ) {
+        fun toForecasts(): List<DailyForecast> = forecastDays.mapIndexed { i, day ->
+            val startTime = day.interval?.startTime
+            val date = if (startTime != null) {
+                runCatching { LocalDate.parse(startTime.take(10)) }.getOrNull()
+            } else null
+            DailyForecast(
+                date = date ?: LocalDate.now().plusDays(i.toLong()),
+                tempLow = day.minTemperature?.degrees ?: 0.0,
+                tempHigh = day.maxTemperature?.degrees ?: 0.0,
+                condition = mapConditionType(day.daytimeForecast?.weatherCondition?.type),
+                precipitationMm = day.daytimeForecast?.precipitation?.qpf?.quantity ?: 0.0,
+                windSpeedKmh = day.maxWindSpeed?.value ?: 0.0,
+                uvIndex = day.uvIndex,
+                humidity = null,
+            )
+        }
+    }
+
+    @Serializable
+    private data class GoogleForecastDay(
+        val interval: TimeInterval? = null,
+        @SerialName("maxTemperature") val maxTemperature: Temperature? = null,
+        @SerialName("minTemperature") val minTemperature: Temperature? = null,
+        @SerialName("daytimeForecast") val daytimeForecast: DaytimeForecast? = null,
+        @SerialName("maxWindSpeed") val maxWindSpeed: WindSpeed? = null,
+        val uvIndex: Int? = null,
+    )
+
+    @Serializable
+    private data class TimeInterval(val startTime: String? = null)
+
+    @Serializable
+    private data class Temperature(val degrees: Double = 0.0)
+
+    @Serializable
+    private data class WindSpeed(val value: Double = 0.0)
+
+    @Serializable
+    private data class DaytimeForecast(
+        val weatherCondition: WeatherConditionDto? = null,
+        val precipitation: Precipitation? = null,
+    )
+
+    @Serializable
+    private data class WeatherConditionDto(val type: String? = null)
+
+    @Serializable
+    private data class Precipitation(val qpf: Qpf? = null)
+
+    @Serializable
+    private data class Qpf(val quantity: Double = 0.0)
+
+    private fun mapConditionType(type: String?): WeatherCondition = when (type?.uppercase()) {
+        "CLEAR" -> WeatherCondition.Sunny
+        "PARTLY_CLOUDY" -> WeatherCondition.PartlyCloudy
+        "MOSTLY_CLOUDY", "CLOUDY" -> WeatherCondition.Cloudy
+        "FOGGY", "FOG" -> WeatherCondition.Foggy
+        "DRIZZLE", "LIGHT_RAIN" -> WeatherCondition.Drizzle
+        "RAIN", "HEAVY_RAIN", "RAIN_SHOWERS" -> WeatherCondition.Rainy
+        "FREEZING_RAIN", "SLEET" -> WeatherCondition.Sleet
+        "SNOW", "LIGHT_SNOW", "SNOW_SHOWERS" -> WeatherCondition.Snowy
+        "HEAVY_SNOW", "BLIZZARD" -> WeatherCondition.HeavySnow
+        "THUNDERSTORM" -> WeatherCondition.Thunderstorm
+        "WINDY" -> WeatherCondition.Windy
+        else -> WeatherCondition.Cloudy
+    }
+}

--- a/app-android/core/data/src/main/kotlin/com/closet/core/data/weather/GoogleWeatherClient.kt
+++ b/app-android/core/data/src/main/kotlin/com/closet/core/data/weather/GoogleWeatherClient.kt
@@ -23,13 +23,12 @@ private const val BASE_URL = "https://weather.googleapis.com/v1/forecast/days:lo
  * this client directly after reading and validating the key from
  * [com.closet.core.data.repository.WeatherPreferencesRepository].
  *
- * IMPORTANT: The response DTOs below are based on the Google Weather API design
- * as of early 2025. Verify field names and endpoint against current Google
- * Weather API documentation if responses are empty or parsing fails. The
- * `ignoreUnknownKeys = true` JSON config means extra fields won't cause crashes,
- * but renamed/removed fields will silently default to null/0.
+ * Response DTOs reflect the Google Weather API v1 daily forecast schema.
+ * Temperatures are returned in the unit specified by the API (may be Fahrenheit
+ * depending on locale); they are always converted to °C before returning.
+ * Wind speed is always converted to km/h.
  *
- * Reference: https://developers.google.com/maps/documentation/weather
+ * Reference: https://developers.google.com/maps/documentation/weather/daily-forecast
  */
 @Singleton
 class GoogleWeatherClient @Inject constructor(
@@ -46,7 +45,6 @@ class GoogleWeatherClient @Inject constructor(
                 parameter("location.latitude", lat)
                 parameter("location.longitude", lon)
                 parameter("days", 7)
-                parameter("unitsSystem", "METRIC")
             }.body()
             response.toForecasts()
         }.onFailure { Timber.e(it, "GoogleWeatherClient: fetch failed") }
@@ -58,46 +56,55 @@ class GoogleWeatherClient @Inject constructor(
         @SerialName("forecastDays") val forecastDays: List<GoogleForecastDay> = emptyList(),
     ) {
         fun toForecasts(): List<DailyForecast> = forecastDays.mapIndexed { i, day ->
-            val startTime = day.interval?.startTime
-            val date = if (startTime != null) {
-                runCatching { LocalDate.parse(startTime.take(10)) }.getOrNull()
-            } else null
+            val date = day.displayDate?.toLocalDate()
+                ?: LocalDate.now().plusDays(i.toLong())
             DailyForecast(
-                date = date ?: LocalDate.now().plusDays(i.toLong()),
-                tempLow = day.minTemperature?.degrees ?: 0.0,
-                tempHigh = day.maxTemperature?.degrees ?: 0.0,
+                date = date,
+                tempLow = day.minTemperature?.toCelsius() ?: 0.0,
+                tempHigh = day.maxTemperature?.toCelsius() ?: 0.0,
                 condition = mapConditionType(day.daytimeForecast?.weatherCondition?.type),
                 precipitationMm = day.daytimeForecast?.precipitation?.qpf?.quantity ?: 0.0,
-                windSpeedKmh = day.maxWindSpeed?.value ?: 0.0,
-                uvIndex = day.uvIndex,
-                humidity = null,
+                windSpeedKmh = day.daytimeForecast?.wind?.speed?.toKmh() ?: 0.0,
+                uvIndex = day.daytimeForecast?.uvIndex,
+                humidity = day.daytimeForecast?.relativeHumidity,
             )
         }
     }
 
     @Serializable
     private data class GoogleForecastDay(
-        val interval: TimeInterval? = null,
+        val displayDate: DisplayDate? = null,
         @SerialName("maxTemperature") val maxTemperature: Temperature? = null,
         @SerialName("minTemperature") val minTemperature: Temperature? = null,
         @SerialName("daytimeForecast") val daytimeForecast: DaytimeForecast? = null,
-        @SerialName("maxWindSpeed") val maxWindSpeed: WindSpeed? = null,
-        val uvIndex: Int? = null,
     )
 
     @Serializable
-    private data class TimeInterval(val startTime: String? = null)
+    private data class DisplayDate(
+        val year: Int = 0,
+        val month: Int = 0,
+        val day: Int = 0,
+    ) {
+        fun toLocalDate(): LocalDate? = runCatching {
+            LocalDate.of(year, month, day)
+        }.getOrNull()
+    }
 
     @Serializable
-    private data class Temperature(val degrees: Double = 0.0)
-
-    @Serializable
-    private data class WindSpeed(val value: Double = 0.0)
+    private data class Temperature(
+        val degrees: Double = 0.0,
+        val unit: String = "CELSIUS",
+    ) {
+        fun toCelsius(): Double = if (unit == "FAHRENHEIT") (degrees - 32) * 5.0 / 9.0 else degrees
+    }
 
     @Serializable
     private data class DaytimeForecast(
         val weatherCondition: WeatherConditionDto? = null,
         val precipitation: Precipitation? = null,
+        val wind: Wind? = null,
+        val uvIndex: Int? = null,
+        val relativeHumidity: Int? = null,
     )
 
     @Serializable
@@ -108,6 +115,17 @@ class GoogleWeatherClient @Inject constructor(
 
     @Serializable
     private data class Qpf(val quantity: Double = 0.0)
+
+    @Serializable
+    private data class Wind(val speed: WindSpeed? = null)
+
+    @Serializable
+    private data class WindSpeed(
+        val value: Double = 0.0,
+        val unit: String = "KILOMETERS_PER_HOUR",
+    ) {
+        fun toKmh(): Double = if (unit == "MILES_PER_HOUR") value * 1.60934 else value
+    }
 
     private fun mapConditionType(type: String?): WeatherCondition = when (type?.uppercase()) {
         "CLEAR" -> WeatherCondition.Sunny

--- a/app-android/core/data/src/main/kotlin/com/closet/core/data/weather/GoogleWeatherClient.kt
+++ b/app-android/core/data/src/main/kotlin/com/closet/core/data/weather/GoogleWeatherClient.kt
@@ -45,6 +45,7 @@ class GoogleWeatherClient @Inject constructor(
                 parameter("location.latitude", lat)
                 parameter("location.longitude", lon)
                 parameter("days", 7)
+                parameter("pageSize", 7)
             }.body()
             response.toForecasts()
         }.onFailure { Timber.e(it, "GoogleWeatherClient: fetch failed") }
@@ -129,17 +130,18 @@ class GoogleWeatherClient @Inject constructor(
 
     companion object {
         private fun mapConditionType(type: String?): WeatherCondition = when (type?.uppercase()) {
-            "CLEAR" -> WeatherCondition.Sunny
+            "CLEAR", "MOSTLY_CLEAR" -> WeatherCondition.Sunny
             "PARTLY_CLOUDY" -> WeatherCondition.PartlyCloudy
             "MOSTLY_CLOUDY", "CLOUDY" -> WeatherCondition.Cloudy
             "FOGGY", "FOG" -> WeatherCondition.Foggy
-            "DRIZZLE", "LIGHT_RAIN" -> WeatherCondition.Drizzle
-            "RAIN", "HEAVY_RAIN", "RAIN_SHOWERS" -> WeatherCondition.Rainy
-            "FREEZING_RAIN", "SLEET" -> WeatherCondition.Sleet
+            "DRIZZLE", "LIGHT_RAIN", "LIGHT_RAIN_SHOWERS" -> WeatherCondition.Drizzle
+            "RAIN", "HEAVY_RAIN", "RAIN_SHOWERS", "WIND_AND_RAIN", "SCATTERED_SHOWERS",
+            "HEAVY_RAIN_SHOWERS" -> WeatherCondition.Rainy
+            "FREEZING_RAIN", "SLEET", "RAIN_AND_SNOW" -> WeatherCondition.Sleet
             "SNOW", "LIGHT_SNOW", "SNOW_SHOWERS" -> WeatherCondition.Snowy
             "HEAVY_SNOW", "BLIZZARD" -> WeatherCondition.HeavySnow
-            "THUNDERSTORM" -> WeatherCondition.Thunderstorm
-            "WINDY" -> WeatherCondition.Windy
+            "THUNDERSTORM", "THUNDERSHOWER" -> WeatherCondition.Thunderstorm
+            "WINDY", "SQUALL" -> WeatherCondition.Windy
             else -> WeatherCondition.Cloudy
         }
     }

--- a/app-android/core/data/src/main/kotlin/com/closet/core/data/weather/GoogleWeatherClient.kt
+++ b/app-android/core/data/src/main/kotlin/com/closet/core/data/weather/GoogleWeatherClient.kt
@@ -8,6 +8,7 @@ import io.ktor.client.request.get
 import io.ktor.client.request.parameter
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import kotlinx.coroutines.CancellationException
 import timber.log.Timber
 import java.time.LocalDate
 import javax.inject.Inject
@@ -48,7 +49,7 @@ class GoogleWeatherClient @Inject constructor(
                 parameter("pageSize", 7)
             }.body()
             response.toForecasts()
-        }.onFailure { Timber.e(it, "GoogleWeatherClient: fetch failed") }
+        }.onFailure { if (it is CancellationException) throw it else Timber.e(it, "GoogleWeatherClient: fetch failed") }
 
     // ── Response DTOs ─────────────────────────────────────────────────────────
 

--- a/app-android/core/data/src/main/kotlin/com/closet/core/data/weather/GoogleWeatherClient.kt
+++ b/app-android/core/data/src/main/kotlin/com/closet/core/data/weather/GoogleWeatherClient.kt
@@ -127,18 +127,20 @@ class GoogleWeatherClient @Inject constructor(
         fun toKmh(): Double = if (unit == "MILES_PER_HOUR") value * 1.60934 else value
     }
 
-    private fun mapConditionType(type: String?): WeatherCondition = when (type?.uppercase()) {
-        "CLEAR" -> WeatherCondition.Sunny
-        "PARTLY_CLOUDY" -> WeatherCondition.PartlyCloudy
-        "MOSTLY_CLOUDY", "CLOUDY" -> WeatherCondition.Cloudy
-        "FOGGY", "FOG" -> WeatherCondition.Foggy
-        "DRIZZLE", "LIGHT_RAIN" -> WeatherCondition.Drizzle
-        "RAIN", "HEAVY_RAIN", "RAIN_SHOWERS" -> WeatherCondition.Rainy
-        "FREEZING_RAIN", "SLEET" -> WeatherCondition.Sleet
-        "SNOW", "LIGHT_SNOW", "SNOW_SHOWERS" -> WeatherCondition.Snowy
-        "HEAVY_SNOW", "BLIZZARD" -> WeatherCondition.HeavySnow
-        "THUNDERSTORM" -> WeatherCondition.Thunderstorm
-        "WINDY" -> WeatherCondition.Windy
-        else -> WeatherCondition.Cloudy
+    companion object {
+        private fun mapConditionType(type: String?): WeatherCondition = when (type?.uppercase()) {
+            "CLEAR" -> WeatherCondition.Sunny
+            "PARTLY_CLOUDY" -> WeatherCondition.PartlyCloudy
+            "MOSTLY_CLOUDY", "CLOUDY" -> WeatherCondition.Cloudy
+            "FOGGY", "FOG" -> WeatherCondition.Foggy
+            "DRIZZLE", "LIGHT_RAIN" -> WeatherCondition.Drizzle
+            "RAIN", "HEAVY_RAIN", "RAIN_SHOWERS" -> WeatherCondition.Rainy
+            "FREEZING_RAIN", "SLEET" -> WeatherCondition.Sleet
+            "SNOW", "LIGHT_SNOW", "SNOW_SHOWERS" -> WeatherCondition.Snowy
+            "HEAVY_SNOW", "BLIZZARD" -> WeatherCondition.HeavySnow
+            "THUNDERSTORM" -> WeatherCondition.Thunderstorm
+            "WINDY" -> WeatherCondition.Windy
+            else -> WeatherCondition.Cloudy
+        }
     }
 }

--- a/app-android/core/data/src/main/kotlin/com/closet/core/data/weather/NwsClient.kt
+++ b/app-android/core/data/src/main/kotlin/com/closet/core/data/weather/NwsClient.kt
@@ -6,6 +6,7 @@ import io.ktor.client.HttpClient
 import io.ktor.client.call.body
 import io.ktor.client.request.get
 import io.ktor.client.request.header
+import kotlinx.coroutines.CancellationException
 import kotlinx.serialization.Serializable
 import timber.log.Timber
 import java.time.LocalDate
@@ -27,7 +28,7 @@ private const val USER_AGENT = "(hangr wardrobe app, github.com/Masked-Kunsiquat
  *
  * Notes:
  * - Precipitation (mm) is not available in the basic gridpoint forecast endpoint;
- *   `precipitationMm` is always 0.0.
+ *   `precipitationMm` is always `null`.
  * - UV index and humidity are not available from this endpoint; both are `null`.
  *
  * Reference: https://www.weather.gov/documentation/services-web-api
@@ -38,7 +39,7 @@ class NwsClient @Inject constructor(
 ) : WeatherServiceClient {
 
     override suspend fun fetchDailyForecast(lat: Double, lon: Double): Result<List<DailyForecast>> =
-        runCatching {
+        try {
             // Step 1 — resolve grid point for this lat/lon
             val points: NwsPointsResponse = client.get("$POINTS_URL/$lat,$lon") {
                 header("User-Agent", USER_AGENT)
@@ -51,8 +52,13 @@ class NwsClient @Inject constructor(
                 header("Accept", "application/geo+json")
             }.body()
 
-            mergePeriods(forecast.properties.periods)
-        }.onFailure { Timber.e(it, "NwsClient: fetch failed") }
+            Result.success(mergePeriods(forecast.properties.periods))
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            Timber.e(e, "NwsClient: fetch failed")
+            Result.failure(e)
+        }
 
     /**
      * NWS delivers 12-hour periods (daytime + nighttime). Group by calendar date
@@ -78,14 +84,20 @@ class NwsClient @Inject constructor(
             .map { (date, pair) ->
                 val day = pair.first
                 val night = pair.second
-                val representative = day ?: night!! // safe: filter above guarantees at least one
+                val dayCondition = day?.let { mapShortForecast(it.shortForecast) }
+                val nightCondition = night?.let { mapShortForecast(it.shortForecast) }
+                val worstCondition = worstOf(dayCondition, nightCondition) ?: WeatherCondition.Cloudy
+                val maxWindKmh = maxOf(
+                    day?.let { parseWindSpeedKmh(it.windSpeed) } ?: 0.0,
+                    night?.let { parseWindSpeedKmh(it.windSpeed) } ?: 0.0,
+                )
                 DailyForecast(
                     date = date,
                     tempHigh = (day ?: night!!).temperatureCelsius,
                     tempLow = (night ?: day!!).temperatureCelsius,
-                    condition = mapShortForecast(representative.shortForecast),
-                    precipitationMm = 0.0,
-                    windSpeedKmh = parseWindSpeedKmh(representative.windSpeed),
+                    condition = worstCondition,
+                    precipitationMm = null,
+                    windSpeedKmh = maxWindKmh,
                     uvIndex = null,
                     humidity = null,
                 )
@@ -115,6 +127,32 @@ class NwsClient @Inject constructor(
         if (windSpeed.contains("calm", ignoreCase = true)) return 0.0
         val mph = Regex("""\d+""").findAll(windSpeed).map { it.value.toInt() }.lastOrNull() ?: 0
         return mph * 1.60934
+    }
+
+    /**
+     * Returns the more severe of two [WeatherCondition]s, or the non-null one if only
+     * one is present. Severity order (highest first): Thunderstorm, HeavySnow, Snowy,
+     * Sleet, Rainy, Drizzle, Foggy, Windy, PartlyCloudy, Cloudy, Sunny, null.
+     */
+    private fun worstOf(a: WeatherCondition?, b: WeatherCondition?): WeatherCondition? {
+        if (a == null) return b
+        if (b == null) return a
+        val severity = listOf(
+            WeatherCondition.Thunderstorm,
+            WeatherCondition.HeavySnow,
+            WeatherCondition.Snowy,
+            WeatherCondition.Sleet,
+            WeatherCondition.Rainy,
+            WeatherCondition.Drizzle,
+            WeatherCondition.Foggy,
+            WeatherCondition.Windy,
+            WeatherCondition.PartlyCloudy,
+            WeatherCondition.Cloudy,
+            WeatherCondition.Sunny,
+        )
+        val indexA = severity.indexOf(a).takeIf { it >= 0 } ?: severity.size
+        val indexB = severity.indexOf(b).takeIf { it >= 0 } ?: severity.size
+        return if (indexA <= indexB) a else b
     }
 
     // ── Response DTOs ─────────────────────────────────────────────────────────

--- a/app-android/core/data/src/main/kotlin/com/closet/core/data/weather/NwsClient.kt
+++ b/app-android/core/data/src/main/kotlin/com/closet/core/data/weather/NwsClient.kt
@@ -72,21 +72,24 @@ class NwsClient @Inject constructor(
                 Pair(existing.first, period)
             }
         }
-        return byDate.entries.take(7).map { (date, pair) ->
-            val day = pair.first
-            val night = pair.second
-            val representative = day ?: night!!
-            DailyForecast(
-                date = date,
-                tempHigh = (day ?: night!!).temperatureCelsius,
-                tempLow = (night ?: day!!).temperatureCelsius,
-                condition = mapShortForecast(representative.shortForecast),
-                precipitationMm = 0.0,
-                windSpeedKmh = parseWindSpeedKmh(representative.windSpeed),
-                uvIndex = null,
-                humidity = null,
-            )
-        }
+        return byDate.entries
+            .filter { (_, pair) -> pair.first != null || pair.second != null }
+            .take(7)
+            .map { (date, pair) ->
+                val day = pair.first
+                val night = pair.second
+                val representative = day ?: night!! // safe: filter above guarantees at least one
+                DailyForecast(
+                    date = date,
+                    tempHigh = (day ?: night!!).temperatureCelsius,
+                    tempLow = (night ?: day!!).temperatureCelsius,
+                    condition = mapShortForecast(representative.shortForecast),
+                    precipitationMm = 0.0,
+                    windSpeedKmh = parseWindSpeedKmh(representative.windSpeed),
+                    uvIndex = null,
+                    humidity = null,
+                )
+            }
     }
 
     private fun mapShortForecast(forecast: String): WeatherCondition {

--- a/app-android/core/data/src/main/kotlin/com/closet/core/data/weather/NwsClient.kt
+++ b/app-android/core/data/src/main/kotlin/com/closet/core/data/weather/NwsClient.kt
@@ -1,0 +1,143 @@
+package com.closet.core.data.weather
+
+import com.closet.core.data.model.DailyForecast
+import com.closet.core.data.model.WeatherCondition
+import io.ktor.client.HttpClient
+import io.ktor.client.call.body
+import io.ktor.client.request.get
+import io.ktor.client.request.header
+import kotlinx.serialization.Serializable
+import timber.log.Timber
+import java.time.LocalDate
+import java.time.OffsetDateTime
+import javax.inject.Inject
+import javax.inject.Singleton
+
+private const val POINTS_URL = "https://api.weather.gov/points"
+
+// NWS requires a descriptive User-Agent with contact info.
+private const val USER_AGENT = "(hangr wardrobe app, github.com/Masked-Kunsiquat/closet)"
+
+/**
+ * National Weather Service client. No API key required, but US-only.
+ *
+ * Returns [Result.failure] with a descriptive message for non-US coordinates
+ * (NWS /points returns a 404 for locations outside the US). [WeatherRepository]
+ * surfaces this to the user rather than silently falling back to Open-Meteo.
+ *
+ * Notes:
+ * - Precipitation (mm) is not available in the basic gridpoint forecast endpoint;
+ *   `precipitationMm` is always 0.0.
+ * - UV index and humidity are not available from this endpoint; both are `null`.
+ *
+ * Reference: https://www.weather.gov/documentation/services-web-api
+ */
+@Singleton
+class NwsClient @Inject constructor(
+    private val client: HttpClient,
+) : WeatherServiceClient {
+
+    override suspend fun fetchDailyForecast(lat: Double, lon: Double): Result<List<DailyForecast>> =
+        runCatching {
+            // Step 1 — resolve grid point for this lat/lon
+            val points: NwsPointsResponse = client.get("$POINTS_URL/$lat,$lon") {
+                header("User-Agent", USER_AGENT)
+                header("Accept", "application/geo+json")
+            }.body()
+
+            // Step 2 — fetch the 12-hour period forecast
+            val forecast: NwsForecastResponse = client.get(points.properties.forecast) {
+                header("User-Agent", USER_AGENT)
+                header("Accept", "application/geo+json")
+            }.body()
+
+            mergePeriods(forecast.properties.periods)
+        }.onFailure { Timber.e(it, "NwsClient: fetch failed") }
+
+    /**
+     * NWS delivers 12-hour periods (daytime + nighttime). Group by calendar date
+     * and pick the daytime period's temp as [DailyForecast.tempHigh], nighttime
+     * as [DailyForecast.tempLow]. Either half may be absent (e.g. first period of
+     * the day is already nighttime) — fall back gracefully.
+     */
+    private fun mergePeriods(periods: List<NwsPeriod>): List<DailyForecast> {
+        // date → (daytime period, nighttime period)
+        val byDate = linkedMapOf<LocalDate, Pair<NwsPeriod?, NwsPeriod?>>()
+        for (period in periods) {
+            val date = OffsetDateTime.parse(period.startTime).toLocalDate()
+            val existing = byDate.getOrDefault(date, Pair(null, null))
+            byDate[date] = if (period.isDaytime) {
+                Pair(period, existing.second)
+            } else {
+                Pair(existing.first, period)
+            }
+        }
+        return byDate.entries.take(7).map { (date, pair) ->
+            val day = pair.first
+            val night = pair.second
+            val representative = day ?: night!!
+            DailyForecast(
+                date = date,
+                tempHigh = (day ?: night!!).temperatureCelsius,
+                tempLow = (night ?: day!!).temperatureCelsius,
+                condition = mapShortForecast(representative.shortForecast),
+                precipitationMm = 0.0,
+                windSpeedKmh = parseWindSpeedKmh(representative.windSpeed),
+                uvIndex = null,
+                humidity = null,
+            )
+        }
+    }
+
+    private fun mapShortForecast(forecast: String): WeatherCondition {
+        val f = forecast.lowercase()
+        return when {
+            "thunder" in f -> WeatherCondition.Thunderstorm
+            "heavy snow" in f || "blizzard" in f -> WeatherCondition.HeavySnow
+            "snow" in f || "flurr" in f -> WeatherCondition.Snowy
+            "sleet" in f || "freezing rain" in f -> WeatherCondition.Sleet
+            "drizzle" in f -> WeatherCondition.Drizzle
+            "rain" in f || "shower" in f -> WeatherCondition.Rainy
+            "fog" in f -> WeatherCondition.Foggy
+            "windy" in f || "breezy" in f -> WeatherCondition.Windy
+            "sunny" in f || "clear" in f -> WeatherCondition.Sunny
+            "partly" in f -> WeatherCondition.PartlyCloudy
+            "mostly cloudy" in f || "overcast" in f || "cloudy" in f -> WeatherCondition.Cloudy
+            else -> WeatherCondition.Cloudy
+        }
+    }
+
+    /** Parses "10 mph", "10 to 15 mph", or "Calm" → km/h. Takes the higher bound. */
+    private fun parseWindSpeedKmh(windSpeed: String): Double {
+        if (windSpeed.contains("calm", ignoreCase = true)) return 0.0
+        val mph = Regex("""\d+""").findAll(windSpeed).map { it.value.toInt() }.lastOrNull() ?: 0
+        return mph * 1.60934
+    }
+
+    // ── Response DTOs ─────────────────────────────────────────────────────────
+
+    @Serializable
+    private data class NwsPointsResponse(val properties: PointsProperties)
+
+    @Serializable
+    private data class PointsProperties(val forecast: String)
+
+    @Serializable
+    private data class NwsForecastResponse(val properties: ForecastProperties)
+
+    @Serializable
+    private data class ForecastProperties(val periods: List<NwsPeriod>)
+
+    @Serializable
+    private data class NwsPeriod(
+        val isDaytime: Boolean,
+        val temperature: Double,
+        val temperatureUnit: String,  // "F" or "C"
+        val windSpeed: String,
+        val shortForecast: String,
+        val startTime: String,
+    ) {
+        val temperatureCelsius: Double
+            get() = if (temperatureUnit == "F") (temperature - 32) * 5.0 / 9.0 else temperature
+    }
+}

--- a/app-android/core/data/src/main/kotlin/com/closet/core/data/weather/OpenMeteoClient.kt
+++ b/app-android/core/data/src/main/kotlin/com/closet/core/data/weather/OpenMeteoClient.kt
@@ -1,0 +1,75 @@
+package com.closet.core.data.weather
+
+import com.closet.core.data.model.DailyForecast
+import com.closet.core.data.model.WeatherCondition
+import io.ktor.client.HttpClient
+import io.ktor.client.call.body
+import io.ktor.client.request.get
+import io.ktor.client.request.parameter
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import timber.log.Timber
+import java.time.LocalDate
+import javax.inject.Inject
+import javax.inject.Singleton
+
+private const val BASE_URL = "https://api.open-meteo.com/v1/forecast"
+
+/**
+ * Open-Meteo weather client. Free, no API key required.
+ *
+ * Fetches a 7-day daily forecast. [humidity] is not available in the daily
+ * endpoint (Open-Meteo exposes it hourly only) and is always `null`.
+ *
+ * Reference: https://open-meteo.com/en/docs
+ */
+@Singleton
+class OpenMeteoClient @Inject constructor(
+    private val client: HttpClient,
+) : WeatherServiceClient {
+
+    override suspend fun fetchDailyForecast(lat: Double, lon: Double): Result<List<DailyForecast>> =
+        runCatching {
+            val response: OpenMeteoResponse = client.get(BASE_URL) {
+                parameter("latitude", lat)
+                parameter("longitude", lon)
+                parameter(
+                    "daily",
+                    "temperature_2m_max,temperature_2m_min,precipitation_sum," +
+                        "windspeed_10m_max,weathercode,uv_index_max",
+                )
+                parameter("forecast_days", 7)
+                parameter("timezone", "auto")
+            }.body()
+            response.toForecasts()
+        }.onFailure { Timber.e(it, "OpenMeteoClient: fetch failed") }
+
+    // ── Response DTOs ─────────────────────────────────────────────────────────
+
+    @Serializable
+    private data class OpenMeteoResponse(val daily: DailyData) {
+        fun toForecasts(): List<DailyForecast> = daily.time.indices.map { i ->
+            DailyForecast(
+                date = LocalDate.parse(daily.time[i]),
+                tempLow = daily.temperatureMin[i],
+                tempHigh = daily.temperatureMax[i],
+                condition = WeatherCondition.fromWmoCode(daily.weathercode[i]),
+                precipitationMm = daily.precipitationSum[i],
+                windSpeedKmh = daily.windspeedMax[i],
+                uvIndex = daily.uvIndexMax.getOrNull(i)?.toInt(),
+                humidity = null,
+            )
+        }
+    }
+
+    @Serializable
+    private data class DailyData(
+        val time: List<String>,
+        @SerialName("temperature_2m_max") val temperatureMax: List<Double>,
+        @SerialName("temperature_2m_min") val temperatureMin: List<Double>,
+        @SerialName("precipitation_sum") val precipitationSum: List<Double>,
+        @SerialName("windspeed_10m_max") val windspeedMax: List<Double>,
+        val weathercode: List<Int>,
+        @SerialName("uv_index_max") val uvIndexMax: List<Double> = emptyList(),
+    )
+}

--- a/app-android/core/data/src/main/kotlin/com/closet/core/data/weather/OpenMeteoClient.kt
+++ b/app-android/core/data/src/main/kotlin/com/closet/core/data/weather/OpenMeteoClient.kt
@@ -36,7 +36,7 @@ class OpenMeteoClient @Inject constructor(
                 parameter(
                     "daily",
                     "temperature_2m_max,temperature_2m_min,precipitation_sum," +
-                        "windspeed_10m_max,weathercode,uv_index_max",
+                        "wind_speed_10m_max,weather_code,uv_index_max",
                 )
                 parameter("forecast_days", 7)
                 parameter("timezone", "auto")
@@ -53,7 +53,7 @@ class OpenMeteoClient @Inject constructor(
                 date = LocalDate.parse(daily.time[i]),
                 tempLow = daily.temperatureMin[i],
                 tempHigh = daily.temperatureMax[i],
-                condition = WeatherCondition.fromWmoCode(daily.weathercode[i]),
+                condition = WeatherCondition.fromWmoCode(daily.weatherCode[i]),
                 precipitationMm = daily.precipitationSum[i],
                 windSpeedKmh = daily.windspeedMax[i],
                 uvIndex = daily.uvIndexMax.getOrNull(i)?.toInt(),
@@ -68,8 +68,8 @@ class OpenMeteoClient @Inject constructor(
         @SerialName("temperature_2m_max") val temperatureMax: List<Double>,
         @SerialName("temperature_2m_min") val temperatureMin: List<Double>,
         @SerialName("precipitation_sum") val precipitationSum: List<Double>,
-        @SerialName("windspeed_10m_max") val windspeedMax: List<Double>,
-        val weathercode: List<Int>,
+        @SerialName("wind_speed_10m_max") val windspeedMax: List<Double>,
+        @SerialName("weather_code") val weatherCode: List<Int>,
         @SerialName("uv_index_max") val uvIndexMax: List<Double> = emptyList(),
     )
 }

--- a/app-android/core/data/src/main/kotlin/com/closet/core/data/weather/WeatherServiceClient.kt
+++ b/app-android/core/data/src/main/kotlin/com/closet/core/data/weather/WeatherServiceClient.kt
@@ -1,0 +1,17 @@
+package com.closet.core.data.weather
+
+import com.closet.core.data.model.DailyForecast
+
+/**
+ * Contract for weather service clients that return a 7-day forecast.
+ *
+ * Implementations:
+ * - [OpenMeteoClient] — default, no API key required
+ * - [NwsClient] — US-only, no API key required
+ *
+ * [GoogleWeatherClient] uses a separate method signature (requires an API key)
+ * and does not implement this interface.
+ */
+interface WeatherServiceClient {
+    suspend fun fetchDailyForecast(lat: Double, lon: Double): Result<List<DailyForecast>>
+}

--- a/app-android/features/outfits/src/main/kotlin/com/closet/features/outfits/DayDetailSheet.kt
+++ b/app-android/features/outfits/src/main/kotlin/com/closet/features/outfits/DayDetailSheet.kt
@@ -43,6 +43,8 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
 import com.closet.core.data.dao.OutfitLogWithMeta
+import com.closet.core.data.model.TemperatureUnit
+import com.closet.core.data.model.WeatherCondition
 import java.io.File
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
@@ -73,6 +75,7 @@ internal fun DayDetailSheet(
     onOotdToggle: (logId: Long, currentIsOotd: Boolean) -> Unit,
     onDeleteLog: (logId: Long) -> Unit,
     resolveImage: (String?) -> File?,
+    temperatureUnit: TemperatureUnit = TemperatureUnit.Celsius,
     modifier: Modifier = Modifier,
 ) {
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
@@ -140,6 +143,7 @@ internal fun DayDetailSheet(
                     LogCard(
                         log = log,
                         imageFile = resolveImage(log.coverImage),
+                        temperatureUnit = temperatureUnit,
                         onClick = { onEditLog(log) },
                         onOotdToggle = { onOotdToggle(log.id, log.isOotd == 1) },
                         onDelete = { onDeleteLog(log.id) },
@@ -156,6 +160,7 @@ internal fun DayDetailSheet(
 private fun LogCard(
     log: OutfitLogWithMeta,
     imageFile: File?,
+    temperatureUnit: TemperatureUnit,
     onClick: () -> Unit,
     onOotdToggle: () -> Unit,
     onDelete: () -> Unit,
@@ -209,14 +214,43 @@ private fun LogCard(
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
-                // Show weather + notes summary if either is set
-                val summary = buildList {
-                    log.weatherCondition?.let { add(it) }
-                    log.notes?.let { add(it) }
-                }.joinToString(" · ")
-                if (summary.isNotEmpty()) {
+                // Weather row: condition icon + label + temp range (read-only, stored on log)
+                val condition = WeatherCondition.fromString(log.weatherCondition)
+                val tempText = when {
+                    log.temperatureLow != null && log.temperatureHigh != null ->
+                        "${log.temperatureLow.toDisplayTemp(temperatureUnit)} / ${log.temperatureHigh.toDisplayTemp(temperatureUnit)}"
+                    log.temperatureLow != null -> log.temperatureLow.toDisplayTemp(temperatureUnit)
+                    log.temperatureHigh != null -> log.temperatureHigh.toDisplayTemp(temperatureUnit)
+                    else -> null
+                }
+                val weatherText = listOfNotNull(condition?.label, tempText).joinToString(" · ")
+                if (condition != null || tempText != null) {
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(4.dp),
+                    ) {
+                        if (condition != null) {
+                            Icon(
+                                imageVector = condition.icon(),
+                                contentDescription = null,
+                                modifier = Modifier.size(12.dp),
+                                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                            )
+                        }
+                        if (weatherText.isNotEmpty()) {
+                            Text(
+                                text = weatherText,
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                maxLines = 1,
+                                overflow = TextOverflow.Ellipsis,
+                            )
+                        }
+                    }
+                }
+                if (log.notes != null) {
                     Text(
-                        text = summary,
+                        text = log.notes,
                         style = MaterialTheme.typography.bodySmall,
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
                         maxLines = 1,

--- a/app-android/features/outfits/src/main/kotlin/com/closet/features/outfits/DayDetailSheet.kt
+++ b/app-android/features/outfits/src/main/kotlin/com/closet/features/outfits/DayDetailSheet.kt
@@ -216,11 +216,13 @@ private fun LogCard(
                 )
                 // Weather row: condition icon + label + temp range (read-only, stored on log)
                 val condition = WeatherCondition.fromString(log.weatherCondition)
+                val tempLow = log.temperatureLow
+                val tempHigh = log.temperatureHigh
                 val tempText = when {
-                    log.temperatureLow != null && log.temperatureHigh != null ->
-                        "${log.temperatureLow.toDisplayTemp(temperatureUnit)} / ${log.temperatureHigh.toDisplayTemp(temperatureUnit)}"
-                    log.temperatureLow != null -> log.temperatureLow.toDisplayTemp(temperatureUnit)
-                    log.temperatureHigh != null -> log.temperatureHigh.toDisplayTemp(temperatureUnit)
+                    tempLow != null && tempHigh != null ->
+                        "${tempLow.toDisplayTemp(temperatureUnit)} / ${tempHigh.toDisplayTemp(temperatureUnit)}"
+                    tempLow != null -> tempLow.toDisplayTemp(temperatureUnit)
+                    tempHigh != null -> tempHigh.toDisplayTemp(temperatureUnit)
                     else -> null
                 }
                 val weatherText = listOfNotNull(condition?.label, tempText).joinToString(" · ")
@@ -248,9 +250,10 @@ private fun LogCard(
                         }
                     }
                 }
-                if (log.notes != null) {
+                val notes = log.notes
+                if (notes != null) {
                     Text(
-                        text = log.notes,
+                        text = notes,
                         style = MaterialTheme.typography.bodySmall,
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
                         maxLines = 1,

--- a/app-android/features/outfits/src/main/kotlin/com/closet/features/outfits/ForecastSheet.kt
+++ b/app-android/features/outfits/src/main/kotlin/com/closet/features/outfits/ForecastSheet.kt
@@ -68,12 +68,20 @@ internal fun ForecastSheet(
                 modifier = Modifier.padding(bottom = 16.dp),
             )
             val today = remember { LocalDate.now() }
-            forecasts.forEachIndexed { index, forecast ->
-                DailyForecastRow(forecast = forecast, temperatureUnit = temperatureUnit, today = today)
-                if (index < forecasts.lastIndex) {
-                    HorizontalDivider(
-                        color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f),
-                    )
+            if (forecasts.isEmpty()) {
+                Text(
+                    text = stringResource(R.string.journal_forecast_empty),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            } else {
+                forecasts.forEachIndexed { index, forecast ->
+                    DailyForecastRow(forecast = forecast, temperatureUnit = temperatureUnit, today = today)
+                    if (index < forecasts.lastIndex) {
+                        HorizontalDivider(
+                            color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f),
+                        )
+                    }
                 }
             }
         }

--- a/app-android/features/outfits/src/main/kotlin/com/closet/features/outfits/ForecastSheet.kt
+++ b/app-android/features/outfits/src/main/kotlin/com/closet/features/outfits/ForecastSheet.kt
@@ -2,6 +2,8 @@ package com.closet.features.outfits
 
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -57,6 +59,7 @@ internal fun ForecastSheet(
         Column(
             modifier = Modifier
                 .fillMaxWidth()
+                .verticalScroll(rememberScrollState())
                 .padding(horizontal = 24.dp)
                 .padding(bottom = 32.dp),
         ) {
@@ -118,7 +121,11 @@ private fun DailyForecastRow(
             modifier = Modifier.weight(1.2f),
         )
         Text(
-            text = "${forecast.tempLow.toDisplayTemp(temperatureUnit)} / ${forecast.tempHigh.toDisplayTemp(temperatureUnit)}",
+            text = stringResource(
+                R.string.journal_forecast_temp_range,
+                forecast.tempLow.toDisplayTemp(temperatureUnit),
+                forecast.tempHigh.toDisplayTemp(temperatureUnit),
+            ),
             style = MaterialTheme.typography.bodyMedium,
             textAlign = TextAlign.End,
         )

--- a/app-android/features/outfits/src/main/kotlin/com/closet/features/outfits/ForecastSheet.kt
+++ b/app-android/features/outfits/src/main/kotlin/com/closet/features/outfits/ForecastSheet.kt
@@ -15,6 +15,7 @@ import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Text
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
@@ -28,13 +29,10 @@ import java.time.format.TextStyle
 import java.util.Locale
 
 @Composable
-private fun LocalDate.toForecastLabelComposable(): String {
-    val today = LocalDate.now()
-    return when (this) {
-        today -> stringResource(R.string.journal_forecast_today)
-        today.plusDays(1) -> stringResource(R.string.journal_forecast_tomorrow)
-        else -> "${dayOfWeek.getDisplayName(TextStyle.SHORT, Locale.getDefault())} $dayOfMonth"
-    }
+private fun LocalDate.toForecastLabelComposable(today: LocalDate): String = when (this) {
+    today -> stringResource(R.string.journal_forecast_today)
+    today.plusDays(1) -> stringResource(R.string.journal_forecast_tomorrow)
+    else -> "${dayOfWeek.getDisplayName(TextStyle.SHORT, Locale.getDefault())} $dayOfMonth"
 }
 
 /**
@@ -69,11 +67,14 @@ internal fun ForecastSheet(
                 fontWeight = FontWeight.SemiBold,
                 modifier = Modifier.padding(bottom = 16.dp),
             )
-            forecasts.forEach { forecast ->
-                DailyForecastRow(forecast = forecast, temperatureUnit = temperatureUnit)
-                HorizontalDivider(
-                    color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f),
-                )
+            val today = remember { LocalDate.now() }
+            forecasts.forEachIndexed { index, forecast ->
+                DailyForecastRow(forecast = forecast, temperatureUnit = temperatureUnit, today = today)
+                if (index < forecasts.lastIndex) {
+                    HorizontalDivider(
+                        color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f),
+                    )
+                }
             }
         }
     }
@@ -83,6 +84,7 @@ internal fun ForecastSheet(
 private fun DailyForecastRow(
     forecast: DailyForecast,
     temperatureUnit: TemperatureUnit,
+    today: LocalDate,
     modifier: Modifier = Modifier,
 ) {
     Row(
@@ -92,7 +94,7 @@ private fun DailyForecastRow(
         verticalAlignment = Alignment.CenterVertically,
     ) {
         Text(
-            text = forecast.date.toForecastLabelComposable(),
+            text = forecast.date.toForecastLabelComposable(today),
             style = MaterialTheme.typography.bodyMedium,
             modifier = Modifier.weight(1f),
         )

--- a/app-android/features/outfits/src/main/kotlin/com/closet/features/outfits/ForecastSheet.kt
+++ b/app-android/features/outfits/src/main/kotlin/com/closet/features/outfits/ForecastSheet.kt
@@ -1,0 +1,116 @@
+package com.closet.features.outfits
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import com.closet.core.data.model.DailyForecast
+import com.closet.core.data.model.TemperatureUnit
+import java.time.LocalDate
+import java.time.format.TextStyle
+import java.util.Locale
+
+/**
+ * Bottom sheet showing a 7-day forecast.
+ *
+ * Opened by tapping the [TodayForecastChip] on the Journal header.
+ * Temperature values are formatted in [temperatureUnit].
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+internal fun ForecastSheet(
+    forecasts: List<DailyForecast>,
+    temperatureUnit: TemperatureUnit,
+    onDismiss: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    ModalBottomSheet(
+        onDismissRequest = onDismiss,
+        sheetState = sheetState,
+        modifier = modifier,
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 24.dp)
+                .padding(bottom = 32.dp),
+        ) {
+            Text(
+                text = stringResource(R.string.journal_forecast_sheet_title),
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.SemiBold,
+                modifier = Modifier.padding(bottom = 16.dp),
+            )
+            forecasts.forEach { forecast ->
+                DailyForecastRow(forecast = forecast, temperatureUnit = temperatureUnit)
+                HorizontalDivider(
+                    color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f),
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun DailyForecastRow(
+    forecast: DailyForecast,
+    temperatureUnit: TemperatureUnit,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(vertical = 12.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(
+            text = forecast.date.toForecastLabel(),
+            style = MaterialTheme.typography.bodyMedium,
+            modifier = Modifier.weight(1f),
+        )
+        Icon(
+            imageVector = forecast.condition.icon(),
+            contentDescription = forecast.condition.label,
+            modifier = Modifier.size(18.dp),
+        )
+        Spacer(Modifier.width(6.dp))
+        Text(
+            text = forecast.condition.label,
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.weight(1.2f),
+        )
+        Text(
+            text = "${forecast.tempLow.toDisplayTemp(temperatureUnit)} / ${forecast.tempHigh.toDisplayTemp(temperatureUnit)}",
+            style = MaterialTheme.typography.bodyMedium,
+            textAlign = TextAlign.End,
+        )
+    }
+}
+
+private fun LocalDate.toForecastLabel(): String {
+    val today = LocalDate.now()
+    return when (this) {
+        today -> "Today"
+        today.plusDays(1) -> "Tomorrow"
+        else -> "${dayOfWeek.getDisplayName(TextStyle.SHORT, Locale.getDefault())} $dayOfMonth"
+    }
+}

--- a/app-android/features/outfits/src/main/kotlin/com/closet/features/outfits/ForecastSheet.kt
+++ b/app-android/features/outfits/src/main/kotlin/com/closet/features/outfits/ForecastSheet.kt
@@ -15,7 +15,6 @@ import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Text
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
@@ -67,7 +66,7 @@ internal fun ForecastSheet(
                 fontWeight = FontWeight.SemiBold,
                 modifier = Modifier.padding(bottom = 16.dp),
             )
-            val today = remember { LocalDate.now() }
+            val today = LocalDate.now()
             if (forecasts.isEmpty()) {
                 Text(
                     text = stringResource(R.string.journal_forecast_empty),

--- a/app-android/features/outfits/src/main/kotlin/com/closet/features/outfits/ForecastSheet.kt
+++ b/app-android/features/outfits/src/main/kotlin/com/closet/features/outfits/ForecastSheet.kt
@@ -27,6 +27,16 @@ import java.time.LocalDate
 import java.time.format.TextStyle
 import java.util.Locale
 
+@Composable
+private fun LocalDate.toForecastLabelComposable(): String {
+    val today = LocalDate.now()
+    return when (this) {
+        today -> stringResource(R.string.journal_forecast_today)
+        today.plusDays(1) -> stringResource(R.string.journal_forecast_tomorrow)
+        else -> "${dayOfWeek.getDisplayName(TextStyle.SHORT, Locale.getDefault())} $dayOfMonth"
+    }
+}
+
 /**
  * Bottom sheet showing a 7-day forecast.
  *
@@ -82,13 +92,13 @@ private fun DailyForecastRow(
         verticalAlignment = Alignment.CenterVertically,
     ) {
         Text(
-            text = forecast.date.toForecastLabel(),
+            text = forecast.date.toForecastLabelComposable(),
             style = MaterialTheme.typography.bodyMedium,
             modifier = Modifier.weight(1f),
         )
         Icon(
             imageVector = forecast.condition.icon(),
-            contentDescription = forecast.condition.label,
+            contentDescription = null, // decorative — condition label follows immediately
             modifier = Modifier.size(18.dp),
         )
         Spacer(Modifier.width(6.dp))
@@ -106,11 +116,3 @@ private fun DailyForecastRow(
     }
 }
 
-private fun LocalDate.toForecastLabel(): String {
-    val today = LocalDate.now()
-    return when (this) {
-        today -> "Today"
-        today.plusDays(1) -> "Tomorrow"
-        else -> "${dayOfWeek.getDisplayName(TextStyle.SHORT, Locale.getDefault())} $dayOfMonth"
-    }
-}

--- a/app-android/features/outfits/src/main/kotlin/com/closet/features/outfits/JournalScreen.kt
+++ b/app-android/features/outfits/src/main/kotlin/com/closet/features/outfits/JournalScreen.kt
@@ -217,6 +217,7 @@ internal fun JournalContent(
                 onOotdToggle = onOotdToggle,
                 onDeleteLog = onDeleteLog,
                 resolveImage = resolveImage,
+                temperatureUnit = uiState.temperatureUnit,
             )
         }
     }

--- a/app-android/features/outfits/src/main/kotlin/com/closet/features/outfits/JournalScreen.kt
+++ b/app-android/features/outfits/src/main/kotlin/com/closet/features/outfits/JournalScreen.kt
@@ -19,6 +19,8 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.KeyboardArrowLeft
 import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
+import androidx.compose.material3.AssistChip
+import androidx.compose.material3.AssistChipDefaults
 import androidx.compose.material3.CenterAlignedTopAppBar
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
@@ -48,7 +50,9 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.closet.core.data.dao.CalendarDay
 import com.closet.core.data.dao.OutfitLogWithMeta
+import com.closet.core.data.model.DailyForecast
 import com.closet.core.data.model.OutfitWithItems
+import com.closet.core.data.model.TemperatureUnit
 import com.closet.core.data.model.WeatherCondition
 import java.io.File
 import java.time.DayOfWeek
@@ -96,6 +100,8 @@ fun JournalScreen(
         onDismissEdit = viewModel::dismissLogEdit,
         onSaveEdit = viewModel::saveLogEdit,
         resolveImage = viewModel::resolveImagePath,
+        onForecastChipClick = viewModel::openForecastSheet,
+        onDismissForecastSheet = viewModel::closeForecastSheet,
         modifier = modifier,
     )
 }
@@ -121,6 +127,8 @@ internal fun JournalContent(
     onDismissEdit: () -> Unit,
     onSaveEdit: (notes: String?, weatherCondition: WeatherCondition?) -> Unit,
     resolveImage: (String?) -> File?,
+    onForecastChipClick: () -> Unit,
+    onDismissForecastSheet: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val today = remember(uiState.currentYearMonth) { LocalDate.now() }
@@ -144,6 +152,15 @@ internal fun JournalContent(
                 .verticalScroll(rememberScrollState())
                 .padding(horizontal = 16.dp, vertical = 8.dp)
         ) {
+            if (uiState.todayForecast != null) {
+                TodayForecastChip(
+                    forecast = uiState.todayForecast,
+                    temperatureUnit = uiState.temperatureUnit,
+                    onClick = onForecastChipClick,
+                )
+                Spacer(Modifier.height(4.dp))
+            }
+
             MonthNavHeader(
                 yearMonth = uiState.currentYearMonth,
                 onPrevious = onPreviousMonth,
@@ -166,6 +183,14 @@ internal fun JournalContent(
                 JournalEmptyState()
             }
         }
+    }
+
+    if (uiState.showForecastSheet) {
+        ForecastSheet(
+            forecasts = uiState.forecastDays,
+            temperatureUnit = uiState.temperatureUnit,
+            onDismiss = onDismissForecastSheet,
+        )
     }
 
     val selectedDate = uiState.selectedDate
@@ -374,6 +399,35 @@ private fun DayCell(
             )
         }
     }
+}
+
+// ─── Today's forecast chip ────────────────────────────────────────────────────
+
+@Composable
+private fun TodayForecastChip(
+    forecast: DailyForecast,
+    temperatureUnit: TemperatureUnit,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    AssistChip(
+        onClick = onClick,
+        label = {
+            Text(
+                text = "${forecast.condition.label} · " +
+                    "${forecast.tempLow.toDisplayTemp(temperatureUnit)} / " +
+                    forecast.tempHigh.toDisplayTemp(temperatureUnit),
+            )
+        },
+        leadingIcon = {
+            Icon(
+                imageVector = forecast.condition.icon(),
+                contentDescription = null,
+                modifier = Modifier.size(AssistChipDefaults.IconSize),
+            )
+        },
+        modifier = modifier,
+    )
 }
 
 // ─── Empty state ──────────────────────────────────────────────────────────────

--- a/app-android/features/outfits/src/main/kotlin/com/closet/features/outfits/JournalViewModel.kt
+++ b/app-android/features/outfits/src/main/kotlin/com/closet/features/outfits/JournalViewModel.kt
@@ -305,6 +305,8 @@ class JournalViewModel @Inject constructor(
                 temperatureLow = forecast?.tempLow,
                 temperatureHigh = forecast?.tempHigh,
                 weatherCondition = forecast?.condition,
+                precipitationMm = forecast?.precipitationMm,
+                windSpeedKmh = forecast?.windSpeedKmh,
             )) {
                 is DataResult.Success -> _showOutfitPicker.value = false
                 is DataResult.Error -> {

--- a/app-android/features/outfits/src/main/kotlin/com/closet/features/outfits/JournalViewModel.kt
+++ b/app-android/features/outfits/src/main/kotlin/com/closet/features/outfits/JournalViewModel.kt
@@ -90,13 +90,17 @@ class JournalViewModel @Inject constructor(
     private val _showForecastSheet = MutableStateFlow(false)
 
     // Emits today's 7-day forecast whenever weather is enabled; empty list when disabled.
+    // Emits emptyList() immediately so combine() is not blocked while the fetch is in-flight.
     private val forecastDays: Flow<List<DailyForecast>> =
         weatherPrefsRepo.getWeatherEnabled().flatMapLatest { enabled ->
             if (!enabled) flowOf(emptyList())
             else flow {
-                weatherRepository.getForecast()
-                    .onSuccess { emit(it) }
-                    .onFailure { Timber.w(it, "JournalViewModel: forecast unavailable") }
+                emit(emptyList())
+                when (val result = weatherRepository.getForecast()) {
+                    is DataResult.Success -> emit(result.data)
+                    is DataResult.Error -> Timber.w(result.throwable, "JournalViewModel: forecast unavailable")
+                    DataResult.Loading -> Unit
+                }
             }
         }
 

--- a/app-android/features/outfits/src/main/kotlin/com/closet/features/outfits/JournalViewModel.kt
+++ b/app-android/features/outfits/src/main/kotlin/com/closet/features/outfits/JournalViewModel.kt
@@ -4,12 +4,16 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.closet.core.data.dao.CalendarDay
 import com.closet.core.data.dao.OutfitLogWithMeta
+import com.closet.core.data.model.DailyForecast
 import com.closet.core.data.model.OutfitLogEntity
 import com.closet.core.data.model.OutfitWithItems
+import com.closet.core.data.model.TemperatureUnit
 import com.closet.core.data.model.WeatherCondition
 import com.closet.core.data.repository.LogRepository
 import com.closet.core.data.repository.OutfitRepository
 import com.closet.core.data.repository.StorageRepository
+import com.closet.core.data.repository.WeatherPreferencesRepository
+import com.closet.core.data.repository.WeatherRepository
 import com.closet.core.data.util.AppError
 import com.closet.core.data.util.DataResult
 import com.closet.core.ui.util.UserMessage
@@ -19,6 +23,7 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.channels.BufferOverflow
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
@@ -27,6 +32,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
@@ -54,6 +60,10 @@ data class JournalUiState(
     val logsForSelectedDate: List<OutfitLogWithMeta> = emptyList(),
     val showOutfitPicker: Boolean = false,
     val editingLog: OutfitLogWithMeta? = null,
+    val todayForecast: DailyForecast? = null,
+    val forecastDays: List<DailyForecast> = emptyList(),
+    val showForecastSheet: Boolean = false,
+    val temperatureUnit: TemperatureUnit = TemperatureUnit.Celsius,
 )
 
 /**
@@ -69,12 +79,28 @@ class JournalViewModel @Inject constructor(
     private val logRepository: LogRepository,
     private val outfitRepository: OutfitRepository,
     private val storageRepository: StorageRepository,
+    private val weatherRepository: WeatherRepository,
+    private val weatherPrefsRepo: WeatherPreferencesRepository,
 ) : ViewModel() {
 
     private val _currentYearMonth = MutableStateFlow(YearMonth.now())
     private val _selectedDate = MutableStateFlow<String?>(null)
     private val _showOutfitPicker = MutableStateFlow(false)
     private val _editingLog = MutableStateFlow<OutfitLogWithMeta?>(null)
+    private val _showForecastSheet = MutableStateFlow(false)
+
+    // Emits today's 7-day forecast whenever weather is enabled; empty list when disabled.
+    private val forecastDays: Flow<List<DailyForecast>> =
+        weatherPrefsRepo.getWeatherEnabled().flatMapLatest { enabled ->
+            if (!enabled) flowOf(emptyList())
+            else flow {
+                weatherRepository.getForecast()
+                    .onSuccess { emit(it) }
+                    .onFailure { Timber.w(it, "JournalViewModel: forecast unavailable") }
+            }
+        }
+
+    private val temperatureUnit: Flow<TemperatureUnit> = weatherPrefsRepo.getTemperatureUnit()
 
     private val _actionError = MutableSharedFlow<UserMessage>(
         replay = 0,
@@ -111,6 +137,16 @@ class JournalViewModel @Inject constructor(
         )
     }.combine(_editingLog) { state, editingLog ->
         state.copy(editingLog = editingLog)
+    }.combine(forecastDays) { state, forecasts ->
+        val today = LocalDate.now()
+        state.copy(
+            todayForecast = forecasts.find { it.date == today },
+            forecastDays = forecasts,
+        )
+    }.combine(_showForecastSheet) { state, show ->
+        state.copy(showForecastSheet = show)
+    }.combine(temperatureUnit) { state, unit ->
+        state.copy(temperatureUnit = unit)
     }.stateIn(
         scope = viewModelScope,
         started = SharingStarted.WhileSubscribed(5_000),
@@ -268,6 +304,9 @@ class JournalViewModel @Inject constructor(
             }
         }
     }
+
+    fun openForecastSheet() { _showForecastSheet.value = true }
+    fun closeForecastSheet() { _showForecastSheet.value = false }
 
     /** Resolves a relative image path to an absolute [File] for Coil. */
     fun resolveImagePath(path: String?): File? = path?.let { storageRepository.getFile(it) }

--- a/app-android/features/outfits/src/main/kotlin/com/closet/features/outfits/JournalViewModel.kt
+++ b/app-android/features/outfits/src/main/kotlin/com/closet/features/outfits/JournalViewModel.kt
@@ -288,13 +288,24 @@ class JournalViewModel @Inject constructor(
     /**
      * Logs [outfitId] as worn on the currently selected date, then closes the picker.
      * Idempotent — no-op if the outfit was already logged for that date.
+     *
+     * If a cached forecast entry exists for the selected date, its temperature and
+     * condition values are pre-populated on the new log. The user can still override
+     * them via [openLogEdit].
      */
     fun logOutfitOnDate(outfitId: Long) {
         viewModelScope.launch {
             val date = _selectedDate.value ?: return@launch
             val parsedDate = runCatching { LocalDate.parse(date) }.getOrNull() ?: return@launch
             if (parsedDate.isAfter(LocalDate.now())) return@launch
-            when (val result = logRepository.wearOutfitOnDate(outfitId, date)) {
+            val forecast = uiState.value.forecastDays.find { it.date == parsedDate }
+            when (val result = logRepository.wearOutfitOnDate(
+                outfitId = outfitId,
+                date = date,
+                temperatureLow = forecast?.tempLow,
+                temperatureHigh = forecast?.tempHigh,
+                weatherCondition = forecast?.condition,
+            )) {
                 is DataResult.Success -> _showOutfitPicker.value = false
                 is DataResult.Error -> {
                     Timber.e(result.throwable, "logOutfitOnDate: failed to log outfit $outfitId on $date")

--- a/app-android/features/outfits/src/main/kotlin/com/closet/features/outfits/LogEditSheet.kt
+++ b/app-android/features/outfits/src/main/kotlin/com/closet/features/outfits/LogEditSheet.kt
@@ -12,13 +12,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.outlined.AcUnit
-import androidx.compose.material.icons.outlined.Air
-import androidx.compose.material.icons.outlined.Cloud
-import androidx.compose.material.icons.outlined.Grain
-import androidx.compose.material.icons.outlined.WbCloudy
-import androidx.compose.material.icons.outlined.WbSunny
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FilterChip
 import androidx.compose.material3.Icon
@@ -36,7 +29,6 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
@@ -158,13 +150,3 @@ internal fun LogEditSheet(
     }
 }
 
-// ─── Weather icon mapping ─────────────────────────────────────────────────────
-
-private fun WeatherCondition.icon(): ImageVector = when (this) {
-    WeatherCondition.Sunny       -> Icons.Outlined.WbSunny
-    WeatherCondition.PartlyCloudy -> Icons.Outlined.WbCloudy
-    WeatherCondition.Cloudy      -> Icons.Outlined.Cloud
-    WeatherCondition.Rainy       -> Icons.Outlined.Grain
-    WeatherCondition.Snowy       -> Icons.Outlined.AcUnit
-    WeatherCondition.Windy       -> Icons.Outlined.Air
-}

--- a/app-android/features/outfits/src/main/kotlin/com/closet/features/outfits/WeatherConditionExt.kt
+++ b/app-android/features/outfits/src/main/kotlin/com/closet/features/outfits/WeatherConditionExt.kt
@@ -1,0 +1,34 @@
+package com.closet.features.outfits
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.AcUnit
+import androidx.compose.material.icons.outlined.Air
+import androidx.compose.material.icons.outlined.Cloud
+import androidx.compose.material.icons.outlined.Grain
+import androidx.compose.material.icons.outlined.Thunderstorm
+import androidx.compose.material.icons.outlined.WbCloudy
+import androidx.compose.material.icons.outlined.WbSunny
+import androidx.compose.ui.graphics.vector.ImageVector
+import com.closet.core.data.model.TemperatureUnit
+import com.closet.core.data.model.WeatherCondition
+import kotlin.math.roundToInt
+
+internal fun WeatherCondition.icon(): ImageVector = when (this) {
+    WeatherCondition.Sunny        -> Icons.Outlined.WbSunny
+    WeatherCondition.PartlyCloudy -> Icons.Outlined.WbCloudy
+    WeatherCondition.Cloudy       -> Icons.Outlined.Cloud
+    WeatherCondition.Rainy        -> Icons.Outlined.Grain
+    WeatherCondition.Snowy        -> Icons.Outlined.AcUnit
+    WeatherCondition.Windy        -> Icons.Outlined.Air
+    WeatherCondition.Thunderstorm -> Icons.Outlined.Thunderstorm
+    WeatherCondition.Foggy        -> Icons.Outlined.Cloud
+    WeatherCondition.Drizzle      -> Icons.Outlined.Grain
+    WeatherCondition.Sleet        -> Icons.Outlined.AcUnit
+    WeatherCondition.HeavySnow    -> Icons.Outlined.AcUnit
+}
+
+/** Converts a °C value to the user's preferred display unit and formats it as "N°". */
+internal fun Double.toDisplayTemp(unit: TemperatureUnit): String {
+    val value = if (unit == TemperatureUnit.Fahrenheit) (this * 9.0 / 5.0 + 32) else this
+    return "${value.roundToInt()}°"
+}

--- a/app-android/features/outfits/src/main/res/values/strings.xml
+++ b/app-android/features/outfits/src/main/res/values/strings.xml
@@ -45,6 +45,7 @@
     <string name="journal_forecast_sheet_title">7-Day Forecast</string>
     <string name="journal_forecast_today">Today</string>
     <string name="journal_forecast_tomorrow">Tomorrow</string>
+    <string name="journal_forecast_empty">Forecast unavailable</string>
 
     <!-- Outfit Builder -->
     <string name="outfits_builder_title">New Outfit</string>

--- a/app-android/features/outfits/src/main/res/values/strings.xml
+++ b/app-android/features/outfits/src/main/res/values/strings.xml
@@ -41,6 +41,8 @@
     <string name="journal_edit_weather_label">Weather</string>
     <string name="journal_edit_save">Save</string>
     <string name="journal_edit_cancel">Cancel</string>
+    <string name="journal_forecast_chip_description">Today\'s forecast — tap to see 7-day forecast</string>
+    <string name="journal_forecast_sheet_title">7-Day Forecast</string>
 
     <!-- Outfit Builder -->
     <string name="outfits_builder_title">New Outfit</string>

--- a/app-android/features/outfits/src/main/res/values/strings.xml
+++ b/app-android/features/outfits/src/main/res/values/strings.xml
@@ -46,6 +46,7 @@
     <string name="journal_forecast_today">Today</string>
     <string name="journal_forecast_tomorrow">Tomorrow</string>
     <string name="journal_forecast_empty">Forecast unavailable</string>
+    <string name="journal_forecast_temp_range">%1$s / %2$s</string>
 
     <!-- Outfit Builder -->
     <string name="outfits_builder_title">New Outfit</string>

--- a/app-android/features/outfits/src/main/res/values/strings.xml
+++ b/app-android/features/outfits/src/main/res/values/strings.xml
@@ -43,6 +43,8 @@
     <string name="journal_edit_cancel">Cancel</string>
     <string name="journal_forecast_chip_description">Today\'s forecast — tap to see 7-day forecast</string>
     <string name="journal_forecast_sheet_title">7-Day Forecast</string>
+    <string name="journal_forecast_today">Today</string>
+    <string name="journal_forecast_tomorrow">Tomorrow</string>
 
     <!-- Outfit Builder -->
     <string name="outfits_builder_title">New Outfit</string>

--- a/app-android/features/settings/build.gradle.kts
+++ b/app-android/features/settings/build.gradle.kts
@@ -43,6 +43,7 @@ dependencies {
     implementation(libs.androidx.compose.material.icons.extended)
     debugImplementation(libs.androidx.ui.tooling)
 
+    implementation(libs.androidx.activity.compose)
     implementation(libs.androidx.navigation.compose)
     implementation(libs.kotlinx.serialization.json)
 

--- a/app-android/features/settings/build.gradle.kts
+++ b/app-android/features/settings/build.gradle.kts
@@ -34,6 +34,7 @@ kotlin {
 
 dependencies {
     implementation(project(":core:ui"))
+    implementation(project(":core:data"))
 
     implementation(platform(libs.androidx.compose.bom))
     implementation(libs.androidx.ui)

--- a/app-android/features/settings/src/main/kotlin/com/closet/features/settings/SettingsScreen.kt
+++ b/app-android/features/settings/src/main/kotlin/com/closet/features/settings/SettingsScreen.kt
@@ -270,9 +270,9 @@ internal fun SettingsContent(
                         onSelect = onTemperatureUnitChange,
                     )
                 }
-                item {
-                    ClearCacheItem(onClick = onClearCache)
-                }
+            }
+            item {
+                ClearCacheItem(onClick = onClearCache)
             }
         }
     }

--- a/app-android/features/settings/src/main/kotlin/com/closet/features/settings/SettingsScreen.kt
+++ b/app-android/features/settings/src/main/kotlin/com/closet/features/settings/SettingsScreen.kt
@@ -9,11 +9,13 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material3.CenterAlignedTopAppBar
@@ -22,7 +24,11 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.ListItem
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SegmentedButton
+import androidx.compose.material3.SegmentedButtonDefaults
+import androidx.compose.material3.SingleChoiceSegmentedButtonRow
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -36,18 +42,21 @@ import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.role
 import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.closet.core.data.model.TemperatureUnit
+import com.closet.core.data.model.WeatherService
 import com.closet.core.ui.theme.ClosetAccent
 import com.closet.core.ui.theme.ClosetTheme
 
 /**
  * Settings screen entry point.
  *
- * Collects [SettingsViewModel.accent] and [SettingsViewModel.dynamicColor] and
- * delegates all rendering to [SettingsContent].
+ * Collects all [SettingsViewModel] state and delegates rendering to [SettingsContent].
  *
  * @param onNavigateUp Called when the user taps the back arrow.
  * @param viewModel Hilt-provided [SettingsViewModel]; override in tests.
@@ -59,12 +68,25 @@ fun SettingsScreen(
 ) {
     val accent by viewModel.accent.collectAsStateWithLifecycle()
     val dynamicColor by viewModel.dynamicColor.collectAsStateWithLifecycle()
+    val weatherEnabled by viewModel.weatherEnabled.collectAsStateWithLifecycle()
+    val weatherService by viewModel.weatherService.collectAsStateWithLifecycle()
+    val googleApiKey by viewModel.googleApiKey.collectAsStateWithLifecycle()
+    val temperatureUnit by viewModel.temperatureUnit.collectAsStateWithLifecycle()
 
     SettingsContent(
         currentAccent = accent,
         dynamicColor = dynamicColor,
         onSetAccent = viewModel::setAccent,
         onSetDynamicColor = viewModel::setDynamicColor,
+        weatherEnabled = weatherEnabled,
+        weatherService = weatherService,
+        googleApiKey = googleApiKey,
+        temperatureUnit = temperatureUnit,
+        onWeatherEnabledChange = viewModel::setWeatherEnabled,
+        onWeatherServiceChange = viewModel::setWeatherService,
+        onGoogleApiKeyChange = viewModel::setGoogleApiKey,
+        onTemperatureUnitChange = viewModel::setTemperatureUnit,
+        onClearCache = viewModel::clearForecastCache,
         onNavigateUp = onNavigateUp,
     )
 }
@@ -72,18 +94,10 @@ fun SettingsScreen(
 /**
  * Stateless rendering of the Settings screen.
  *
- * Layout: a [Scaffold] with a [CenterAlignedTopAppBar] and a [LazyColumn] body.
- * The Appearance section contains:
- * - A "Use system colors" [Switch] (shown only on Android 12+) that enables
- *   Material You dynamic color.
- * - An accent colour swatch row, disabled when dynamic color is active since
- *   it has no effect while Material You is in control.
- *
- * @param currentAccent The currently active [ClosetAccent].
- * @param dynamicColor Whether Material You dynamic color is enabled.
- * @param onSetAccent Invoked with the newly selected [ClosetAccent].
- * @param onSetDynamicColor Invoked with the new dynamic color enabled state.
- * @param onNavigateUp Called when the user taps the back arrow.
+ * Sections:
+ * - **Appearance**: dynamic color toggle (API 31+) + accent color picker.
+ * - **Weather**: forecast toggle; when on — service picker, optional API key
+ *   field (Google only), temperature unit picker, and a clear-cache action.
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -92,6 +106,15 @@ internal fun SettingsContent(
     dynamicColor: Boolean,
     onSetAccent: (ClosetAccent) -> Unit,
     onSetDynamicColor: (Boolean) -> Unit,
+    weatherEnabled: Boolean,
+    weatherService: WeatherService,
+    googleApiKey: String,
+    temperatureUnit: TemperatureUnit,
+    onWeatherEnabledChange: (Boolean) -> Unit,
+    onWeatherServiceChange: (WeatherService) -> Unit,
+    onGoogleApiKeyChange: (String) -> Unit,
+    onTemperatureUnitChange: (TemperatureUnit) -> Unit,
+    onClearCache: () -> Unit,
     onNavigateUp: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -116,6 +139,7 @@ internal fun SettingsContent(
                 .fillMaxSize()
                 .padding(innerPadding),
         ) {
+            // ── Appearance ────────────────────────────────────────────────────
             item {
                 SettingsSectionHeader(stringResource(R.string.settings_section_appearance))
             }
@@ -134,16 +158,48 @@ internal fun SettingsContent(
                     enabled = !dynamicColor,
                 )
             }
+
+            // ── Weather ───────────────────────────────────────────────────────
+            item {
+                SettingsSectionHeader(stringResource(R.string.settings_section_weather))
+            }
+            item {
+                WeatherToggleItem(
+                    enabled = weatherEnabled,
+                    onCheckedChange = onWeatherEnabledChange,
+                )
+            }
+            if (weatherEnabled) {
+                item {
+                    WeatherServiceItem(
+                        selected = weatherService,
+                        onSelect = onWeatherServiceChange,
+                    )
+                }
+                if (weatherService == WeatherService.Google) {
+                    item {
+                        ApiKeyItem(
+                            apiKey = googleApiKey,
+                            onApiKeyChange = onGoogleApiKeyChange,
+                        )
+                    }
+                }
+                item {
+                    TemperatureUnitItem(
+                        selected = temperatureUnit,
+                        onSelect = onTemperatureUnitChange,
+                    )
+                }
+                item {
+                    ClearCacheItem(onClick = onClearCache)
+                }
+            }
         }
     }
 }
 
-/**
- * Section heading styled with [MaterialTheme.typography.labelLarge] in
- * [MaterialTheme.colorScheme.primary], matching the Material 3 settings pattern.
- *
- * @param title The label to display above the section's preference items.
- */
+// ── Shared ────────────────────────────────────────────────────────────────────
+
 @Composable
 private fun SettingsSectionHeader(title: String) {
     Text(
@@ -154,15 +210,8 @@ private fun SettingsSectionHeader(title: String) {
     )
 }
 
-/**
- * Settings list item for the Material You dynamic color toggle (Android 12+ only).
- *
- * Renders a [ListItem] with a [Switch] as trailing content. When enabled,
- * dynamic color takes over from the user-selected accent.
- *
- * @param enabled Whether dynamic color is currently on.
- * @param onCheckedChange Invoked with the new checked state when the switch is toggled.
- */
+// ── Appearance items ──────────────────────────────────────────────────────────
+
 @Composable
 private fun DynamicColorItem(
     enabled: Boolean,
@@ -180,18 +229,6 @@ private fun DynamicColorItem(
     )
 }
 
-/**
- * Settings list item for the accent colour preference.
- *
- * Renders a [ListItem] with the preference label as the headline and a horizontal
- * row of [AccentSwatch]s as supporting content. When [enabled] is `false` (i.e.
- * dynamic color is active), the row is visually dimmed and swatches are
- * non-interactive.
- *
- * @param currentAccent The currently active [ClosetAccent].
- * @param onSetAccent Invoked with the newly selected [ClosetAccent].
- * @param enabled Whether the accent preference is interactive.
- */
 @Composable
 private fun AccentColorItem(
     currentAccent: ClosetAccent,
@@ -224,21 +261,6 @@ private fun AccentColorItem(
     )
 }
 
-/**
- * A tappable circular swatch representing a single [ClosetAccent].
- *
- * Renders a 36 dp filled circle inside a 48 dp touch target (meeting M3 minimum).
- * When [selected], a 2 dp ring in [ClosetAccent.muted] is drawn between the touch
- * target boundary and the fill circle to indicate the active choice.
- *
- * Provides a full accessibility [contentDescription] via [semantics]:
- * "[accent name], selected" or "[accent name]".
- *
- * @param accent The accent whose [ClosetAccent.primary] colour fills the circle.
- * @param selected Whether this swatch represents the currently active accent.
- * @param enabled Whether the swatch is interactive; `false` when dynamic color is on.
- * @param onClick Invoked when the user taps the swatch.
- */
 @Composable
 private fun AccentSwatch(
     accent: ClosetAccent,
@@ -279,7 +301,6 @@ private fun AccentSwatch(
     }
 }
 
-/** Returns the localized display name for [accent]. */
 @Composable
 private fun accentLabel(accent: ClosetAccent): String = when (accent) {
     ClosetAccent.Amber -> stringResource(R.string.settings_accent_amber)
@@ -290,29 +311,186 @@ private fun accentLabel(accent: ClosetAccent): String = when (accent) {
     ClosetAccent.Rose -> stringResource(R.string.settings_accent_rose)
 }
 
-@Preview(showBackground = true, name = "Accent active")
+// ── Weather items ─────────────────────────────────────────────────────────────
+
 @Composable
-private fun SettingsContentAccentPreview() {
+private fun WeatherToggleItem(
+    enabled: Boolean,
+    onCheckedChange: (Boolean) -> Unit,
+) {
+    ListItem(
+        headlineContent = { Text(stringResource(R.string.settings_weather_enabled)) },
+        supportingContent = { Text(stringResource(R.string.settings_weather_enabled_summary)) },
+        trailingContent = {
+            Switch(
+                checked = enabled,
+                onCheckedChange = onCheckedChange,
+            )
+        },
+    )
+}
+
+/**
+ * Service picker using a [SingleChoiceSegmentedButtonRow].
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun WeatherServiceItem(
+    selected: WeatherService,
+    onSelect: (WeatherService) -> Unit,
+) {
+    val services = WeatherService.entries
+    ListItem(
+        headlineContent = { Text(stringResource(R.string.settings_weather_service)) },
+        supportingContent = {
+            SingleChoiceSegmentedButtonRow(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(top = 8.dp),
+            ) {
+                services.forEachIndexed { index, service ->
+                    SegmentedButton(
+                        selected = service == selected,
+                        onClick = { onSelect(service) },
+                        shape = SegmentedButtonDefaults.itemShape(index, services.size),
+                        label = { Text(service.label) },
+                    )
+                }
+            }
+        },
+    )
+}
+
+/**
+ * Google API key input. Uses [KeyboardType.Password] to suppress autofill
+ * suggestions, but text is kept visible so the user can verify the key.
+ */
+@Composable
+private fun ApiKeyItem(
+    apiKey: String,
+    onApiKeyChange: (String) -> Unit,
+) {
+    ListItem(
+        headlineContent = {
+            OutlinedTextField(
+                value = apiKey,
+                onValueChange = onApiKeyChange,
+                label = { Text(stringResource(R.string.settings_weather_api_key)) },
+                placeholder = { Text(stringResource(R.string.settings_weather_api_key_placeholder)) },
+                singleLine = true,
+                keyboardOptions = KeyboardOptions(
+                    keyboardType = KeyboardType.Password,
+                    imeAction = ImeAction.Done,
+                ),
+                modifier = Modifier.fillMaxWidth(),
+            )
+        },
+    )
+}
+
+/**
+ * Temperature unit picker (°C / °F).
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun TemperatureUnitItem(
+    selected: TemperatureUnit,
+    onSelect: (TemperatureUnit) -> Unit,
+) {
+    val units = TemperatureUnit.entries
+    ListItem(
+        headlineContent = { Text(stringResource(R.string.settings_temperature_unit)) },
+        supportingContent = {
+            SingleChoiceSegmentedButtonRow(modifier = Modifier.padding(top = 8.dp)) {
+                units.forEachIndexed { index, unit ->
+                    SegmentedButton(
+                        selected = unit == selected,
+                        onClick = { onSelect(unit) },
+                        shape = SegmentedButtonDefaults.itemShape(index, units.size),
+                        label = { Text(unit.label) },
+                    )
+                }
+            }
+        },
+    )
+}
+
+/** Tappable list item that clears the cached forecast from DataStore. */
+@Composable
+private fun ClearCacheItem(onClick: () -> Unit) {
+    ListItem(
+        headlineContent = { Text(stringResource(R.string.settings_clear_cache)) },
+        supportingContent = { Text(stringResource(R.string.settings_clear_cache_summary)) },
+        modifier = Modifier.clickable(onClick = onClick),
+    )
+}
+
+// ── Previews ──────────────────────────────────────────────────────────────────
+
+@Preview(showBackground = true, name = "Appearance / weather off")
+@Composable
+private fun SettingsContentDefaultPreview() {
     ClosetTheme {
         SettingsContent(
             currentAccent = ClosetAccent.Amber,
             dynamicColor = false,
             onSetAccent = {},
             onSetDynamicColor = {},
+            weatherEnabled = false,
+            weatherService = WeatherService.OpenMeteo,
+            googleApiKey = "",
+            temperatureUnit = TemperatureUnit.Celsius,
+            onWeatherEnabledChange = {},
+            onWeatherServiceChange = {},
+            onGoogleApiKeyChange = {},
+            onTemperatureUnitChange = {},
+            onClearCache = {},
             onNavigateUp = {},
         )
     }
 }
 
-@Preview(showBackground = true, name = "Dynamic color active")
+@Preview(showBackground = true, name = "Weather on / Open-Meteo")
 @Composable
-private fun SettingsContentDynamicPreview() {
+private fun SettingsContentWeatherOpenMeteoPreview() {
     ClosetTheme {
         SettingsContent(
             currentAccent = ClosetAccent.Sky,
-            dynamicColor = true,
+            dynamicColor = false,
             onSetAccent = {},
             onSetDynamicColor = {},
+            weatherEnabled = true,
+            weatherService = WeatherService.OpenMeteo,
+            googleApiKey = "",
+            temperatureUnit = TemperatureUnit.Celsius,
+            onWeatherEnabledChange = {},
+            onWeatherServiceChange = {},
+            onGoogleApiKeyChange = {},
+            onTemperatureUnitChange = {},
+            onClearCache = {},
+            onNavigateUp = {},
+        )
+    }
+}
+
+@Preview(showBackground = true, name = "Weather on / Google + API key")
+@Composable
+private fun SettingsContentWeatherGooglePreview() {
+    ClosetTheme {
+        SettingsContent(
+            currentAccent = ClosetAccent.Coral,
+            dynamicColor = false,
+            onSetAccent = {},
+            onSetDynamicColor = {},
+            weatherEnabled = true,
+            weatherService = WeatherService.Google,
+            googleApiKey = "AIzaSy••••••••••••••",
+            temperatureUnit = TemperatureUnit.Fahrenheit,
+            onWeatherEnabledChange = {},
+            onWeatherServiceChange = {},
+            onGoogleApiKeyChange = {},
+            onTemperatureUnitChange = {},
+            onClearCache = {},
             onNavigateUp = {},
         )
     }

--- a/app-android/features/settings/src/main/kotlin/com/closet/features/settings/SettingsScreen.kt
+++ b/app-android/features/settings/src/main/kotlin/com/closet/features/settings/SettingsScreen.kt
@@ -1,6 +1,14 @@
 package com.closet.features.settings
 
+import android.Manifest
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.net.Uri
 import android.os.Build
+import android.provider.Settings
+import androidx.activity.compose.LocalActivity
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
@@ -18,6 +26,7 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.CenterAlignedTopAppBar
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
@@ -29,10 +38,17 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SegmentedButton
 import androidx.compose.material3.SegmentedButtonDefaults
 import androidx.compose.material3.SingleChoiceSegmentedButtonRow
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
@@ -44,10 +60,14 @@ import androidx.compose.ui.semantics.role
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.core.app.ActivityCompat
+import androidx.core.content.ContextCompat
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import kotlinx.coroutines.launch
 import com.closet.core.data.model.TemperatureUnit
 import com.closet.core.data.model.WeatherService
 import com.closet.core.ui.theme.ClosetAccent
@@ -73,6 +93,63 @@ fun SettingsScreen(
     val googleApiKey by viewModel.googleApiKey.collectAsStateWithLifecycle()
     val temperatureUnit by viewModel.temperatureUnit.collectAsStateWithLifecycle()
 
+    val context = LocalContext.current
+    val activity = LocalActivity.current
+    val coroutineScope = rememberCoroutineScope()
+    val snackbarHostState = remember { SnackbarHostState() }
+    var showRationaleDialog by remember { mutableStateOf(false) }
+
+    val deniedMessage = stringResource(R.string.settings_location_snackbar)
+
+    val permissionLauncher = rememberLauncherForActivityResult(
+        ActivityResultContracts.RequestPermission(),
+    ) { granted ->
+        if (granted) {
+            viewModel.setWeatherEnabled(true)
+        } else {
+            val shouldShow = activity?.let {
+                ActivityCompat.shouldShowRequestPermissionRationale(
+                    it,
+                    Manifest.permission.ACCESS_COARSE_LOCATION,
+                )
+            } ?: false
+            if (shouldShow) {
+                coroutineScope.launch { snackbarHostState.showSnackbar(deniedMessage) }
+            } else {
+                showRationaleDialog = true
+            }
+        }
+    }
+
+    val onWeatherToggle: (Boolean) -> Unit = { enabled ->
+        if (!enabled) {
+            viewModel.setWeatherEnabled(false)
+        } else {
+            val granted = ContextCompat.checkSelfPermission(
+                context,
+                Manifest.permission.ACCESS_COARSE_LOCATION,
+            ) == PackageManager.PERMISSION_GRANTED
+            if (granted) {
+                viewModel.setWeatherEnabled(true)
+            } else {
+                permissionLauncher.launch(Manifest.permission.ACCESS_COARSE_LOCATION)
+            }
+        }
+    }
+
+    if (showRationaleDialog) {
+        PermissionRationaleDialog(
+            onOpenSettings = {
+                showRationaleDialog = false
+                val intent = Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS).apply {
+                    data = Uri.fromParts("package", context.packageName, null)
+                }
+                context.startActivity(intent)
+            },
+            onDismiss = { showRationaleDialog = false },
+        )
+    }
+
     SettingsContent(
         currentAccent = accent,
         dynamicColor = dynamicColor,
@@ -82,11 +159,12 @@ fun SettingsScreen(
         weatherService = weatherService,
         googleApiKey = googleApiKey,
         temperatureUnit = temperatureUnit,
-        onWeatherEnabledChange = viewModel::setWeatherEnabled,
+        onWeatherEnabledChange = onWeatherToggle,
         onWeatherServiceChange = viewModel::setWeatherService,
         onGoogleApiKeyChange = viewModel::setGoogleApiKey,
         onTemperatureUnitChange = viewModel::setTemperatureUnit,
         onClearCache = viewModel::clearForecastCache,
+        snackbarHostState = snackbarHostState,
         onNavigateUp = onNavigateUp,
     )
 }
@@ -115,11 +193,13 @@ internal fun SettingsContent(
     onGoogleApiKeyChange: (String) -> Unit,
     onTemperatureUnitChange: (TemperatureUnit) -> Unit,
     onClearCache: () -> Unit,
+    snackbarHostState: SnackbarHostState,
     onNavigateUp: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Scaffold(
         modifier = modifier.fillMaxSize(),
+        snackbarHost = { SnackbarHost(snackbarHostState) },
         topBar = {
             CenterAlignedTopAppBar(
                 title = { Text(stringResource(R.string.settings_title)) },
@@ -425,6 +505,35 @@ private fun ClearCacheItem(onClick: () -> Unit) {
     )
 }
 
+// ── Dialogs ───────────────────────────────────────────────────────────────────
+
+/**
+ * Shown when the user has permanently denied [ACCESS_COARSE_LOCATION].
+ * Explains why the permission is needed and offers a direct link to system
+ * app settings so the user can grant it without navigating manually.
+ */
+@Composable
+private fun PermissionRationaleDialog(
+    onOpenSettings: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(stringResource(R.string.settings_location_dialog_title)) },
+        text = { Text(stringResource(R.string.settings_location_dialog_message)) },
+        confirmButton = {
+            TextButton(onClick = onOpenSettings) {
+                Text(stringResource(R.string.settings_location_dialog_open_settings))
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text(stringResource(R.string.settings_location_dialog_cancel))
+            }
+        },
+    )
+}
+
 // ── Previews ──────────────────────────────────────────────────────────────────
 
 @Preview(showBackground = true, name = "Appearance / weather off")
@@ -445,6 +554,7 @@ private fun SettingsContentDefaultPreview() {
             onGoogleApiKeyChange = {},
             onTemperatureUnitChange = {},
             onClearCache = {},
+            snackbarHostState = remember { SnackbarHostState() },
             onNavigateUp = {},
         )
     }
@@ -468,6 +578,7 @@ private fun SettingsContentWeatherOpenMeteoPreview() {
             onGoogleApiKeyChange = {},
             onTemperatureUnitChange = {},
             onClearCache = {},
+            snackbarHostState = remember { SnackbarHostState() },
             onNavigateUp = {},
         )
     }
@@ -491,6 +602,7 @@ private fun SettingsContentWeatherGooglePreview() {
             onGoogleApiKeyChange = {},
             onTemperatureUnitChange = {},
             onClearCache = {},
+            snackbarHostState = remember { SnackbarHostState() },
             onNavigateUp = {},
         )
     }

--- a/app-android/features/settings/src/main/kotlin/com/closet/features/settings/SettingsViewModel.kt
+++ b/app-android/features/settings/src/main/kotlin/com/closet/features/settings/SettingsViewModel.kt
@@ -2,6 +2,9 @@ package com.closet.features.settings
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.closet.core.data.model.TemperatureUnit
+import com.closet.core.data.model.WeatherService
+import com.closet.core.data.repository.WeatherPreferencesRepository
 import com.closet.core.ui.preferences.PreferencesRepository
 import com.closet.core.ui.theme.ClosetAccent
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -14,15 +17,21 @@ import javax.inject.Inject
 /**
  * ViewModel for the Settings screen.
  *
- * Bridges [PreferencesRepository] to the UI layer, exposing persisted preferences
- * as [StateFlow]s and providing write paths for each. Changes propagate immediately
- * to [ClosetTheme] via [MainActivity][com.closet.MainActivity]'s collected flows,
- * causing the entire app theme to recompose.
+ * Bridges [PreferencesRepository] (appearance) and [WeatherPreferencesRepository]
+ * (weather) to the UI layer. All preferences are exposed as [StateFlow]s; writes
+ * are fire-and-forget coroutines in [viewModelScope].
+ *
+ * Changes to appearance preferences propagate immediately to [ClosetTheme] via
+ * [MainActivity][com.closet.MainActivity]'s collected flows, causing the entire
+ * app theme to recompose.
  */
 @HiltViewModel
 class SettingsViewModel @Inject constructor(
     private val prefsRepo: PreferencesRepository,
+    private val weatherPrefsRepo: WeatherPreferencesRepository,
 ) : ViewModel() {
+
+    // ── Appearance ────────────────────────────────────────────────────────────
 
     /** The current accent colour, persisted across app launches. */
     val accent: StateFlow<ClosetAccent> = prefsRepo.getAccent()
@@ -43,5 +52,46 @@ class SettingsViewModel @Inject constructor(
     /** Persists the dynamic color [enabled] flag to [PreferencesRepository]. */
     fun setDynamicColor(enabled: Boolean) {
         viewModelScope.launch { prefsRepo.setDynamicColor(enabled) }
+    }
+
+    // ── Weather ───────────────────────────────────────────────────────────────
+
+    /**
+     * Whether the weather feature is enabled. In Phase 2 this toggle will gate
+     * the location permission request; for now it writes directly to DataStore.
+     */
+    val weatherEnabled: StateFlow<Boolean> = weatherPrefsRepo.getWeatherEnabled()
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), false)
+
+    /** The selected weather service provider. */
+    val weatherService: StateFlow<WeatherService> = weatherPrefsRepo.getWeatherService()
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), WeatherService.OpenMeteo)
+
+    /** The stored Google Weather API key (empty string when not set). */
+    val googleApiKey: StateFlow<String> = weatherPrefsRepo.getGoogleApiKey()
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), "")
+
+    /** The preferred temperature display unit. Storage is always °C. */
+    val temperatureUnit: StateFlow<TemperatureUnit> = weatherPrefsRepo.getTemperatureUnit()
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), TemperatureUnit.Celsius)
+
+    fun setWeatherEnabled(enabled: Boolean) {
+        viewModelScope.launch { weatherPrefsRepo.setWeatherEnabled(enabled) }
+    }
+
+    fun setWeatherService(service: WeatherService) {
+        viewModelScope.launch { weatherPrefsRepo.setWeatherService(service) }
+    }
+
+    fun setGoogleApiKey(key: String) {
+        viewModelScope.launch { weatherPrefsRepo.setGoogleApiKey(key) }
+    }
+
+    fun setTemperatureUnit(unit: TemperatureUnit) {
+        viewModelScope.launch { weatherPrefsRepo.setTemperatureUnit(unit) }
+    }
+
+    fun clearForecastCache() {
+        viewModelScope.launch { weatherPrefsRepo.clearCache() }
     }
 }

--- a/app-android/features/settings/src/main/res/values/strings.xml
+++ b/app-android/features/settings/src/main/res/values/strings.xml
@@ -31,4 +31,11 @@
     <string name="settings_temperature_unit">Temperature unit</string>
     <string name="settings_clear_cache">Clear cached forecast</string>
     <string name="settings_clear_cache_summary">Remove stored forecast data</string>
+
+    <!-- Location permission -->
+    <string name="settings_location_snackbar">Location access is needed to fetch weather. You can enable it in System Settings.</string>
+    <string name="settings_location_dialog_title">Location permission required</string>
+    <string name="settings_location_dialog_message">Location access is needed to show your local weather forecast. Tap Open Settings to grant it.</string>
+    <string name="settings_location_dialog_open_settings">Open Settings</string>
+    <string name="settings_location_dialog_cancel">Cancel</string>
 </resources>

--- a/app-android/features/settings/src/main/res/values/strings.xml
+++ b/app-android/features/settings/src/main/res/values/strings.xml
@@ -5,6 +5,7 @@
 
     <!-- Section headers -->
     <string name="settings_section_appearance">Appearance</string>
+    <string name="settings_section_weather">Weather</string>
 
     <!-- Appearance preferences -->
     <string name="settings_dynamic_color">Use system colors</string>
@@ -20,4 +21,14 @@
     <string name="settings_accent_rose">Rose</string>
     <string name="settings_accent_selected">%s, selected</string>
     <string name="settings_accent_unselected">%s</string>
+
+    <!-- Weather preferences -->
+    <string name="settings_weather_enabled">Show weather forecast</string>
+    <string name="settings_weather_enabled_summary">Fetch today\'s forecast using your location</string>
+    <string name="settings_weather_service">Weather service</string>
+    <string name="settings_weather_api_key">Google API key</string>
+    <string name="settings_weather_api_key_placeholder">Paste your API key here</string>
+    <string name="settings_temperature_unit">Temperature unit</string>
+    <string name="settings_clear_cache">Clear cached forecast</string>
+    <string name="settings_clear_cache_summary">Remove stored forecast data</string>
 </resources>

--- a/app-android/gradle/libs.versions.toml
+++ b/app-android/gradle/libs.versions.toml
@@ -26,6 +26,7 @@ datastorePreferences = "1.1.4"
 vico = "3.0.3"
 turbine = "1.2.0"
 mockk = "1.13.14"
+ktor = "3.1.3"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "androidxCore" }
@@ -64,6 +65,10 @@ vico-compose-m3 = { group = "com.patrykandpatrick.vico", name = "compose-m3", ve
 kotlinx-coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version.ref = "kotlinxCoroutines" }
 turbine = { group = "app.cash.turbine", name = "turbine", version.ref = "turbine" }
 mockk = { group = "io.mockk", name = "mockk", version.ref = "mockk" }
+ktor-client-okhttp = { group = "io.ktor", name = "ktor-client-okhttp", version.ref = "ktor" }
+ktor-client-content-negotiation = { group = "io.ktor", name = "ktor-client-content-negotiation", version.ref = "ktor" }
+ktor-serialization-kotlinx-json = { group = "io.ktor", name = "ktor-serialization-kotlinx-json", version.ref = "ktor" }
+ktor-client-logging = { group = "io.ktor", name = "ktor-client-logging", version.ref = "ktor" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }

--- a/app-android/outfit-rec-roadmap.md
+++ b/app-android/outfit-rec-roadmap.md
@@ -9,7 +9,7 @@ An opt-in outfit suggestion feature that uses a two-layer architecture:
    color/pattern rules, and candidate trimming. SQL only, no AI.
 
 2. **Gemini Nano coherence scorer** — sees only a small, clean, constrained candidate
-   pool. Acts as a last-mile style coherence scorer, not a generative engine.
+   pool. Acts as a last-mile-style coherence scorer, not a generative engine.
 
 AI is entirely optional. The programmatic pipeline alone is a useful feature.
 Coherence scoring is an enhancement layered on top when the device supports it.

--- a/app-android/outfit-rec-roadmap.md
+++ b/app-android/outfit-rec-roadmap.md
@@ -41,7 +41,7 @@ Coherence scoring is an enhancement layered on top when the device supports it.
 - Occasion match — user-selects at suggestion time
 
 ### 1b. Statistical suitability scores (derived from log history, not stored)
-These are SQL aggregations over `outfit_logs` + `outfit_log_items` + `outfit_log`
+These are SQL aggregations over `outfit_logs` + `outfit_log_items` + `outfit_logs`
 weather columns. Items with no history are treated as neutral (score = 0.5).
 
 - **Comfortable temp range** — collect all logs where this item was worn with a

--- a/app-android/outfit-rec-roadmap.md
+++ b/app-android/outfit-rec-roadmap.md
@@ -1,0 +1,165 @@
+# Outfit Recommendations Feature — Design Notes
+# (v2 — refined 2026-03-24 after weather feature design sessions)
+
+## Overview
+An opt-in outfit suggestion feature that uses a two-layer architecture:
+
+1. **Programmatic pipeline** — does the heavy lifting. Handles weather/temperature
+   filtering, statistical suitability scoring from log history, category completeness,
+   color/pattern rules, and candidate trimming. SQL only, no AI.
+
+2. **Gemini Nano coherence scorer** — sees only a small, clean, constrained candidate
+   pool. Acts as a last-mile style coherence scorer, not a generative engine.
+
+AI is entirely optional. The programmatic pipeline alone is a useful feature.
+Coherence scoring is an enhancement layered on top when the device supports it.
+
+---
+
+## Architecture Philosophy
+- Programmatic logic does the heavy lifting — AI only sees a small, clean payload
+- AI cannot hallucinate invalid categories/items because output is validated against real DB IDs
+- User can always override suggestions
+- Feature is entirely opt-in, hidden behind a settings toggle
+- Programmatic suggestions work even on devices that don't support Gemini Nano
+- Statistical suitability is derived from log history at query time — never stored as a
+  column (consistent with the project's no-derived-data rule)
+
+---
+
+## Layer 1 — Programmatic Pre-Filter (no AI involved)
+
+### 1a. Hard filters (binary — item either passes or doesn't)
+- `wash_status = Clean` only
+- `status = Active` only
+- Season match — two modes run in parallel:
+    - Calendar mode: item's seasons include the current calendar season
+    - Temperature-band mode: current forecast temp falls within `temp_low_c`/`temp_high_c`
+      on any of the item's tagged seasons (uses the `seasons` lookup table added in
+      Migration 1→2). An item passes season filter if it passes EITHER mode.
+    - All Season items always pass.
+- Occasion match — user-selects at suggestion time
+
+### 1b. Statistical suitability scores (derived from log history, not stored)
+These are SQL aggregations over `outfit_logs` + `outfit_log_items` + `outfit_log`
+weather columns. Items with no history are treated as neutral (score = 0.5).
+
+- **Comfortable temp range** — collect all logs where this item was worn with a
+  non-null temperature range. Comfortable range = 10th–90th percentile of logged
+  `temperature_low`/`temperature_high` values. If today's forecast is outside that
+  range, down-score. Sparse data (< 5 logs with temps): skip this filter, don't penalise.
+- **Rain suitability** — % of this item's logs where `precipitation_mm` > 1.0 mm.
+  If raining today and rain% < 20%, down-score. Sparse data: skip.
+- **Wind suitability** — % of logs where `wind_speed_kmh` > 30 km/h. If windy today
+  and wind% < 20%, down-score. Sparse data: skip.
+- **Worn-recently penalty** — if the item appears in any log within the past 3 days,
+  apply a soft penalty (not a hard filter). User preference could relax this later.
+
+> Note: these scores inform ranking and trimming, not hard exclusion. An item with a
+> low suitability score is still a candidate — it's just ranked lower and trimmed first
+> when the pool needs to shrink.
+
+### 1c. Layering validation (outfit-level, not item-level)
+Uses `warmth_layer` on `categories` (None / Base / Mid / Outer — Migration 1→2).
+
+- Cold day (below 5°C): candidate pool must include at least one Outer item or the
+  engine adds the highest-ranked Outer item from the full active/clean set.
+- Moderate day (5–15°C): Mid layer encouraged but not required.
+- Warm day (above 20°C): Outer items down-ranked (still available for user override).
+- Layering score is applied at the OUTFIT level after item selection — a t-shirt alone
+  scores low on a cold day; same t-shirt with a jacket scores fine.
+
+### 1d. Category completeness
+Valid outfit = (top + bottom) OR (dress/jumpsuit), with optional outerwear/footwear/accessories.
+Engine builds combinations satisfying completeness before passing to the AI.
+
+### 1e. Presentation-layer trimming (before AI payload)
+- Color harmony: complementary, analogous, neutral pairing. Clashing combos ranked lower.
+- Pattern mixing: solid + pattern = OK; pattern + pattern = flagged (lower rank, not excluded).
+- Color deduplication: one representative per color/subcategory combo — no 8 black t-shirts.
+- Per-category cap: 1–2 candidates per category slot max.
+
+---
+
+## Layer 2 — Gemini Nano Coherence Scorer (opt-in, device-dependent)
+
+Only runs if:
+- AI features toggle is on in settings
+- Model is downloaded and `aiReady` flag is true in DataStore
+- Candidate pool is non-empty after Layer 1
+
+If any condition is false, the top Layer-1-ranked combination is returned directly.
+
+### Token Management
+- On feature init: `getTokenLimit()` — store in DataStore, never hardcode
+- Before every inference: serialize candidate payload → `countTokens()` → trim if over
+- Treat `FinishReason.MAX_TOKENS` as failed inference, not partial result
+- `countTokens()` gates only the dynamic candidate payload — system instructions are
+  cached via `PromptPrefix`
+
+### PromptPrefix (Cached System Instructions)
+**Prefix (cached once):**
+- Full output format instructions (JSON only, no preamble)
+- Behavioral constraints ("only select from the IDs provided")
+- Output schema definition
+
+**Dynamic suffix (per request):**
+- Serialized JSON of the pre-filtered + ranked candidate items for this specific request
+- Include statistical suitability scores as context hints so Nano has signal beyond raw item data
+
+### Prompt Design
+Constrained output — AI selects from IDs provided, never generates free-text clothing data:
+```json
+{ "selected_ids": [1, 4, 7], "reason": "..." }
+```
+- `selected_ids` validated against the candidate list before any DB interaction
+- `reason` field surfaced behind a "why?" tap, not shown by default
+- Any response that fails JSON parsing or contains unknown IDs is discarded silently
+  and the top programmatic result is returned instead
+
+---
+
+## Category & Subcategory Auto-Fill (separate but related)
+When user adds a clothing image:
+- Send image + constrained prompt to Gemini Nano (ImagePart + TextPart)
+- Prompt includes full category/subcategory taxonomy, instructs JSON-only response
+- Response validated against actual lookup table values before populating form
+- Pre-fills category and subcategory dropdowns — user can override freely
+- Gated on `aiReady` flag, same as outfit suggestions
+
+---
+
+## Settings & Opt-In Flow
+- "AI features" toggle in settings — off by default
+- On toggle on, background worker runs in sequence:
+    1. `checkStatus()` — not supported? surface error, flip toggle back off
+    2. Supported but not downloaded? `download()` — stream progress to UI
+    3. Downloaded? `getTokenLimit()` — store in DataStore
+    4. Mark `aiReady = true` in DataStore
+- UI surfaces status: Checking → Downloading (n%) → Ready / Failed / Not Supported
+- All AI-dependent features check `aiReady` flag before running
+- If not ready: show programmatic result with no "AI" label; hide "why?" affordance
+- `aiReady`, `tokenLimit` stored in DataStore (not DB, not SharedPreferences)
+- Programmatic suggestions work regardless of `aiReady`
+
+---
+
+## Known Caveats
+- GenAI Prompt API (MLKit) is in beta — API surface may change before release
+- Gemini Nano minimum requirements: Pixel 6 or equivalent (≥ Android 10); ~1.5 GB
+  free storage for model download. Unavailable on most mid-range/budget devices.
+- Nano is a small model — occasional poor picks are expected; override is always available
+- Statistical suitability needs log history to build up. New users see programmatic
+  suggestions without suitability scoring until enough logs accumulate (5+ per item).
+- Layering scores require `warmth_layer` to be set on categories. Only Outerwear and
+  Underwear & Intimates are seeded. Other categories default to "None" — users will
+  need to assign Base/Mid as that UI is built.
+
+---
+
+## Future Considerations
+- Thumbs up/down feedback loop to weight future suggestions (requires new table)
+- `general notes` field on clothing items fed as context to Nano for user-defined rules
+- Expose per-item suitability scores in item detail view ("you usually wear this in
+  15–25°C, sunny conditions")
+- User-configurable worn-recently window (3 days default)

--- a/app-android/weather-roadmap.md
+++ b/app-android/weather-roadmap.md
@@ -222,8 +222,13 @@ toDisplayTemp() honours temperatureUnit preference passed from JournalContent.
 Phase 5 — Schema gaps (needed for outfit recommendation filtering)
 
 These are independent of Phases 1–4 and can be done at any time, but are
-required before weather data can drive outfit suggestions. All changes
-go in Migration 2 (or a new migration if chain has moved).
+required before weather data can drive outfit suggestions.
+
+Migration conventions (see also core/data/.../migrations/AGENTS.md):
+- NEVER edit an applied migration. Add a new one instead.
+- Every migrate() block MUST start with:
+    db.execSQL("DROP INDEX IF EXISTS one_ootd_per_day")
+  even if the migration does not touch outfit_logs.
 
 Design decisions settled (2026-03-24):
 

--- a/app-android/weather-roadmap.md
+++ b/app-android/weather-roadmap.md
@@ -131,12 +131,9 @@ features/settings/build.gradle.kts gains :core:data dep.
   ---
 Phase 2 — Location permission
 
-🔲 2.1 — Manifest
-Add to AndroidManifest.xml:
-  <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
-COARSE is sufficient for city-level weather. Do not request FINE — it
-signals GPS tracking, which is trust-destroying for a privacy-first app.
-(INTERNET permission already added in Phase 0.3.)
+✅ 2.1 — Manifest
+ACCESS_COARSE_LOCATION added to AndroidManifest.xml.
+(INTERNET already added in Phase 0.3.)
 
 🔲 2.2 — Permission request flow
 When the Settings toggle transitions from off → on:

--- a/app-android/weather-roadmap.md
+++ b/app-android/weather-roadmap.md
@@ -248,23 +248,24 @@ the project's no-derived-data rule). The engine concept:
 ✅ Gap 3 — WeatherCondition enum expansion — DONE in Phase 0.2.
 Added Thunderstorm, Foggy, Drizzle, Sleet, HeavySnow and fromWmoCode().
 
-🔲 Gap 4 — Seasons with temperature ranges
+✅ Gap 4 — Seasons with temperature ranges
 Add temp_low_c REAL nullable and temp_high_c REAL nullable to the seasons
 lookup table. Enables temperature-band-driven season matching alongside
 calendar quarters (e.g. "Winter" = below 5°C in user's locale, not just
 Dec–Feb). Feeds the future recommendation engine: if the forecast hits the
 Winter temp band on a warm January day, Winter-tagged items are still
-surfaced. Update DatabaseSeeder with sensible defaults per season.
-Add warmth_layer TEXT NOT NULL DEFAULT 'None' to the categories table
-(values: None / Base / Mid / Outer) at the same time — needed for the
-layering logic described above.
+surfaced. DatabaseSeeder updated with sensible defaults per season.
+warmth_layer TEXT NOT NULL DEFAULT 'None' added to the categories table
+(values: None / Base / Mid / Outer) — needed for the layering logic
+described above. Seeded: Outerwear=Outer, Underwear & Intimates=Base.
+Done in Migration 1→2.
 
-🔲 Gap 5 — precipitation_mm and wind_speed_kmh on outfit_logs
-Add precipitation_mm REAL nullable and wind_speed_kmh REAL nullable to
-outfit_logs. Pure data-collection infrastructure — auto-populated from the
-cached forecast on log creation (same hook as temperature, Phase 4.2).
-This is what the recommendation engine feeds on for rain/wind suitability
-inference. No user-facing change. Do in the same migration as Gap 4.
+✅ Gap 5 — precipitation_mm and wind_speed_kmh on outfit_logs
+Added precipitation_mm REAL nullable and wind_speed_kmh REAL nullable to
+outfit_logs. Auto-populated from the cached forecast on log creation
+(JournalViewModel.logOutfitOnDate passes forecast.precipitationMm and
+forecast.windSpeedKmh through LogRepository.wearOutfitOnDate). No
+user-facing change. Done in the same migration as Gap 4 (Migration 1→2).
 
   ---
 Phase ordering summary

--- a/app-android/weather-roadmap.md
+++ b/app-android/weather-roadmap.md
@@ -94,12 +94,15 @@ Persists:
 
 Provide via Hilt @Singleton in DataModule.kt.
 
-🔲 0.3 — HTTP client
-Add Ktor-client-android + ktor-client-okhttp + ktor-client-content-negotiation
-+ ktor-serialization-kotlinx-json to libs.versions.toml.
-kotlinx-serialization-json is already present (1.10.0) — just add Ktor.
-Weather APIs are simple GET-only JSON endpoints; Retrofit is not needed.
-Provide KtorHttpClient as a @Singleton in DataModule.kt.
+✅ 0.3 — HTTP client
+Ktor 3.1.3 (ktor-client-okhttp + content-negotiation + serialization-kotlinx-json
++ client-logging) added to libs.versions.toml and core/data/build.gradle.kts.
+HttpClient singleton provided in DataModule: OkHttp engine, ContentNegotiation
+with ignoreUnknownKeys=true, Timber-backed logging (BODY in debug, NONE in
+release). BuildConfig generation enabled in core/data for the DEBUG flag.
+INTERNET permission added to AndroidManifest.xml (pulled forward from Phase 2.1
+— it's a normal permission with no user-facing prompt, needed the moment any
+HTTP call is made).
 
   ---
 Phase 1 — Settings screen
@@ -134,10 +137,9 @@ Phase 2 — Location permission
 🔲 2.1 — Manifest
 Add to AndroidManifest.xml:
   <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
-  <uses-permission android:name="android.permission.INTERNET" />
 COARSE is sufficient for city-level weather. Do not request FINE — it
 signals GPS tracking, which is trust-destroying for a privacy-first app.
-INTERNET is required for any outbound HTTP call.
+(INTERNET permission already added in Phase 0.3.)
 
 🔲 2.2 — Permission request flow
 When the Settings toggle transitions from off → on:

--- a/app-android/weather-roadmap.md
+++ b/app-android/weather-roadmap.md
@@ -135,19 +135,18 @@ Phase 2 — Location permission
 ACCESS_COARSE_LOCATION added to AndroidManifest.xml.
 (INTERNET already added in Phase 0.3.)
 
-🔲 2.2 — Permission request flow
-When the Settings toggle transitions from off → on:
-1. Check if ACCESS_COARSE_LOCATION is already granted.
-2. If not: use Compose rememberLauncherForActivityResult(RequestPermission)
-   to surface the native modal.
-3. On grant: save weatherEnabled = true in DataStore, trigger initial
-   forecast fetch.
-4. On deny: revert the toggle to off, show a non-blocking snackbar:
-   "Location access is needed to fetch weather. You can enable it later in
-   System Settings."
-5. On permanent deny (shouldShowRationale = false after a denial): show a
-   dialog explaining why + deep-link to system app settings via
-   ACTION_APPLICATION_DETAILS_SETTINGS. Still revert the toggle.
+✅ 2.2 — Permission request flow
+Toggle interception lives in SettingsScreen (not ViewModel). On → off:
+writes directly. On → on: checks ContextCompat.checkSelfPermission first;
+if already granted, writes directly. If not granted, launches
+rememberLauncherForActivityResult(RequestPermission).
+Launcher result:
+  Granted → viewModel.setWeatherEnabled(true)
+  Denied + shouldShowRationale=true → Snackbar (non-blocking)
+  Denied + shouldShowRationale=false → PermissionRationaleDialog with
+    "Open Settings" deeplink to ACTION_APPLICATION_DETAILS_SETTINGS
+SettingsContent gains SnackbarHostState param wired to Scaffold.
+"Trigger initial forecast fetch" deferred to Phase 3 (no fetch client yet).
 
 🔲 2.3 — Location fetch
 Use LocationManager (no Play Services dependency — the app has none).

--- a/app-android/weather-roadmap.md
+++ b/app-android/weather-roadmap.md
@@ -174,8 +174,12 @@ precipitationMm=0.0, uvIndex=null (not in basic forecast endpoint).
 
 ✅ 3.4 — Google Weather API implementation (key required)
 GoogleWeatherClient has separate fetchDailyForecast(lat, lon, apiKey) — does
-not implement WeatherServiceClient (different signature). DTOs based on
-Google Weather API v1; marked with verification note in code.
+not implement WeatherServiceClient (different signature). DTOs match the
+actual Google Weather API v1 daily forecast schema:
+- displayDate.year/month/day for date parsing
+- daytimeForecast.wind.speed.value + unit (mph→km/h conversion)
+- daytimeForecast.uvIndex and relativeHumidity
+- Temperature.unit field with F→C conversion; no unitsSystem request param
 
 ✅ 3.5 — WeatherRepository + caching
 FORECAST_CACHE_TTL_MS = 3h named constant. Cache-first: if fresh, parse and

--- a/app-android/weather-roadmap.md
+++ b/app-android/weather-roadmap.md
@@ -115,21 +115,18 @@ ClosetNavGraph.kt. Gear icon wired on ClosetScreen. DONE.
 SettingsScreen.kt + SettingsViewModel.kt exist. Dynamic color toggle +
 accent color picker implemented. DONE.
 
-🔲 1.3 — Weather section in Settings
-Extend SettingsViewModel to also inject WeatherPreferencesRepository.
-Add a "Weather" section to SettingsScreen with:
-- Toggle: "Show weather forecast" (off by default). On first enable →
-  trigger location permission request (Phase 2).
-- Service picker (visible only when toggle is on):
-  Open-Meteo / NWS / Google Weather API.
-- Conditional API key input field (visible only when Google is selected).
-- Units toggle: °C / °F (moves here from a hypothetical general section —
-  it only matters once weather is enabled).
-- "Clear cached forecast" action.
-
-All state flows from WeatherPreferencesRepository via SettingsViewModel.
-Note: features/settings can depend on both core/ui and core/data — no
-module dependency issue.
+✅ 1.3 — Weather section in Settings
+SettingsViewModel now injects WeatherPreferencesRepository alongside
+PreferencesRepository. Exposes 4 new StateFlows (weatherEnabled,
+weatherService, googleApiKey, temperatureUnit) + 5 new actions.
+SettingsScreen adds a "Weather" section:
+- Toggle: "Show weather forecast" (off by default)
+- Service picker (SingleChoiceSegmentedButtonRow, visible when on):
+  Open-Meteo / NWS / Google
+- API key field (OutlinedTextField, visible only when Google selected)
+- Temperature unit picker (°C / °F segmented button, visible when on)
+- "Clear cached forecast" tappable ListItem
+features/settings/build.gradle.kts gains :core:data dep.
 
   ---
 Phase 2 — Location permission

--- a/app-android/weather-roadmap.md
+++ b/app-android/weather-roadmap.md
@@ -195,11 +195,13 @@ Phase 4 — Surface forecast in the Journal
 The Journal screen is the natural home for weather since it already shows
 wear history by date.
 
-🔲 4.1 — Today's forecast widget on Journal header
-When weatherEnabled = true and forecast is cached for today: show a compact
-weather chip (condition icon + temp range) at the top of JournalScreen
-above the calendar. Tapping it opens a bottom sheet with the 7-day
-forecast.
+✅ 4.1 — Today's forecast widget on Journal header
+TodayForecastChip shown above the month nav header when todayForecast != null.
+Chip label: "{condition} · {low} / {high}" with condition icon. Taps open
+ForecastSheet (7-day ModalBottomSheet). WeatherConditionExt.kt holds the
+shared icon() extension (all 11 conditions) and toDisplayTemp() helper.
+JournalViewModel injects WeatherRepository + WeatherPreferencesRepository;
+forecastDays uses flatMapLatest on weatherEnabled.
 
 🔲 4.2 — Auto-populate weather on log creation
 In JournalViewModel.logOutfitOnDate(): if weatherEnabled = true and a

--- a/app-android/weather-roadmap.md
+++ b/app-android/weather-roadmap.md
@@ -203,11 +203,14 @@ shared icon() extension (all 11 conditions) and toDisplayTemp() helper.
 JournalViewModel injects WeatherRepository + WeatherPreferencesRepository;
 forecastDays uses flatMapLatest on weatherEnabled.
 
-🔲 4.2 — Auto-populate weather on log creation
-In JournalViewModel.logOutfitOnDate(): if weatherEnabled = true and a
-cached forecast exists for today's date, pre-populate temperatureLow,
-temperatureHigh, and weatherCondition on the new OutfitLogEntity. User
-can still override manually.
+✅ 4.2 — Auto-populate weather on log creation
+LogRepository.wearOutfitOnDate() gains three optional nullable params
+(temperatureLow, temperatureHigh, weatherCondition) passed into the new
+OutfitLogEntity on insert. Idempotent path (existing row) returns early
+and does not overwrite existing weather data.
+JournalViewModel.logOutfitOnDate() looks up forecastDays for the selected
+date and passes values through. No-op when weather is disabled or the date
+has no forecast entry. User can still override via the log-edit sheet.
 
 🔲 4.3 — Weather on DayDetailSheet
 DayDetailSheet.kt exists. Show the stored temperature_low/high and

--- a/app-android/weather-roadmap.md
+++ b/app-android/weather-roadmap.md
@@ -225,30 +225,46 @@ These are independent of Phases 1–4 and can be done at any time, but are
 required before weather data can drive outfit suggestions. All changes
 go in Migration 2 (or a new migration if chain has moved).
 
-🔲 Gap 1 — Temperature suitability on clothing items
-Add temp_min_c REAL nullable and temp_max_c REAL nullable to
-clothing_items. Lets a user express "this jacket is suitable for 0–10°C".
-User-set, not auto-populated.
+Design decisions settled (2026-03-24):
 
-🔲 Gap 2 — Precipitation resistance on clothing items
-Add water_resistant INTEGER NOT NULL DEFAULT 0 to clothing_items. Needed
-to filter for rainy-day suitable items.
+Gap 1 & 2 — DEFERRED. Do not add user-input temp_min_c / temp_max_c or
+water_resistant to clothing_items. Instead, suitability will be DERIVED
+from log history at query time (never stored as a column — consistent with
+the project's no-derived-data rule). The engine concept:
+  - For each clothing item, collect all outfit_logs where it appears with a
+    recorded temperature range.
+  - Comfortable range = statistical distribution (e.g. 10th–90th percentile)
+    of logged temps. Rain suitability = % of logs recorded in wet conditions.
+  - The layering problem (t-shirt OK at 0°C if worn with a heavy jacket) is
+    addressed at the OUTFIT level, not the item level. A warmth_layer enum
+    will be added to categories (None / Base / Mid / Outer) so the engine
+    can score outfit combinations rather than individual items.
+  - MLKit is not the right tool here — personal wardrobes top out at a few
+    hundred log entries, where simple SQL statistics outperform ML. No
+    training data, no model, no on-device inference needed.
+  - This work belongs in a dedicated Recommendation feature roadmap.
+    See recommendation-roadmap.md when ready.
 
-🔲 Gap 3 — WeatherCondition enum expansion  ← do this BEFORE Phase 3
-Current 6 values don't cover: Thunderstorm, Foggy, Drizzle, Sleet,
-HeavySnow, HeatWave. WMO weathercode mapping has ~30 codes. Expand the
-enum and add fromWmoCode(code: Int): WeatherCondition factory. Room
-stores this as a String (label), so adding new values is non-breaking.
+✅ Gap 3 — WeatherCondition enum expansion — DONE in Phase 0.2.
+Added Thunderstorm, Foggy, Drizzle, Sleet, HeavySnow and fromWmoCode().
 
-🔲 Gap 4 — Seasons with temperature ranges (optional, low priority)
-Add temp_low_c / temp_high_c to the seasons lookup table for automatic
-season-tag suggestions from forecast temperature. Works fine without it
-if temperature suitability is on items directly (Gap 1).
+🔲 Gap 4 — Seasons with temperature ranges
+Add temp_low_c REAL nullable and temp_high_c REAL nullable to the seasons
+lookup table. Enables temperature-band-driven season matching alongside
+calendar quarters (e.g. "Winter" = below 5°C in user's locale, not just
+Dec–Feb). Feeds the future recommendation engine: if the forecast hits the
+Winter temp band on a warm January day, Winter-tagged items are still
+surfaced. Update DatabaseSeeder with sensible defaults per season.
+Add warmth_layer TEXT NOT NULL DEFAULT 'None' to the categories table
+(values: None / Base / Mid / Outer) at the same time — needed for the
+layering logic described above.
 
 🔲 Gap 5 — precipitation_mm and wind_speed_kmh on outfit_logs
 Add precipitation_mm REAL nullable and wind_speed_kmh REAL nullable to
-outfit_logs for richer historical analysis ("what did I wear last time it
-rained heavily?"). Include in the same migration as Gaps 1 and 2.
+outfit_logs. Pure data-collection infrastructure — auto-populated from the
+cached forecast on log creation (same hook as temperature, Phase 4.2).
+This is what the recommendation engine feeds on for rain/wind suitability
+inference. No user-facing change. Do in the same migration as Gap 4.
 
   ---
 Phase ordering summary
@@ -282,14 +298,12 @@ Key design decisions (resolved or still open)
    the app has none and adding Play Services is a meaningful SDK bloat
    decision). NETWORK_PROVIDER gives city-level accuracy — sufficient.
 
-🔲 3. Temperature unit — canonical storage is °C (recommended). All DB
-   columns (temperature_low, temperature_high, temp_min_c, temp_max_c)
-   store Celsius. Convert to °F for display only, driven by
-   temperatureUnit preference. CONFIRM before any data is written.
+✅ 3. Temperature unit — canonical storage is °C. All DB columns store
+   Celsius. toDisplayTemp() converts to °F for display only, driven by
+   temperatureUnit preference. CONFIRMED — implemented throughout.
 
-🔲 4. NWS out-of-US — notify the user and ask them to switch service
-   (do not silently fall back). Rationale: user made a deliberate choice;
-   silent fallback would be confusing if NWS and Open-Meteo disagree.
-   CONFIRM this UX.
+✅ 4. NWS out-of-US — returns Result.failure with a descriptive message;
+   WeatherRepository surfaces it to the caller. No silent fallback to
+   Open-Meteo. CONFIRMED — implemented in NwsClient.
 
 ✅ 5. Cache TTL — 3 hours, stored as named constant FORECAST_CACHE_TTL_MS.

--- a/app-android/weather-roadmap.md
+++ b/app-android/weather-roadmap.md
@@ -148,67 +148,42 @@ Launcher result:
 SettingsContent gains SnackbarHostState param wired to Scaffold.
 "Trigger initial forecast fetch" deferred to Phase 3 (no fetch client yet).
 
-🔲 2.3 — Location fetch
-Use LocationManager (no Play Services dependency — the app has none).
-Do a single passive location read (NETWORK_PROVIDER is sufficient for
-city-level accuracy). Cache lat/lon in DataStore alongside the forecast.
-Only re-request location when fetching a fresh forecast.
+✅ 2.3 — Location fetch
+LocationProvider (@Singleton) wraps LocationManager. Tries NETWORK_PROVIDER
+last-known, then GPS last-known, then a one-shot active update with 10s
+timeout if both caches are empty. Falls back to cached lat/lon in DataStore
+if no device fix is available.
 
   ---
 Phase 3 — Weather service abstraction
 
-🔲 3.1 — WeatherService interface
-interface WeatherServiceClient {
-    suspend fun fetchDailyForecast(lat: Double, lon: Double): Result<DailyForecast>
-}
+✅ 3.1 — WeatherService interface + domain models
+WeatherServiceClient interface: fetchDailyForecast(lat, lon): Result<List<DailyForecast>>
+DailyForecast domain model (all temps °C).
+CachedForecastEntry @Serializable DTO (primitives only) + toDomain/toCached extensions.
 
-data class DailyForecast(
-    val date: LocalDate,
-    val tempLow: Double,       // always stored in °C; convert for display
-    val tempHigh: Double,
-    val condition: WeatherCondition,
-    val precipitationMm: Double,
-    val windSpeedKmh: Double,
-    val uvIndex: Int?,
-    val humidity: Int?         // percent
-)
+✅ 3.2 — Open-Meteo implementation (default, no key)
+GET /v1/forecast with 7-day daily params. WMO weathercode → WeatherCondition
+via fromWmoCode(). humidity=null (daily endpoint only).
 
-Must implement WeatherCondition enum expansion (Gap 3 below) before this
-step — the mapping from WMO codes depends on the expanded enum.
+✅ 3.3 — NWS implementation (US-only, no key)
+Two-step /points + forecast URL. Merges 12h periods to daily via date grouping.
+shortForecast text → WeatherCondition keyword map. F→C conversion. Returns
+Result.failure on 404 (non-US) — user must switch service manually.
+precipitationMm=0.0, uvIndex=null (not in basic forecast endpoint).
 
-🔲 3.2 — Open-Meteo implementation (default, no key)
-Endpoint: https://api.open-meteo.com/v1/forecast
-Params: latitude, longitude,
-  daily=temperature_2m_max,temperature_2m_min,precipitation_sum,
-  windspeed_10m_max,weathercode,uv_index_max,
-  forecast_days=7, timezone=auto
-Map WMO weathercode integer → WeatherCondition via fromWmoCode() factory.
-This is the most important mapping work in the whole feature.
+✅ 3.4 — Google Weather API implementation (key required)
+GoogleWeatherClient has separate fetchDailyForecast(lat, lon, apiKey) — does
+not implement WeatherServiceClient (different signature). DTOs based on
+Google Weather API v1; marked with verification note in code.
 
-🔲 3.3 — NWS implementation (US-only, no key)
-Two-step: /points/{lat},{lon} → get forecastUrl → fetch that URL.
-NWS returns 12-hour periods — merge pairs into daily low/high.
-Detect US location: if /points returns 404, notify the user that NWS is
-US-only and ask them to switch service (do not silently fall back — the
-user chose NWS deliberately).
-
-🔲 3.4 — Google Weather API implementation (key required)
-Per Google's current Weather API docs. Validate key is non-empty before
-any request. Surface an error state in Settings if the key returns 401.
-
-🔲 3.5 — WeatherRepository
-Wraps the active client. Implements the caching rule:
-- Read cached forecast from DataStore (cachedForecastJson + timestamp).
-- If age < FORECAST_CACHE_TTL_MS (3 hours): return cached data immediately.
-- Otherwise: fetch fresh, serialize to JSON, store with new timestamp.
-- On fetch failure: return cached data if present, otherwise
-  Result.failure with a typed AppError.
-
-FORECAST_CACHE_TTL_MS = 3 * 60 * 60 * 1000L  // named constant, not magic
-
-Hilt: use @Named qualifier or a sealed binding to provide the correct
-WeatherServiceClient at runtime based on
-WeatherPreferencesRepository.weatherService.
+✅ 3.5 — WeatherRepository + caching
+FORECAST_CACHE_TTL_MS = 3h named constant. Cache-first: if fresh, parse and
+return cached JSON. On fresh fetch: get location (LocationProvider → cached
+lat/lon fallback), select client, fetch, serialize to CachedForecastEntry list,
+saveCache(). On fetch failure: return stale cache if present.
+DataModule: Json extracted to @Provides @Singleton; HttpClient now takes json
+param so both HTTP and cache serialization share the same Json config.
 
   ---
 Phase 4 — Surface forecast in the Journal

--- a/app-android/weather-roadmap.md
+++ b/app-android/weather-roadmap.md
@@ -212,10 +212,11 @@ JournalViewModel.logOutfitOnDate() looks up forecastDays for the selected
 date and passes values through. No-op when weather is disabled or the date
 has no forecast entry. User can still override via the log-edit sheet.
 
-🔲 4.3 — Weather on DayDetailSheet
-DayDetailSheet.kt exists. Show the stored temperature_low/high and
-weather_condition from the OutfitLog entity if present. This is a
-read-only display — no fetch involved.
+✅ 4.3 — Weather on DayDetailSheet
+LogCard upgraded: condition icon (12dp) + label + temp range on a dedicated
+weather row; notes on a separate line below. Both are read-only from stored
+OutfitLogWithMeta fields. WeatherCondition.fromString() parses the DB string;
+toDisplayTemp() honours temperatureUnit preference passed from JournalContent.
 
   ---
 Phase 5 — Schema gaps (needed for outfit recommendation filtering)

--- a/app-android/weather-roadmap.md
+++ b/app-android/weather-roadmap.md
@@ -1,0 +1,315 @@
+Audit Findings (updated 2026-03-24)
+
+What Already Exists
+
+outfit_logs table — columns in schema v1 (current):
+- temperature_low REAL nullable
+- temperature_high REAL nullable
+- weather_condition TEXT nullable (Room type-converted from WeatherCondition enum)
+
+WeatherCondition enum (core/data/.../model/Enums.kt):
+Sunny | Partly Cloudy | Cloudy | Rainy | Snowy | Windy
+Has fromString() factory. No fromWmoCode() factory yet.
+
+These fields are on the log (what the user wore on a past date), not on
+clothing items or lookup tables. They record observed conditions after the
+fact, not predictive/filter attributes.
+
+Seasons lookup (DatabaseSeeder.kt):
+Spring | Summer | Fall | Winter | All Season
+Generic calendar-based. No temperature ranges, no precipitation data attached.
+
+Occasions lookup: 9 entries (Casual → Special Occasion). Tangentially
+weather-aware (Outdoor/Hiking) but not weather-driven.
+
+Settings screen: EXISTS — features/settings module, fully integrated.
+  - SettingsScreen.kt + SettingsViewModel.kt (HiltViewModel)
+  - Appearance section: dynamic color toggle (API 31+) + accent color picker
+  - Accessed via gear icon on ClosetScreen top app bar
+  - Route: SettingsRoute, registered in ClosetNavGraph.kt
+
+DataStore: EXISTS — core/ui/preferences/PreferencesRepository.kt
+  - DataStore file name: "closet_prefs"
+  - Keys: accent (String), dynamic_color (Boolean)
+  - Provided as @Singleton via Hilt in core/ui
+  - Dependency already in libs.versions.toml (datastorePreferences = "1.1.4")
+  - NOT yet added to core/data/build.gradle.kts
+
+HTTP client: None — no OkHttp, Retrofit, or Ktor in libs.versions.toml.
+Location permissions: None in manifest or any source file.
+Navigation: 4 bottom-nav tabs (Closet / Outfits / Journal / Stats), 11 total
+registered destinations. Settings route registered (gear icon entry point).
+Database: schema v1 (pre-release; no shipped installs — migration chain can
+  still be reset if needed).
+
+  ---
+Schema Granularity Assessment
+
+What exists: temperature_low / temperature_high on outfit_logs
+Maps to forecast data?: Yes — directly maps to a daily forecast range
+────────────────────────────────────────
+What exists: WeatherCondition (6 values)
+Maps to forecast data?: Partially — covers precip (Rainy, Snowy), sky cover
+    (Sunny, Partly Cloudy, Cloudy), wind (Windy) but collapses everything into
+    one field. Missing: humidity, UV index, feels-like, heavy vs light rain,
+    thunderstorm, fog
+────────────────────────────────────────
+What exists: Seasons (4 + All Season)
+Maps to forecast data?: Very coarse — calendar quarters only, not
+temperature-band driven
+────────────────────────────────────────
+What exists: Occasions
+Maps to forecast data?: Not weather-related
+
+Gap summary: The schema records user-observed weather on past logs, but
+nothing on clothing items themselves links them to weather suitability.
+There is no temperature-band, wind-chill, precipitation-type, or UV
+metadata on clothing_items, categories, or any junction table. This is the
+primary gap that would need filling for outfit recommendation filtering.
+
+  ---
+Implementation Roadmap
+
+✅ = done  🔲 = not done
+
+Phase 0 — Groundwork (no user-visible features)
+
+✅ 0.1 — DataStore dependency
+datastorePreferences = "1.1.4" in libs.versions.toml. Added to both
+core/ui/build.gradle.kts and core/data/build.gradle.kts.
+
+✅ 0.2 — WeatherPreferences data class + DataStore repository
+Create core/data/.../repository/WeatherPreferencesRepository.kt.
+Use a separate DataStore file ("weather_prefs") so weather concerns stay
+in core/data and don't pollute core/ui's "closet_prefs" file.
+Persists:
+  weatherEnabled: Boolean = false
+  weatherService: WeatherService = OPEN_METEO  // enum: OPEN_METEO | NWS | GOOGLE
+  googleApiKey: String = ""
+  temperatureUnit: TemperatureUnit = CELSIUS   // enum: CELSIUS | FAHRENHEIT
+  cachedForecastJson: String = ""
+  cachedForecastTimestamp: Long = 0L
+  cachedLatitude: Double = 0.0
+  cachedLongitude: Double = 0.0
+
+Provide via Hilt @Singleton in DataModule.kt.
+
+🔲 0.3 — HTTP client
+Add Ktor-client-android + ktor-client-okhttp + ktor-client-content-negotiation
++ ktor-serialization-kotlinx-json to libs.versions.toml.
+kotlinx-serialization-json is already present (1.10.0) — just add Ktor.
+Weather APIs are simple GET-only JSON endpoints; Retrofit is not needed.
+Provide KtorHttpClient as a @Singleton in DataModule.kt.
+
+  ---
+Phase 1 — Settings screen
+
+✅ 1.1 — Settings destination
+features/settings module exists. SettingsRoute registered in
+ClosetNavGraph.kt. Gear icon wired on ClosetScreen. DONE.
+
+✅ 1.2 — Settings screen skeleton
+SettingsScreen.kt + SettingsViewModel.kt exist. Dynamic color toggle +
+accent color picker implemented. DONE.
+
+🔲 1.3 — Weather section in Settings
+Extend SettingsViewModel to also inject WeatherPreferencesRepository.
+Add a "Weather" section to SettingsScreen with:
+- Toggle: "Show weather forecast" (off by default). On first enable →
+  trigger location permission request (Phase 2).
+- Service picker (visible only when toggle is on):
+  Open-Meteo / NWS / Google Weather API.
+- Conditional API key input field (visible only when Google is selected).
+- Units toggle: °C / °F (moves here from a hypothetical general section —
+  it only matters once weather is enabled).
+- "Clear cached forecast" action.
+
+All state flows from WeatherPreferencesRepository via SettingsViewModel.
+Note: features/settings can depend on both core/ui and core/data — no
+module dependency issue.
+
+  ---
+Phase 2 — Location permission
+
+🔲 2.1 — Manifest
+Add to AndroidManifest.xml:
+  <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
+  <uses-permission android:name="android.permission.INTERNET" />
+COARSE is sufficient for city-level weather. Do not request FINE — it
+signals GPS tracking, which is trust-destroying for a privacy-first app.
+INTERNET is required for any outbound HTTP call.
+
+🔲 2.2 — Permission request flow
+When the Settings toggle transitions from off → on:
+1. Check if ACCESS_COARSE_LOCATION is already granted.
+2. If not: use Compose rememberLauncherForActivityResult(RequestPermission)
+   to surface the native modal.
+3. On grant: save weatherEnabled = true in DataStore, trigger initial
+   forecast fetch.
+4. On deny: revert the toggle to off, show a non-blocking snackbar:
+   "Location access is needed to fetch weather. You can enable it later in
+   System Settings."
+5. On permanent deny (shouldShowRationale = false after a denial): show a
+   dialog explaining why + deep-link to system app settings via
+   ACTION_APPLICATION_DETAILS_SETTINGS. Still revert the toggle.
+
+🔲 2.3 — Location fetch
+Use LocationManager (no Play Services dependency — the app has none).
+Do a single passive location read (NETWORK_PROVIDER is sufficient for
+city-level accuracy). Cache lat/lon in DataStore alongside the forecast.
+Only re-request location when fetching a fresh forecast.
+
+  ---
+Phase 3 — Weather service abstraction
+
+🔲 3.1 — WeatherService interface
+interface WeatherServiceClient {
+    suspend fun fetchDailyForecast(lat: Double, lon: Double): Result<DailyForecast>
+}
+
+data class DailyForecast(
+    val date: LocalDate,
+    val tempLow: Double,       // always stored in °C; convert for display
+    val tempHigh: Double,
+    val condition: WeatherCondition,
+    val precipitationMm: Double,
+    val windSpeedKmh: Double,
+    val uvIndex: Int?,
+    val humidity: Int?         // percent
+)
+
+Must implement WeatherCondition enum expansion (Gap 3 below) before this
+step — the mapping from WMO codes depends on the expanded enum.
+
+🔲 3.2 — Open-Meteo implementation (default, no key)
+Endpoint: https://api.open-meteo.com/v1/forecast
+Params: latitude, longitude,
+  daily=temperature_2m_max,temperature_2m_min,precipitation_sum,
+  windspeed_10m_max,weathercode,uv_index_max,
+  forecast_days=7, timezone=auto
+Map WMO weathercode integer → WeatherCondition via fromWmoCode() factory.
+This is the most important mapping work in the whole feature.
+
+🔲 3.3 — NWS implementation (US-only, no key)
+Two-step: /points/{lat},{lon} → get forecastUrl → fetch that URL.
+NWS returns 12-hour periods — merge pairs into daily low/high.
+Detect US location: if /points returns 404, notify the user that NWS is
+US-only and ask them to switch service (do not silently fall back — the
+user chose NWS deliberately).
+
+🔲 3.4 — Google Weather API implementation (key required)
+Per Google's current Weather API docs. Validate key is non-empty before
+any request. Surface an error state in Settings if the key returns 401.
+
+🔲 3.5 — WeatherRepository
+Wraps the active client. Implements the caching rule:
+- Read cached forecast from DataStore (cachedForecastJson + timestamp).
+- If age < FORECAST_CACHE_TTL_MS (3 hours): return cached data immediately.
+- Otherwise: fetch fresh, serialize to JSON, store with new timestamp.
+- On fetch failure: return cached data if present, otherwise
+  Result.failure with a typed AppError.
+
+FORECAST_CACHE_TTL_MS = 3 * 60 * 60 * 1000L  // named constant, not magic
+
+Hilt: use @Named qualifier or a sealed binding to provide the correct
+WeatherServiceClient at runtime based on
+WeatherPreferencesRepository.weatherService.
+
+  ---
+Phase 4 — Surface forecast in the Journal
+
+The Journal screen is the natural home for weather since it already shows
+wear history by date.
+
+🔲 4.1 — Today's forecast widget on Journal header
+When weatherEnabled = true and forecast is cached for today: show a compact
+weather chip (condition icon + temp range) at the top of JournalScreen
+above the calendar. Tapping it opens a bottom sheet with the 7-day
+forecast.
+
+🔲 4.2 — Auto-populate weather on log creation
+In JournalViewModel.logOutfitOnDate(): if weatherEnabled = true and a
+cached forecast exists for today's date, pre-populate temperatureLow,
+temperatureHigh, and weatherCondition on the new OutfitLogEntity. User
+can still override manually.
+
+🔲 4.3 — Weather on DayDetailSheet
+DayDetailSheet.kt exists. Show the stored temperature_low/high and
+weather_condition from the OutfitLog entity if present. This is a
+read-only display — no fetch involved.
+
+  ---
+Phase 5 — Schema gaps (needed for outfit recommendation filtering)
+
+These are independent of Phases 1–4 and can be done at any time, but are
+required before weather data can drive outfit suggestions. All changes
+go in Migration 2 (or a new migration if chain has moved).
+
+🔲 Gap 1 — Temperature suitability on clothing items
+Add temp_min_c REAL nullable and temp_max_c REAL nullable to
+clothing_items. Lets a user express "this jacket is suitable for 0–10°C".
+User-set, not auto-populated.
+
+🔲 Gap 2 — Precipitation resistance on clothing items
+Add water_resistant INTEGER NOT NULL DEFAULT 0 to clothing_items. Needed
+to filter for rainy-day suitable items.
+
+🔲 Gap 3 — WeatherCondition enum expansion  ← do this BEFORE Phase 3
+Current 6 values don't cover: Thunderstorm, Foggy, Drizzle, Sleet,
+HeavySnow, HeatWave. WMO weathercode mapping has ~30 codes. Expand the
+enum and add fromWmoCode(code: Int): WeatherCondition factory. Room
+stores this as a String (label), so adding new values is non-breaking.
+
+🔲 Gap 4 — Seasons with temperature ranges (optional, low priority)
+Add temp_low_c / temp_high_c to the seasons lookup table for automatic
+season-tag suggestions from forecast temperature. Works fine without it
+if temperature suitability is on items directly (Gap 1).
+
+🔲 Gap 5 — precipitation_mm and wind_speed_kmh on outfit_logs
+Add precipitation_mm REAL nullable and wind_speed_kmh REAL nullable to
+outfit_logs for richer historical analysis ("what did I wear last time it
+rained heavily?"). Include in the same migration as Gaps 1 and 2.
+
+  ---
+Phase ordering summary
+
+┌───────┬─────────────────────────────────────────┬────────────────────────┐
+│ Phase │               What ships                │    Prerequisite        │
+├───────┼─────────────────────────────────────────┼────────────────────────┤
+│ 0     │ WeatherPrefs DataStore repo + HTTP      │ —  (0.1 already done)  │
+│       │ client wired up, no UI                  │                        │
+├───────┼─────────────────────────────────────────┼────────────────────────┤
+│ 1     │ Weather section in existing Settings    │ Phase 0                │
+│       │ screen (1.1 + 1.2 already done)         │                        │
+├───────┼─────────────────────────────────────────┼────────────────────────┤
+│ 2     │ Location permission request flow        │ Phase 1                │
+├───────┼─────────────────────────────────────────┼────────────────────────┤
+│ 3     │ Weather service clients + caching       │ Phase 0, 2, Gap 3      │
+├───────┼─────────────────────────────────────────┼────────────────────────┤
+│ 4     │ Journal forecast widget + auto-populate │ Phase 3                │
+│       │ on log                                  │                        │
+├───────┼─────────────────────────────────────────┼────────────────────────┤
+│ 5     │ Schema additions for future             │ Any time, independent  │
+│       │ recommendation filtering                │                        │
+└───────┴─────────────────────────────────────────┴────────────────────────┘
+
+  ---
+Key design decisions (resolved or still open)
+
+✅ 1. Settings entry point — gear icon on Closet screen top app bar. DONE.
+
+✅ 2. Location library — use LocationManager (no Play Services dependency;
+   the app has none and adding Play Services is a meaningful SDK bloat
+   decision). NETWORK_PROVIDER gives city-level accuracy — sufficient.
+
+🔲 3. Temperature unit — canonical storage is °C (recommended). All DB
+   columns (temperature_low, temperature_high, temp_min_c, temp_max_c)
+   store Celsius. Convert to °F for display only, driven by
+   temperatureUnit preference. CONFIRM before any data is written.
+
+🔲 4. NWS out-of-US — notify the user and ask them to switch service
+   (do not silently fall back). Rationale: user made a deliberate choice;
+   silent fallback would be confusing if NWS and Open-Meteo disagree.
+   CONFIRM this UX.
+
+✅ 5. Cache TTL — 3 hours, stored as named constant FORECAST_CACHE_TTL_MS.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 7‑day forecasts (OpenMeteo, NWS, Google), forecast sheet, Today forecast chip, forecast-driven auto‑population when logging outfits, temperature unit support.

* **Settings**
  * Weather section: enable forecasts, select provider, enter Google API key, choose temperature unit, clear cached forecast.

* **Background**
  * 3‑hour cache with stale‑fallback, location lookup without Play Services, resilient fetch + cache behavior.

* **Permissions**
  * Requests for coarse location and Internet access.

* **Database**
  * Schema version bump with season temp bands, category warmth layer, new weather columns on logs; migration and tests included.

* **Documentation**
  * Added weather and outfit‑recommendation roadmaps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->