### PR TITLE
Add background segmentation and removal features

### DIFF
--- a/app-android/CLAUDE.md
+++ b/app-android/CLAUDE.md
@@ -54,7 +54,7 @@ Module dependencies: `app` → `features/*` → `core/ui` → `core/data`.
 
 ### Product flavors
 
-Two flavors on the `distribution` dimension. Only `app/` and `features/recommendations/` declare flavor dimensions; all other modules are single-variant.
+Two flavors on the `distribution` dimension. Only `app/`, `features/recommendations/`, and `features/wardrobe/` declare flavor dimensions; all other modules are single-variant.
 
 - **`full`** — includes GMS-backed features (MLKit GenAI Prompt API / Gemini Nano). Use for local dev, GitHub releases, sideload APKs. Android Studio defaults to `fullDebug`.
 - **`foss`** — no Google Play Services dependencies. GMS features are stubbed to no-ops. Target: F-Droid distribution.

--- a/app-android/app/build.gradle.kts
+++ b/app-android/app/build.gradle.kts
@@ -16,7 +16,7 @@ android {
         minSdk = libs.versions.minSdk.get().toInt()
         targetSdk = libs.versions.targetSdk.get().toInt()
         versionCode = 1
-        versionName = "1.0"
+        versionName = "0.1.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {

--- a/app-android/app/build.gradle.kts
+++ b/app-android/app/build.gradle.kts
@@ -102,6 +102,7 @@ dependencies {
     ksp(libs.hilt.compiler)
     ksp(libs.androidx.hilt.compiler)
     implementation(libs.androidx.hilt.navigation.compose)
+    implementation(libs.androidx.hilt.work)
 
     // Logging
     implementation(libs.timber)

--- a/app-android/app/build.gradle.kts
+++ b/app-android/app/build.gradle.kts
@@ -100,6 +100,7 @@ dependencies {
     // Hilt
     implementation(libs.hilt.android)
     ksp(libs.hilt.compiler)
+    ksp(libs.androidx.hilt.compiler)
     implementation(libs.androidx.hilt.navigation.compose)
 
     // Logging

--- a/app-android/app/src/main/AndroidManifest.xml
+++ b/app-android/app/src/main/AndroidManifest.xml
@@ -1,9 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     package="com.closet">
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
+    <!-- Required for BatchSegmentationWorker foreground service -->
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />
+    <!-- Required on API 33+ to post progress notifications -->
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 
     <application
         android:name=".ClosetApp"
@@ -22,6 +28,22 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+
+        <!--
+            Disable WorkManager's default auto-initializer so our custom HiltWorkerFactory
+            (configured in ClosetApp.workManagerConfiguration) is used instead.
+            WorkManager initializes on-demand on the first getInstance() call.
+        -->
+        <provider
+            android:name="androidx.startup.InitializationProvider"
+            android:authorities="${applicationId}.androidx-startup"
+            android:exported="false"
+            tools:node="merge">
+            <meta-data
+                android:name="androidx.work.WorkManagerInitializer"
+                android:value="androidx.startup"
+                tools:node="remove" />
+        </provider>
     </application>
 
 </manifest>

--- a/app-android/app/src/main/AndroidManifest.xml
+++ b/app-android/app/src/main/AndroidManifest.xml
@@ -34,6 +34,17 @@
             (configured in ClosetApp.workManagerConfiguration) is used instead.
             WorkManager initializes on-demand on the first getInstance() call.
         -->
+        <!--
+            WorkManager's internal foreground service. Merging foregroundServiceType here
+            is required on API 34+ when setForeground() is called with
+            ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC; without it Android throws
+            MissingForegroundServiceTypeException at runtime.
+        -->
+        <service
+            android:name="androidx.work.impl.foreground.SystemForegroundService"
+            android:foregroundServiceType="dataSync"
+            tools:node="merge" />
+
         <provider
             android:name="androidx.startup.InitializationProvider"
             android:authorities="${applicationId}.androidx-startup"

--- a/app-android/app/src/main/kotlin/com/closet/ClosetApp.kt
+++ b/app-android/app/src/main/kotlin/com/closet/ClosetApp.kt
@@ -1,6 +1,8 @@
 package com.closet
 
 import android.app.Application
+import androidx.hilt.work.HiltWorkerFactory
+import androidx.work.Configuration
 import com.closet.core.data.repository.AiPreferencesRepository
 import dagger.hilt.android.HiltAndroidApp
 import kotlinx.coroutines.CoroutineScope
@@ -13,11 +15,19 @@ import javax.inject.Inject
 /**
  * The Application class for the Closet app.
  * Required by Hilt for dependency injection.
+ *
+ * Implements [Configuration.Provider] so WorkManager uses [HiltWorkerFactory] instead of the
+ * default factory. The default WorkManager initializer is disabled in AndroidManifest.xml;
+ * WorkManager initializes on-demand on the first [androidx.work.WorkManager.getInstance] call.
  */
 @HiltAndroidApp
-class ClosetApp : Application() {
+class ClosetApp : Application(), Configuration.Provider {
 
     @Inject lateinit var aiPreferencesRepository: AiPreferencesRepository
+    @Inject lateinit var workerFactory: HiltWorkerFactory
+
+    override val workManagerConfiguration: Configuration
+        get() = Configuration.Builder().setWorkerFactory(workerFactory).build()
 
     private val applicationScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
 

--- a/app-android/app/src/main/kotlin/com/closet/ClosetApp.kt
+++ b/app-android/app/src/main/kotlin/com/closet/ClosetApp.kt
@@ -26,8 +26,8 @@ class ClosetApp : Application(), Configuration.Provider {
     @Inject lateinit var aiPreferencesRepository: AiPreferencesRepository
     @Inject lateinit var workerFactory: HiltWorkerFactory
 
-    override val workManagerConfiguration: Configuration
-        get() = Configuration.Builder().setWorkerFactory(workerFactory).build()
+    override fun getWorkManagerConfiguration(): Configuration =
+        Configuration.Builder().setWorkerFactory(workerFactory).build()
 
     private val applicationScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
 

--- a/app-android/core/data/src/main/kotlin/com/closet/core/data/dao/ClothingDao.kt
+++ b/app-android/core/data/src/main/kotlin/com/closet/core/data/dao/ClothingDao.kt
@@ -219,6 +219,10 @@ interface ClothingDao {
     @Query("SELECT * FROM clothing_items WHERE image_path IS NOT NULL AND image_path NOT LIKE '%.png'")
     suspend fun getItemsNeedingSegmentation(): List<ClothingItemEntity>
 
+    /** Live count of items eligible for batch segmentation. Updates whenever the table changes. */
+    @Query("SELECT COUNT(*) FROM clothing_items WHERE image_path IS NOT NULL AND image_path NOT LIKE '%.png'")
+    fun getSegmentationEligibleCount(): Flow<Int>
+
     /** Replaces the stored image path for a single item and updates its timestamp. */
     @Query("UPDATE clothing_items SET image_path = :imagePath, updated_at = :updatedAt WHERE id = :id")
     suspend fun updateItemImagePath(id: Long, imagePath: String, updatedAt: java.time.Instant)

--- a/app-android/core/data/src/main/kotlin/com/closet/core/data/dao/ClothingDao.kt
+++ b/app-android/core/data/src/main/kotlin/com/closet/core/data/dao/ClothingDao.kt
@@ -212,4 +212,14 @@ interface ClothingDao {
 
     @Insert(onConflict = OnConflictStrategy.IGNORE)
     suspend fun insertItemPatterns(items: List<ClothingItemPatternEntity>)
+
+    // ── Batch segmentation ───────────────────────────────────────────────────
+
+    /** Returns all items that have an image and have not yet been segmented (no .png extension). */
+    @Query("SELECT * FROM clothing_items WHERE image_path IS NOT NULL AND image_path NOT LIKE '%.png'")
+    suspend fun getItemsNeedingSegmentation(): List<ClothingItemEntity>
+
+    /** Replaces the stored image path for a single item and updates its timestamp. */
+    @Query("UPDATE clothing_items SET image_path = :imagePath, updated_at = :updatedAt WHERE id = :id")
+    suspend fun updateItemImagePath(id: Long, imagePath: String, updatedAt: java.time.Instant)
 }

--- a/app-android/core/data/src/main/kotlin/com/closet/core/data/repository/StorageRepository.kt
+++ b/app-android/core/data/src/main/kotlin/com/closet/core/data/repository/StorageRepository.kt
@@ -9,6 +9,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import timber.log.Timber
 import java.io.File
+import java.io.IOException
 import java.util.UUID
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -83,7 +84,10 @@ class StorageRepository @Inject constructor(
     suspend fun saveBitmap(bitmap: Bitmap, filename: String): String = withContext(Dispatchers.IO) {
         val destFile = File(imagesDir, filename)
         destFile.outputStream().use { out ->
-            bitmap.compress(Bitmap.CompressFormat.PNG, 100, out)
+            if (!bitmap.compress(Bitmap.CompressFormat.PNG, 100, out)) {
+                destFile.delete()
+                throw IOException("Bitmap.compress returned false for $filename")
+            }
         }
         filename
     }

--- a/app-android/core/data/src/main/kotlin/com/closet/core/data/repository/StorageRepository.kt
+++ b/app-android/core/data/src/main/kotlin/com/closet/core/data/repository/StorageRepository.kt
@@ -71,6 +71,24 @@ class StorageRepository @Inject constructor(
     }
 
     /**
+     * Saves a [Bitmap] as a PNG to the app's internal images directory.
+     *
+     * The PNG encoder ignores the quality parameter, so lossless transparency is
+     * preserved — required for segmented images with transparent backgrounds.
+     *
+     * @param bitmap The bitmap to save (should be ARGB_8888 for transparency support).
+     * @param filename The target filename including extension (e.g. `"uuid.png"`).
+     * @return The relative path (filename only, no leading slash) — same convention as [saveImage].
+     */
+    suspend fun saveBitmap(bitmap: Bitmap, filename: String): String = withContext(Dispatchers.IO) {
+        val destFile = File(imagesDir, filename)
+        destFile.outputStream().use { out ->
+            bitmap.compress(Bitmap.CompressFormat.PNG, 100, out)
+        }
+        filename
+    }
+
+    /**
      * Loads a Bitmap from a Uri.
      */
     suspend fun getBitmap(uri: Uri): Bitmap? = withContext(Dispatchers.IO) {

--- a/app-android/core/data/src/main/kotlin/com/closet/core/data/worker/BatchSegmentationWork.kt
+++ b/app-android/core/data/src/main/kotlin/com/closet/core/data/worker/BatchSegmentationWork.kt
@@ -1,0 +1,21 @@
+package com.closet.core.data.worker
+
+/**
+ * Constants shared between `BatchSegmentationWorker` (features/wardrobe) and
+ * `SettingsViewModel` (features/settings) so neither module needs to depend on the other.
+ */
+object BatchSegmentationWork {
+    const val NAME = "batch_segmentation"
+    const val KEY_DONE = "done"
+    const val KEY_TOTAL = "total"
+    const val KEY_FAILED = "failed"
+}
+
+/**
+ * Abstraction that lets [SettingsViewModel] trigger batch segmentation without
+ * a direct dependency on `features/wardrobe`. Bound to its concrete implementation
+ * by `WardrobeModule` in `features/wardrobe`.
+ */
+interface BatchSegmentationScheduler {
+    fun schedule()
+}

--- a/app-android/core/data/src/main/kotlin/com/closet/core/data/worker/BatchSegmentationWork.kt
+++ b/app-android/core/data/src/main/kotlin/com/closet/core/data/worker/BatchSegmentationWork.kt
@@ -17,5 +17,7 @@ object BatchSegmentationWork {
  * by `WardrobeModule` in `features/wardrobe`.
  */
 interface BatchSegmentationScheduler {
+    /** `false` on FOSS builds where ML Kit segmentation is unavailable. */
+    val isSupported: Boolean
     fun schedule()
 }

--- a/app-android/features/settings/build.gradle.kts
+++ b/app-android/features/settings/build.gradle.kts
@@ -53,4 +53,6 @@ dependencies {
 
     implementation(libs.androidx.lifecycle.viewmodel.compose)
     implementation(libs.androidx.lifecycle.runtime.compose)
+
+    implementation(libs.androidx.work.runtime.ktx)
 }

--- a/app-android/features/settings/src/main/kotlin/com/closet/features/settings/SettingsScreen.kt
+++ b/app-android/features/settings/src/main/kotlin/com/closet/features/settings/SettingsScreen.kt
@@ -67,6 +67,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.work.WorkInfo
+import com.closet.core.data.worker.BatchSegmentationWork
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
@@ -151,8 +152,8 @@ fun SettingsScreen(
         val info = batchSegWorkInfo ?: return@LaunchedEffect
         if (info.state == WorkInfo.State.SUCCEEDED && info.id != lastHandledBatchId) {
             lastHandledBatchId = info.id
-            val done = info.outputData.getInt("done", 0)
-            val failed = info.outputData.getInt("failed", 0)
+            val done = info.outputData.getInt(BatchSegmentationWork.KEY_DONE, 0)
+            val failed = info.outputData.getInt(BatchSegmentationWork.KEY_FAILED, 0)
             val msg = if (failed > 0) {
                 String.format(batchResultWithFailuresMsg, done, failed)
             } else {
@@ -1168,8 +1169,8 @@ private fun BatchSegmentationItem(
     }
 
     if (isRunning) {
-        val done = workInfo?.progress?.getInt("done", 0) ?: 0
-        val total = workInfo?.progress?.getInt("total", 0) ?: 0
+        val done = workInfo?.progress?.getInt(BatchSegmentationWork.KEY_DONE, 0) ?: 0
+        val total = workInfo?.progress?.getInt(BatchSegmentationWork.KEY_TOTAL, 0) ?: 0
         ListItem(
             headlineContent = {
                 Text(stringResource(R.string.settings_wardrobe_removing_backgrounds))

--- a/app-android/features/settings/src/main/kotlin/com/closet/features/settings/SettingsScreen.kt
+++ b/app-android/features/settings/src/main/kotlin/com/closet/features/settings/SettingsScreen.kt
@@ -142,16 +142,16 @@ fun SettingsScreen(
 
     val deniedMessage = stringResource(R.string.settings_location_snackbar)
 
-    // Show a snackbar once per completed batch run. Track the last-handled WorkInfo ID
-    // so the snackbar doesn't re-fire if the screen leaves and comes back while the
-    // same SUCCEEDED WorkInfo is still the most recent result.
+    // Show a snackbar once per completed batch run. lastHandledBatchId lives in the
+    // ViewModel so it survives the screen leaving composition and coming back — a
+    // local `remember` would reset to null and re-fire the snackbar on re-entry.
     val batchResultMsg = stringResource(R.string.settings_wardrobe_batch_result)
     val batchResultWithFailuresMsg = stringResource(R.string.settings_wardrobe_batch_result_with_failures)
-    var lastHandledBatchId by remember { mutableStateOf<java.util.UUID?>(null) }
+    val lastHandledBatchId by viewModel.lastHandledBatchId.collectAsStateWithLifecycle()
     LaunchedEffect(batchSegWorkInfo?.id, batchSegWorkInfo?.state) {
         val info = batchSegWorkInfo ?: return@LaunchedEffect
         if (info.state == WorkInfo.State.SUCCEEDED && info.id != lastHandledBatchId) {
-            lastHandledBatchId = info.id
+            viewModel.onBatchResultHandled(info.id)
             val done = info.outputData.getInt(BatchSegmentationWork.KEY_DONE, 0)
             val failed = info.outputData.getInt(BatchSegmentationWork.KEY_FAILED, 0)
             val msg = if (failed > 0) {

--- a/app-android/features/settings/src/main/kotlin/com/closet/features/settings/SettingsScreen.kt
+++ b/app-android/features/settings/src/main/kotlin/com/closet/features/settings/SettingsScreen.kt
@@ -60,11 +60,13 @@ import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
+import androidx.work.WorkInfo
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
@@ -126,6 +128,9 @@ fun SettingsScreen(
     val anthropicModels by viewModel.anthropicModels.collectAsStateWithLifecycle()
     val anthropicModelsLoading by viewModel.anthropicModelsLoading.collectAsStateWithLifecycle()
 
+    val segmentationEligibleCount by viewModel.segmentationEligibleCount.collectAsStateWithLifecycle()
+    val batchSegWorkInfo by viewModel.batchSegWorkInfo.collectAsStateWithLifecycle()
+
     val context = LocalContext.current
     val activity = LocalActivity.current
     val coroutineScope = rememberCoroutineScope()
@@ -134,6 +139,22 @@ fun SettingsScreen(
     var nanoNotSupportedDismissed by remember { mutableStateOf(false) }
 
     val deniedMessage = stringResource(R.string.settings_location_snackbar)
+
+    // Show a snackbar whenever a batch segmentation run completes.
+    val batchResultMsg = stringResource(R.string.settings_wardrobe_batch_result)
+    val batchResultWithFailuresMsg = stringResource(R.string.settings_wardrobe_batch_result_with_failures)
+    LaunchedEffect(batchSegWorkInfo?.id, batchSegWorkInfo?.state) {
+        if (batchSegWorkInfo?.state == WorkInfo.State.SUCCEEDED) {
+            val done = batchSegWorkInfo?.outputData?.getInt("done", 0) ?: 0
+            val failed = batchSegWorkInfo?.outputData?.getInt("failed", 0) ?: 0
+            val msg = if (failed > 0) {
+                String.format(batchResultWithFailuresMsg, done, failed)
+            } else {
+                String.format(batchResultMsg, done)
+            }
+            snackbarHostState.showSnackbar(msg)
+        }
+    }
 
     val permissionLauncher = rememberLauncherForActivityResult(
         ActivityResultContracts.RequestPermission(),
@@ -240,6 +261,9 @@ fun SettingsScreen(
         openAiModelsLoading = openAiModelsLoading,
         anthropicModels = anthropicModels,
         anthropicModelsLoading = anthropicModelsLoading,
+        segmentationEligibleCount = segmentationEligibleCount,
+        batchSegWorkInfo = batchSegWorkInfo,
+        onStartBatchSegmentation = viewModel::startBatchSegmentation,
         snackbarHostState = snackbarHostState,
         onNavigateUp = onNavigateUp,
     )
@@ -292,6 +316,9 @@ internal fun SettingsContent(
     anthropicModelsLoading: Boolean,
     styleVibe: StyleVibe,
     onStyleVibeSelected: (StyleVibe) -> Unit,
+    segmentationEligibleCount: Int,
+    batchSegWorkInfo: WorkInfo?,
+    onStartBatchSegmentation: () -> Unit,
     snackbarHostState: SnackbarHostState,
     onNavigateUp: () -> Unit,
     modifier: Modifier = Modifier,
@@ -424,6 +451,18 @@ internal fun SettingsContent(
                         )
                     }
                 }
+            }
+
+            // ── Wardrobe ──────────────────────────────────────────────────────
+            item {
+                SettingsSectionHeader(stringResource(R.string.settings_section_wardrobe))
+            }
+            item {
+                BatchSegmentationItem(
+                    eligibleCount = segmentationEligibleCount,
+                    workInfo = batchSegWorkInfo,
+                    onStart = onStartBatchSegmentation,
+                )
             }
         }
     }
@@ -1085,6 +1124,67 @@ private val OPENAI_URL_PRESETS = listOf(
     "Ollama (Emulator)" to "http://10.0.2.2:11434",
 )
 
+// ── Wardrobe items ────────────────────────────────────────────────────────────
+
+@Composable
+private fun BatchSegmentationItem(
+    eligibleCount: Int,
+    workInfo: WorkInfo?,
+    onStart: () -> Unit,
+) {
+    val isRunning = workInfo?.state == WorkInfo.State.RUNNING ||
+        workInfo?.state == WorkInfo.State.ENQUEUED
+
+    if (isRunning) {
+        val done = workInfo?.progress?.getInt("done", 0) ?: 0
+        val total = workInfo?.progress?.getInt("total", 0) ?: 0
+        ListItem(
+            headlineContent = {
+                Text(stringResource(R.string.settings_wardrobe_removing_backgrounds))
+            },
+            supportingContent = {
+                Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+                    Text(
+                        stringResource(
+                            R.string.settings_wardrobe_removing_backgrounds_progress,
+                            done,
+                            total,
+                        ),
+                    )
+                    LinearProgressIndicator(
+                        progress = { if (total > 0) done.toFloat() / total else 0f },
+                        modifier = Modifier.fillMaxWidth(),
+                    )
+                }
+            },
+        )
+    } else if (eligibleCount > 0) {
+        ListItem(
+            headlineContent = {
+                Text(stringResource(R.string.settings_wardrobe_remove_backgrounds))
+            },
+            supportingContent = {
+                Text(
+                    stringResource(
+                        R.string.settings_wardrobe_remove_backgrounds_summary,
+                        eligibleCount,
+                    ),
+                )
+            },
+            modifier = Modifier.clickable(onClick = onStart),
+        )
+    } else {
+        ListItem(
+            headlineContent = {
+                Text(
+                    stringResource(R.string.settings_wardrobe_all_done),
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            },
+        )
+    }
+}
+
 // ── Dialogs ───────────────────────────────────────────────────────────────────
 
 /**
@@ -1187,6 +1287,9 @@ private fun SettingsContentDefaultPreview() {
             anthropicModelsLoading = false,
             styleVibe = StyleVibe.SmartCasual,
             onStyleVibeSelected = {},
+            segmentationEligibleCount = 3,
+            batchSegWorkInfo = null,
+            onStartBatchSegmentation = {},
             snackbarHostState = remember { SnackbarHostState() },
             onNavigateUp = {},
         )
@@ -1232,6 +1335,9 @@ private fun SettingsContentWeatherOpenMeteoPreview() {
             anthropicModelsLoading = false,
             styleVibe = StyleVibe.SmartCasual,
             onStyleVibeSelected = {},
+            segmentationEligibleCount = 3,
+            batchSegWorkInfo = null,
+            onStartBatchSegmentation = {},
             snackbarHostState = remember { SnackbarHostState() },
             onNavigateUp = {},
         )
@@ -1277,6 +1383,9 @@ private fun SettingsContentWeatherGooglePreview() {
             anthropicModelsLoading = false,
             styleVibe = StyleVibe.SmartCasual,
             onStyleVibeSelected = {},
+            segmentationEligibleCount = 3,
+            batchSegWorkInfo = null,
+            onStartBatchSegmentation = {},
             snackbarHostState = remember { SnackbarHostState() },
             onNavigateUp = {},
         )
@@ -1322,6 +1431,9 @@ private fun SettingsContentAiNanoCheckingPreview() {
             anthropicModelsLoading = false,
             styleVibe = StyleVibe.SmartCasual,
             onStyleVibeSelected = {},
+            segmentationEligibleCount = 3,
+            batchSegWorkInfo = null,
+            onStartBatchSegmentation = {},
             snackbarHostState = remember { SnackbarHostState() },
             onNavigateUp = {},
         )
@@ -1367,6 +1479,9 @@ private fun SettingsContentAiNanoDownloadingPreview() {
             anthropicModelsLoading = false,
             styleVibe = StyleVibe.SmartCasual,
             onStyleVibeSelected = {},
+            segmentationEligibleCount = 3,
+            batchSegWorkInfo = null,
+            onStartBatchSegmentation = {},
             snackbarHostState = remember { SnackbarHostState() },
             onNavigateUp = {},
         )
@@ -1412,6 +1527,9 @@ private fun SettingsContentAiNanoNotSupportedPreview() {
             anthropicModelsLoading = false,
             styleVibe = StyleVibe.SmartCasual,
             onStyleVibeSelected = {},
+            segmentationEligibleCount = 3,
+            batchSegWorkInfo = null,
+            onStartBatchSegmentation = {},
             snackbarHostState = remember { SnackbarHostState() },
             onNavigateUp = {},
         )
@@ -1457,6 +1575,9 @@ private fun SettingsContentAiOpenAiPreview() {
             anthropicModelsLoading = false,
             styleVibe = StyleVibe.SmartCasual,
             onStyleVibeSelected = {},
+            segmentationEligibleCount = 3,
+            batchSegWorkInfo = null,
+            onStartBatchSegmentation = {},
             snackbarHostState = remember { SnackbarHostState() },
             onNavigateUp = {},
         )
@@ -1502,6 +1623,9 @@ private fun SettingsContentAiAnthropicPreview() {
             openAiModelsLoading = false,
             anthropicModels = listOf("claude-opus-4-6", "claude-sonnet-4-6", "claude-haiku-4-5-20251001"),
             anthropicModelsLoading = false,
+            segmentationEligibleCount = 3,
+            batchSegWorkInfo = null,
+            onStartBatchSegmentation = {},
             snackbarHostState = remember { SnackbarHostState() },
             onNavigateUp = {},
         )

--- a/app-android/features/settings/src/main/kotlin/com/closet/features/settings/SettingsScreen.kt
+++ b/app-android/features/settings/src/main/kotlin/com/closet/features/settings/SettingsScreen.kt
@@ -128,6 +128,7 @@ fun SettingsScreen(
     val anthropicModels by viewModel.anthropicModels.collectAsStateWithLifecycle()
     val anthropicModelsLoading by viewModel.anthropicModelsLoading.collectAsStateWithLifecycle()
 
+    val segmentationSupported = viewModel.segmentationSupported
     val segmentationEligibleCount by viewModel.segmentationEligibleCount.collectAsStateWithLifecycle()
     val batchSegWorkInfo by viewModel.batchSegWorkInfo.collectAsStateWithLifecycle()
 
@@ -140,13 +141,18 @@ fun SettingsScreen(
 
     val deniedMessage = stringResource(R.string.settings_location_snackbar)
 
-    // Show a snackbar whenever a batch segmentation run completes.
+    // Show a snackbar once per completed batch run. Track the last-handled WorkInfo ID
+    // so the snackbar doesn't re-fire if the screen leaves and comes back while the
+    // same SUCCEEDED WorkInfo is still the most recent result.
     val batchResultMsg = stringResource(R.string.settings_wardrobe_batch_result)
     val batchResultWithFailuresMsg = stringResource(R.string.settings_wardrobe_batch_result_with_failures)
+    var lastHandledBatchId by remember { mutableStateOf<java.util.UUID?>(null) }
     LaunchedEffect(batchSegWorkInfo?.id, batchSegWorkInfo?.state) {
-        if (batchSegWorkInfo?.state == WorkInfo.State.SUCCEEDED) {
-            val done = batchSegWorkInfo?.outputData?.getInt("done", 0) ?: 0
-            val failed = batchSegWorkInfo?.outputData?.getInt("failed", 0) ?: 0
+        val info = batchSegWorkInfo ?: return@LaunchedEffect
+        if (info.state == WorkInfo.State.SUCCEEDED && info.id != lastHandledBatchId) {
+            lastHandledBatchId = info.id
+            val done = info.outputData.getInt("done", 0)
+            val failed = info.outputData.getInt("failed", 0)
             val msg = if (failed > 0) {
                 String.format(batchResultWithFailuresMsg, done, failed)
             } else {
@@ -261,6 +267,7 @@ fun SettingsScreen(
         openAiModelsLoading = openAiModelsLoading,
         anthropicModels = anthropicModels,
         anthropicModelsLoading = anthropicModelsLoading,
+        segmentationSupported = segmentationSupported,
         segmentationEligibleCount = segmentationEligibleCount,
         batchSegWorkInfo = batchSegWorkInfo,
         onStartBatchSegmentation = viewModel::startBatchSegmentation,
@@ -316,6 +323,7 @@ internal fun SettingsContent(
     anthropicModelsLoading: Boolean,
     styleVibe: StyleVibe,
     onStyleVibeSelected: (StyleVibe) -> Unit,
+    segmentationSupported: Boolean,
     segmentationEligibleCount: Int,
     batchSegWorkInfo: WorkInfo?,
     onStartBatchSegmentation: () -> Unit,
@@ -454,15 +462,17 @@ internal fun SettingsContent(
             }
 
             // ── Wardrobe ──────────────────────────────────────────────────────
-            item {
-                SettingsSectionHeader(stringResource(R.string.settings_section_wardrobe))
-            }
-            item {
-                BatchSegmentationItem(
-                    eligibleCount = segmentationEligibleCount,
-                    workInfo = batchSegWorkInfo,
-                    onStart = onStartBatchSegmentation,
-                )
+            if (segmentationSupported) {
+                item {
+                    SettingsSectionHeader(stringResource(R.string.settings_section_wardrobe))
+                }
+                item {
+                    BatchSegmentationItem(
+                        eligibleCount = segmentationEligibleCount,
+                        workInfo = batchSegWorkInfo,
+                        onStart = onStartBatchSegmentation,
+                    )
+                }
             }
         }
     }
@@ -1134,6 +1144,28 @@ private fun BatchSegmentationItem(
 ) {
     val isRunning = workInfo?.state == WorkInfo.State.RUNNING ||
         workInfo?.state == WorkInfo.State.ENQUEUED
+    var showConfirmDialog by remember { mutableStateOf(false) }
+
+    if (showConfirmDialog) {
+        AlertDialog(
+            onDismissRequest = { showConfirmDialog = false },
+            title = { Text(stringResource(R.string.settings_wardrobe_batch_confirm_title)) },
+            text = { Text(stringResource(R.string.settings_wardrobe_batch_confirm_message)) },
+            confirmButton = {
+                TextButton(onClick = {
+                    showConfirmDialog = false
+                    onStart()
+                }) {
+                    Text(stringResource(R.string.settings_wardrobe_batch_confirm_ok))
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { showConfirmDialog = false }) {
+                    Text(stringResource(R.string.settings_wardrobe_batch_confirm_cancel))
+                }
+            },
+        )
+    }
 
     if (isRunning) {
         val done = workInfo?.progress?.getInt("done", 0) ?: 0
@@ -1171,7 +1203,7 @@ private fun BatchSegmentationItem(
                     ),
                 )
             },
-            modifier = Modifier.clickable(onClick = onStart),
+            modifier = Modifier.clickable { showConfirmDialog = true },
         )
     } else {
         ListItem(
@@ -1287,6 +1319,7 @@ private fun SettingsContentDefaultPreview() {
             anthropicModelsLoading = false,
             styleVibe = StyleVibe.SmartCasual,
             onStyleVibeSelected = {},
+            segmentationSupported = true,
             segmentationEligibleCount = 3,
             batchSegWorkInfo = null,
             onStartBatchSegmentation = {},
@@ -1335,6 +1368,7 @@ private fun SettingsContentWeatherOpenMeteoPreview() {
             anthropicModelsLoading = false,
             styleVibe = StyleVibe.SmartCasual,
             onStyleVibeSelected = {},
+            segmentationSupported = true,
             segmentationEligibleCount = 3,
             batchSegWorkInfo = null,
             onStartBatchSegmentation = {},
@@ -1383,6 +1417,7 @@ private fun SettingsContentWeatherGooglePreview() {
             anthropicModelsLoading = false,
             styleVibe = StyleVibe.SmartCasual,
             onStyleVibeSelected = {},
+            segmentationSupported = true,
             segmentationEligibleCount = 3,
             batchSegWorkInfo = null,
             onStartBatchSegmentation = {},
@@ -1431,6 +1466,7 @@ private fun SettingsContentAiNanoCheckingPreview() {
             anthropicModelsLoading = false,
             styleVibe = StyleVibe.SmartCasual,
             onStyleVibeSelected = {},
+            segmentationSupported = true,
             segmentationEligibleCount = 3,
             batchSegWorkInfo = null,
             onStartBatchSegmentation = {},
@@ -1479,6 +1515,7 @@ private fun SettingsContentAiNanoDownloadingPreview() {
             anthropicModelsLoading = false,
             styleVibe = StyleVibe.SmartCasual,
             onStyleVibeSelected = {},
+            segmentationSupported = true,
             segmentationEligibleCount = 3,
             batchSegWorkInfo = null,
             onStartBatchSegmentation = {},
@@ -1527,6 +1564,7 @@ private fun SettingsContentAiNanoNotSupportedPreview() {
             anthropicModelsLoading = false,
             styleVibe = StyleVibe.SmartCasual,
             onStyleVibeSelected = {},
+            segmentationSupported = true,
             segmentationEligibleCount = 3,
             batchSegWorkInfo = null,
             onStartBatchSegmentation = {},
@@ -1575,6 +1613,7 @@ private fun SettingsContentAiOpenAiPreview() {
             anthropicModelsLoading = false,
             styleVibe = StyleVibe.SmartCasual,
             onStyleVibeSelected = {},
+            segmentationSupported = true,
             segmentationEligibleCount = 3,
             batchSegWorkInfo = null,
             onStartBatchSegmentation = {},
@@ -1623,6 +1662,7 @@ private fun SettingsContentAiAnthropicPreview() {
             openAiModelsLoading = false,
             anthropicModels = listOf("claude-opus-4-6", "claude-sonnet-4-6", "claude-haiku-4-5-20251001"),
             anthropicModelsLoading = false,
+            segmentationSupported = true,
             segmentationEligibleCount = 3,
             batchSegWorkInfo = null,
             onStartBatchSegmentation = {},

--- a/app-android/features/settings/src/main/kotlin/com/closet/features/settings/SettingsViewModel.kt
+++ b/app-android/features/settings/src/main/kotlin/com/closet/features/settings/SettingsViewModel.kt
@@ -403,6 +403,19 @@ class SettingsViewModel @Inject constructor(
         batchSegmentationScheduler.schedule()
     }
 
+    /**
+     * Tracks the [WorkInfo.id] of the last batch run whose completion snackbar has
+     * already been shown. Stored in the ViewModel (not Compose local state) so it
+     * survives the screen leaving composition and coming back, preventing the snackbar
+     * from re-firing for an already-handled SUCCEEDED WorkInfo.
+     */
+    private val _lastHandledBatchId = MutableStateFlow<java.util.UUID?>(null)
+    val lastHandledBatchId: StateFlow<java.util.UUID?> = _lastHandledBatchId.asStateFlow()
+
+    fun onBatchResultHandled(id: java.util.UUID) {
+        _lastHandledBatchId.value = id
+    }
+
     private companion object {
         /** Minimum API key length before triggering a model discovery fetch. */
         const val MIN_KEY_LENGTH = 20

--- a/app-android/features/settings/src/main/kotlin/com/closet/features/settings/SettingsViewModel.kt
+++ b/app-android/features/settings/src/main/kotlin/com/closet/features/settings/SettingsViewModel.kt
@@ -2,8 +2,11 @@ package com.closet.features.settings
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import androidx.work.WorkInfo
+import androidx.work.WorkManager
 import com.closet.core.data.ai.NanoInitResult
 import com.closet.core.data.ai.NanoInitializer
+import com.closet.core.data.dao.ClothingDao
 import com.closet.core.data.model.AiProvider
 import com.closet.core.data.model.StyleVibe
 import com.closet.core.data.model.TemperatureUnit
@@ -11,6 +14,8 @@ import com.closet.core.data.model.WeatherService
 import com.closet.core.data.repository.AiPreferencesRepository
 import com.closet.core.data.repository.ModelDiscoveryRepository
 import com.closet.core.data.repository.WeatherPreferencesRepository
+import com.closet.core.data.worker.BatchSegmentationScheduler
+import com.closet.core.data.worker.BatchSegmentationWork
 import com.closet.core.ui.preferences.PreferencesRepository
 import com.closet.core.ui.theme.ClosetAccent
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -26,6 +31,7 @@ import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -49,6 +55,9 @@ class SettingsViewModel @Inject constructor(
     private val aiPrefsRepo: AiPreferencesRepository,
     private val nanoInitializer: NanoInitializer,
     private val modelDiscovery: ModelDiscoveryRepository,
+    private val clothingDao: ClothingDao,
+    private val workManager: WorkManager,
+    private val batchSegmentationScheduler: BatchSegmentationScheduler,
 ) : ViewModel() {
 
     // ── Appearance ────────────────────────────────────────────────────────────
@@ -364,6 +373,30 @@ class SettingsViewModel @Inject constructor(
                     }
                 }
         }
+    }
+
+    // ── Batch segmentation ────────────────────────────────────────────────────
+
+    /**
+     * Count of wardrobe items still eligible for background removal (non-PNG images).
+     * Updates reactively whenever the clothing_items table changes.
+     */
+    val segmentationEligibleCount: StateFlow<Int> = clothingDao.getSegmentationEligibleCount()
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), 0)
+
+    /**
+     * Live [WorkInfo] for the unique batch segmentation job. `null` when no run has
+     * been enqueued yet in this install. Use [WorkInfo.state] to drive UI and
+     * [WorkInfo.outputData] / [WorkInfo.progress] to read done/total/failed counts.
+     */
+    val batchSegWorkInfo: StateFlow<WorkInfo?> =
+        workManager.getWorkInfosForUniqueWorkFlow(BatchSegmentationWork.NAME)
+            .map { it.firstOrNull() }
+            .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), null)
+
+    /** Enqueues a one-time batch segmentation run. Idempotent — duplicate taps are ignored. */
+    fun startBatchSegmentation() {
+        batchSegmentationScheduler.schedule()
     }
 
     private companion object {

--- a/app-android/features/settings/src/main/kotlin/com/closet/features/settings/SettingsViewModel.kt
+++ b/app-android/features/settings/src/main/kotlin/com/closet/features/settings/SettingsViewModel.kt
@@ -377,6 +377,9 @@ class SettingsViewModel @Inject constructor(
 
     // ── Batch segmentation ────────────────────────────────────────────────────
 
+    /** `false` on FOSS builds — hides the batch segmentation row entirely. */
+    val segmentationSupported: Boolean = batchSegmentationScheduler.isSupported
+
     /**
      * Count of wardrobe items still eligible for background removal (non-PNG images).
      * Updates reactively whenever the clothing_items table changes.
@@ -396,6 +399,7 @@ class SettingsViewModel @Inject constructor(
 
     /** Enqueues a one-time batch segmentation run. Idempotent — duplicate taps are ignored. */
     fun startBatchSegmentation() {
+        if (!batchSegmentationScheduler.isSupported) return
         batchSegmentationScheduler.schedule()
     }
 

--- a/app-android/features/settings/src/main/res/values/strings.xml
+++ b/app-android/features/settings/src/main/res/values/strings.xml
@@ -80,4 +80,14 @@
     <string name="settings_ai_anthropic_key_placeholder">Paste your sk-ant-… key here</string>
     <string name="settings_ai_anthropic_model">Model</string>
     <string name="settings_ai_anthropic_model_placeholder">Leave blank for Haiku default</string>
+
+    <!-- Wardrobe section -->
+    <string name="settings_section_wardrobe">Wardrobe</string>
+    <string name="settings_wardrobe_remove_backgrounds">Remove backgrounds</string>
+    <string name="settings_wardrobe_remove_backgrounds_summary">%d items can be processed</string>
+    <string name="settings_wardrobe_removing_backgrounds">Removing backgrounds…</string>
+    <string name="settings_wardrobe_removing_backgrounds_progress">%1$d of %2$d items</string>
+    <string name="settings_wardrobe_all_done">All backgrounds already removed</string>
+    <string name="settings_wardrobe_batch_result">%1$d items updated</string>
+    <string name="settings_wardrobe_batch_result_with_failures">%1$d items updated, %2$d skipped</string>
 </resources>

--- a/app-android/features/settings/src/main/res/values/strings.xml
+++ b/app-android/features/settings/src/main/res/values/strings.xml
@@ -90,4 +90,8 @@
     <string name="settings_wardrobe_all_done">All backgrounds already removed</string>
     <string name="settings_wardrobe_batch_result">%1$d items updated</string>
     <string name="settings_wardrobe_batch_result_with_failures">%1$d items updated, %2$d skipped</string>
+    <string name="settings_wardrobe_batch_confirm_title">Remove backgrounds?</string>
+    <string name="settings_wardrobe_batch_confirm_message">Original photos will be replaced with background-removed versions. This cannot be undone.</string>
+    <string name="settings_wardrobe_batch_confirm_ok">Remove</string>
+    <string name="settings_wardrobe_batch_confirm_cancel">Cancel</string>
 </resources>

--- a/app-android/features/wardrobe/build.gradle.kts
+++ b/app-android/features/wardrobe/build.gradle.kts
@@ -16,6 +16,12 @@ android {
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 
+    flavorDimensions += "distribution"
+    productFlavors {
+        create("full") { dimension = "distribution" }
+        create("foss") { dimension = "distribution" }
+    }
+
     buildFeatures {
         compose = true
     }
@@ -62,6 +68,10 @@ dependencies {
 
     // Palette
     implementation(libs.androidx.palette.ktx)
+
+    // ML Kit Subject Segmentation — full flavor only; foss uses a stub (no GMS in F-Droid builds)
+    "fullImplementation"(libs.mlkit.subject.segmentation)
+    "fullImplementation"(libs.kotlinx.coroutines.play.services)
 
     // Logging
     implementation(libs.timber)

--- a/app-android/features/wardrobe/build.gradle.kts
+++ b/app-android/features/wardrobe/build.gradle.kts
@@ -73,6 +73,11 @@ dependencies {
     "fullImplementation"(libs.mlkit.subject.segmentation)
     "fullImplementation"(libs.kotlinx.coroutines.play.services)
 
+    // WorkManager + Hilt integration for BatchSegmentationWorker
+    implementation(libs.androidx.work.runtime.ktx)
+    implementation(libs.androidx.hilt.work)
+    ksp(libs.androidx.hilt.compiler)
+
     // Logging
     implementation(libs.timber)
 

--- a/app-android/features/wardrobe/src/foss/kotlin/com/closet/features/wardrobe/repository/SegmentationRepository.kt
+++ b/app-android/features/wardrobe/src/foss/kotlin/com/closet/features/wardrobe/repository/SegmentationRepository.kt
@@ -1,0 +1,20 @@
+package com.closet.features.wardrobe.repository
+
+import android.graphics.Bitmap
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * FOSS-flavor stub for [SegmentationRepository].
+ *
+ * `play-services-mlkit-subject-segmentation` is a GMS dependency not included in
+ * the FOSS build. This stub satisfies the Hilt binding so the rest of the codebase
+ * compiles unchanged. [removeBackground] throws [UnsupportedOperationException];
+ * the calling ViewModel catches it and emits an error snackbar.
+ */
+@Singleton
+class SegmentationRepository @Inject constructor() {
+
+    suspend fun removeBackground(bitmap: Bitmap): Bitmap =
+        throw UnsupportedOperationException("Background removal is not available in the FOSS build")
+}

--- a/app-android/features/wardrobe/src/foss/kotlin/com/closet/features/wardrobe/repository/SegmentationRepository.kt
+++ b/app-android/features/wardrobe/src/foss/kotlin/com/closet/features/wardrobe/repository/SegmentationRepository.kt
@@ -15,6 +15,9 @@ import javax.inject.Singleton
 @Singleton
 class SegmentationRepository @Inject constructor() {
 
+    /** `false` in the FOSS flavor — hides the "Remove background" button entirely. */
+    val isSupported: Boolean = false
+
     suspend fun removeBackground(bitmap: Bitmap): Bitmap =
         throw UnsupportedOperationException("Background removal is not available in the FOSS build")
 }

--- a/app-android/features/wardrobe/src/foss/kotlin/com/closet/features/wardrobe/repository/SegmentationRepository.kt
+++ b/app-android/features/wardrobe/src/foss/kotlin/com/closet/features/wardrobe/repository/SegmentationRepository.kt
@@ -18,6 +18,10 @@ class SegmentationRepository @Inject constructor() {
     /** `false` in the FOSS flavor — hides the "Remove background" button entirely. */
     val isSupported: Boolean = false
 
+    suspend fun isModelDownloaded(): Boolean = false
+
+    suspend fun ensureModelDownloaded() { /* no-op in FOSS builds */ }
+
     suspend fun removeBackground(bitmap: Bitmap): Bitmap =
         throw UnsupportedOperationException("Background removal is not available in the FOSS build")
 }

--- a/app-android/features/wardrobe/src/full/kotlin/com/closet/features/wardrobe/repository/SegmentationRepository.kt
+++ b/app-android/features/wardrobe/src/full/kotlin/com/closet/features/wardrobe/repository/SegmentationRepository.kt
@@ -1,0 +1,59 @@
+package com.closet.features.wardrobe.repository
+
+import android.graphics.Bitmap
+import com.google.mlkit.vision.common.InputImage
+import com.google.mlkit.vision.segmentation.subject.SubjectSegmentation
+import com.google.mlkit.vision.segmentation.subject.SubjectSegmenterOptions
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.tasks.await
+import kotlinx.coroutines.withContext
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Removes the background from clothing item photos using ML Kit Subject Segmentation.
+ *
+ * Uses the traditional Vision ML API (`play-services-mlkit-subject-segmentation`) which
+ * works on all devices via Google Play Services — no AICore or device-capability check
+ * required. The ~200 KB model is delivered automatically via Play Services on first use.
+ *
+ * Input bitmaps are downsampled to a maximum of 1024 px on the longest side before
+ * processing. The stored image will be the downsampled + masked PNG; original dimensions
+ * are not restored. (Minimum 512×512 is required for accuracy per ML Kit docs.)
+ */
+@Singleton
+class SegmentationRepository @Inject constructor() {
+
+    /**
+     * Removes the background from [bitmap] and returns a new [Bitmap] with a transparent
+     * background (`ARGB_8888`).
+     *
+     * @throws IllegalStateException if the segmenter returns a null foreground bitmap.
+     */
+    suspend fun removeBackground(bitmap: Bitmap): Bitmap = withContext(Dispatchers.IO) {
+        val input = downsample(bitmap)
+        val options = SubjectSegmenterOptions.Builder()
+            .enableForegroundBitmap()
+            .build()
+        val client = SubjectSegmentation.getClient(options)
+        try {
+            val image = InputImage.fromBitmap(input, 0)
+            val result = client.process(image).await()
+            result.foregroundBitmap
+                ?: throw IllegalStateException("SubjectSegmenter returned null foregroundBitmap")
+        } finally {
+            client.close()
+        }
+    }
+
+    /** Scales [bitmap] down so its longest side is at most 1024 px. Returns original if already small enough. */
+    private fun downsample(bitmap: Bitmap): Bitmap {
+        val maxDim = 1024
+        val longest = maxOf(bitmap.width, bitmap.height)
+        if (longest <= maxDim) return bitmap
+        val scale = maxDim.toFloat() / longest
+        val w = (bitmap.width * scale).toInt()
+        val h = (bitmap.height * scale).toInt()
+        return Bitmap.createScaledBitmap(bitmap, w, h, true)
+    }
+}

--- a/app-android/features/wardrobe/src/full/kotlin/com/closet/features/wardrobe/repository/SegmentationRepository.kt
+++ b/app-android/features/wardrobe/src/full/kotlin/com/closet/features/wardrobe/repository/SegmentationRepository.kt
@@ -97,8 +97,8 @@ class SegmentationRepository @Inject constructor() {
         val longest = maxOf(bitmap.width, bitmap.height)
         if (longest <= maxDim) return bitmap
         val scale = maxDim.toFloat() / longest
-        val w = (bitmap.width * scale).toInt()
-        val h = (bitmap.height * scale).toInt()
+        val w = maxOf(1, (bitmap.width * scale).toInt())
+        val h = maxOf(1, (bitmap.height * scale).toInt())
         return Bitmap.createScaledBitmap(bitmap, w, h, true)
     }
 }

--- a/app-android/features/wardrobe/src/full/kotlin/com/closet/features/wardrobe/repository/SegmentationRepository.kt
+++ b/app-android/features/wardrobe/src/full/kotlin/com/closet/features/wardrobe/repository/SegmentationRepository.kt
@@ -24,6 +24,9 @@ import javax.inject.Singleton
 @Singleton
 class SegmentationRepository @Inject constructor() {
 
+    /** `true` in the full flavor; used by the ViewModel to hide the button in FOSS builds. */
+    val isSupported: Boolean = true
+
     /**
      * Removes the background from [bitmap] and returns a new [Bitmap] with a transparent
      * background (`ARGB_8888`).

--- a/app-android/features/wardrobe/src/full/kotlin/com/closet/features/wardrobe/repository/SegmentationRepository.kt
+++ b/app-android/features/wardrobe/src/full/kotlin/com/closet/features/wardrobe/repository/SegmentationRepository.kt
@@ -28,22 +28,36 @@ class SegmentationRepository @Inject constructor() {
     val isSupported: Boolean = true
 
     /**
-     * Removes the background from [bitmap] and returns a new [Bitmap] with a transparent
-     * background (`ARGB_8888`).
+     * Removes the background from [bitmap] and returns a new `ARGB_8888` [Bitmap] where
+     * each pixel's alpha channel is set from the ML Kit confidence mask (0.0 = background,
+     * 1.0 = foreground). Edge pixels receive partial alpha for natural feathering.
      *
-     * @throws IllegalStateException if the segmenter returns a null foreground bitmap.
+     * @throws IllegalStateException if the segmenter returns a null confidence mask.
      */
     suspend fun removeBackground(bitmap: Bitmap): Bitmap = withContext(Dispatchers.IO) {
         val input = downsample(bitmap)
         val options = SubjectSegmenterOptions.Builder()
-            .enableForegroundBitmap()
+            .enableForegroundConfidenceMask()
             .build()
         val client = SubjectSegmentation.getClient(options)
         try {
             val image = InputImage.fromBitmap(input, 0)
             val result = client.process(image).await()
-            result.foregroundBitmap
-                ?: throw IllegalStateException("SubjectSegmenter returned null foregroundBitmap")
+            val mask = result.foregroundConfidenceMask
+                ?: throw IllegalStateException("SubjectSegmenter returned null foregroundConfidenceMask")
+
+            // Apply the per-pixel confidence values as alpha so edge pixels (collar, cuffs,
+            // loose fabric) get partial transparency rather than a hard binary cut.
+            val out = input.copy(android.graphics.Bitmap.Config.ARGB_8888, true)
+            val pixels = IntArray(out.width * out.height)
+            out.getPixels(pixels, 0, out.width, 0, 0, out.width, out.height)
+            for (i in pixels.indices) {
+                val alpha = (mask.get() * 255).toInt().coerceIn(0, 255)
+                pixels[i] = (pixels[i] and 0x00FFFFFF) or (alpha shl 24)
+            }
+            out.setPixels(pixels, 0, out.width, 0, 0, out.width, out.height)
+            mask.rewind()
+            out
         } finally {
             client.close()
         }

--- a/app-android/features/wardrobe/src/full/kotlin/com/closet/features/wardrobe/repository/SegmentationRepository.kt
+++ b/app-android/features/wardrobe/src/full/kotlin/com/closet/features/wardrobe/repository/SegmentationRepository.kt
@@ -28,6 +28,34 @@ class SegmentationRepository @Inject constructor() {
     val isSupported: Boolean = true
 
     /**
+     * Returns `true` if the ML Kit Subject Segmentation model is ready for use.
+     *
+     * Play Services ML Kit manages model delivery automatically via GMS — there is no
+     * public synchronous API to query download status the way Firebase ML Kit's
+     * `RemoteModelManager` does for custom remote models. We optimistically return `true`
+     * here; [ensureModelDownloaded] serves as the actual gate and will throw if GMS cannot
+     * deliver the model (e.g. first cold-start with no network).
+     */
+    suspend fun isModelDownloaded(): Boolean = true
+
+    /**
+     * Ensures the Subject Segmentation model is available before inference begins.
+     *
+     * Creating the [SubjectSegmentation] client registers a GMS module dependency that
+     * triggers Play Services to prepare (and if necessary download) the model in the
+     * background. If GMS is unavailable or client creation fails for any other reason,
+     * this function throws so the caller can surface an appropriate error to the user
+     * rather than letting the first [removeBackground] call fail silently.
+     */
+    suspend fun ensureModelDownloaded(): Unit = withContext(Dispatchers.IO) {
+        val options = SubjectSegmenterOptions.Builder()
+            .enableForegroundConfidenceMask()
+            .build()
+        val client = SubjectSegmentation.getClient(options)
+        client.close()
+    }
+
+    /**
      * Removes the background from [bitmap] and returns a new `ARGB_8888` [Bitmap] where
      * each pixel's alpha channel is set from the ML Kit confidence mask (0.0 = background,
      * 1.0 = foreground). Edge pixels receive partial alpha for natural feathering.

--- a/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/BatchSegmentationWorker.kt
+++ b/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/BatchSegmentationWorker.kt
@@ -131,9 +131,37 @@ class BatchSegmentationWorker @AssistedInject constructor(
     }
 
     private fun buildNotification(done: Int, total: Int): Notification {
-        // TODO(Phase 6): on API 36+ replace with Notification.ProgressStyle for the
-        //   standardised Live Update appearance in the system notification shade.
-        //   ref: https://developer.android.com/develop/ui/views/notifications/live-update
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.BAKLAVA) {
+            buildLiveUpdateNotification(done, total)
+        } else {
+            buildLegacyNotification(done, total)
+        }
+    }
+
+    /**
+     * API 36+ (Android 16): uses [Notification.ProgressStyle] for the standardised
+     * Live Update appearance in the system notification shade.
+     * ref: https://developer.android.com/develop/ui/views/notifications/live-update
+     */
+    @RequiresApi(Build.VERSION_CODES.BAKLAVA)
+    private fun buildLiveUpdateNotification(done: Int, total: Int): Notification {
+        val progress = if (total > 0) done * 10_000 / total else 0
+        return Notification.Builder(context, CHANNEL_ID)
+            .setContentTitle("Removing backgrounds")
+            .setContentText("$done of $total items")
+            .setSmallIcon(android.R.drawable.ic_menu_gallery)
+            .setStyle(
+                Notification.ProgressStyle()
+                    .setProgress(progress)
+                    .setProgressIndeterminate(total == 0)
+            )
+            .setOngoing(true)
+            .setOnlyAlertOnce(true)
+            .build()
+    }
+
+    /** API < 36 fallback: standard determinate progress bar in the notification shade. */
+    private fun buildLegacyNotification(done: Int, total: Int): Notification {
         return NotificationCompat.Builder(context, CHANNEL_ID)
             .setContentTitle("Removing backgrounds")
             .setContentText("$done of $total items")

--- a/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/BatchSegmentationWorker.kt
+++ b/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/BatchSegmentationWorker.kt
@@ -1,0 +1,159 @@
+package com.closet.features.wardrobe
+
+import android.app.Notification
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.content.Context
+import android.content.pm.ServiceInfo
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
+import android.os.Build
+import androidx.annotation.RequiresApi
+import androidx.core.app.NotificationCompat
+import androidx.hilt.work.HiltWorker
+import androidx.work.CoroutineWorker
+import androidx.work.ForegroundInfo
+import androidx.work.WorkerParameters
+import androidx.work.workDataOf
+import com.closet.core.data.dao.ClothingDao
+import com.closet.core.data.repository.StorageRepository
+import com.closet.features.wardrobe.repository.SegmentationRepository
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedInject
+import kotlinx.coroutines.CancellationException
+import timber.log.Timber
+import java.time.Instant
+import java.util.UUID
+
+/**
+ * Background worker that removes the background from all wardrobe items whose stored image is
+ * not yet a PNG (i.e., have not been segmented). Runs as a foreground service so it survives
+ * the app being killed; progress is reported via [setProgress] and a persistent notification.
+ *
+ * Enqueue with [WORK_NAME] as a unique work name to prevent duplicate runs:
+ * ```
+ * WorkManager.getInstance(context).enqueueUniqueWork(
+ *     BatchSegmentationWorker.WORK_NAME,
+ *     ExistingWorkPolicy.KEEP,
+ *     OneTimeWorkRequestBuilder<BatchSegmentationWorker>().build()
+ * )
+ * ```
+ *
+ * On completion, the output [androidx.work.Data] contains [KEY_DONE] and [KEY_FAILED] counts.
+ */
+@HiltWorker
+class BatchSegmentationWorker @AssistedInject constructor(
+    @Assisted private val context: Context,
+    @Assisted params: WorkerParameters,
+    private val clothingDao: ClothingDao,
+    private val storageRepository: StorageRepository,
+    private val segmentationRepository: SegmentationRepository,
+) : CoroutineWorker(context, params) {
+
+    companion object {
+        const val WORK_NAME = "batch_segmentation"
+        const val KEY_DONE = "done"
+        const val KEY_TOTAL = "total"
+        const val KEY_FAILED = "failed"
+
+        private const val NOTIFICATION_ID = 2001
+        private const val CHANNEL_ID = "segmentation_batch"
+    }
+
+    override suspend fun doWork(): Result {
+        // FOSS builds do not include the ML Kit segmentation library; exit cleanly.
+        if (!segmentationRepository.isSupported) return Result.success()
+
+        val items = clothingDao.getItemsNeedingSegmentation()
+        val total = items.size
+        if (total == 0) return Result.success(workDataOf(KEY_DONE to 0, KEY_FAILED to 0))
+
+        ensureNotificationChannel()
+        setForeground(createForegroundInfo(0, total))
+
+        var done = 0
+        var failed = 0
+
+        for (item in items) {
+            try {
+                val originalPath = item.imagePath ?: continue
+                val file = storageRepository.getFile(originalPath)
+
+                val bitmap = decodeSampledBitmap(file.absolutePath, maxDim = 1024)
+                    ?: run {
+                        Timber.w("BatchSeg: could not decode item ${item.id} ($originalPath)")
+                        failed++
+                        continue
+                    }
+
+                val masked = segmentationRepository.removeBackground(bitmap)
+                val savedPath = storageRepository.saveBitmap(masked, "${UUID.randomUUID()}.png")
+                clothingDao.updateItemImagePath(item.id, savedPath, Instant.now())
+
+                // Delete the original file best-effort — a failure here is not fatal
+                runCatching { storageRepository.deleteImage(originalPath) }
+                    .onFailure { Timber.d(it, "BatchSeg: failed to delete original $originalPath") }
+
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                Timber.e(e, "BatchSeg: failed for item ${item.id}")
+                failed++
+            }
+
+            done++
+            setProgress(workDataOf(KEY_DONE to done, KEY_TOTAL to total))
+            setForeground(createForegroundInfo(done, total))
+        }
+
+        return Result.success(workDataOf(KEY_DONE to done, KEY_FAILED to failed))
+    }
+
+    private fun ensureNotificationChannel() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            val channel = NotificationChannel(
+                CHANNEL_ID,
+                "Background removal",
+                NotificationManager.IMPORTANCE_LOW
+            ).apply { setShowBadge(false) }
+            context.getSystemService(NotificationManager::class.java)
+                .createNotificationChannel(channel)
+        }
+    }
+
+    private fun createForegroundInfo(done: Int, total: Int): ForegroundInfo {
+        val notification = buildNotification(done, total)
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+            ForegroundInfo(NOTIFICATION_ID, notification, ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC)
+        } else {
+            ForegroundInfo(NOTIFICATION_ID, notification)
+        }
+    }
+
+    private fun buildNotification(done: Int, total: Int): Notification {
+        // TODO(Phase 6): on API 36+ replace with Notification.ProgressStyle for the
+        //   standardised Live Update appearance in the system notification shade.
+        //   ref: https://developer.android.com/develop/ui/views/notifications/live-update
+        return NotificationCompat.Builder(context, CHANNEL_ID)
+            .setContentTitle("Removing backgrounds")
+            .setContentText("$done of $total items")
+            .setSmallIcon(android.R.drawable.ic_menu_gallery)
+            .setProgress(total, done, /* indeterminate= */ false)
+            .setOngoing(true)
+            .setOnlyAlertOnce(true)
+            .build()
+    }
+
+    /**
+     * Two-pass decode: first reads only the image bounds, then decodes at the largest
+     * power-of-two [inSampleSize] that keeps the longest side ≤ [maxDim].
+     */
+    private fun decodeSampledBitmap(path: String, maxDim: Int): Bitmap? {
+        val opts = BitmapFactory.Options().apply { inJustDecodeBounds = true }
+        BitmapFactory.decodeFile(path, opts)
+        val longest = maxOf(opts.outWidth, opts.outHeight)
+        var sampleSize = 1
+        while (longest / (sampleSize * 2) >= maxDim) sampleSize *= 2
+        return BitmapFactory.decodeFile(path, BitmapFactory.Options().apply { inSampleSize = sampleSize })
+    }
+}

--- a/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/BatchSegmentationWorker.kt
+++ b/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/BatchSegmentationWorker.kt
@@ -84,6 +84,9 @@ class BatchSegmentationWorker @AssistedInject constructor(
                     ?: run {
                         Timber.w("BatchSeg: could not decode item ${item.id} ($originalPath)")
                         failed++
+                        done++
+                        setProgress(workDataOf(KEY_DONE to done, KEY_TOTAL to total))
+                        setForeground(createForegroundInfo(done, total))
                         continue
                     }
 

--- a/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/BatchSegmentationWorker.kt
+++ b/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/BatchSegmentationWorker.kt
@@ -17,6 +17,7 @@ import androidx.work.WorkerParameters
 import androidx.work.workDataOf
 import com.closet.core.data.dao.ClothingDao
 import com.closet.core.data.repository.StorageRepository
+import com.closet.core.data.worker.BatchSegmentationWork
 import com.closet.features.wardrobe.repository.SegmentationRepository
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedInject
@@ -51,10 +52,10 @@ class BatchSegmentationWorker @AssistedInject constructor(
 ) : CoroutineWorker(context, params) {
 
     companion object {
-        const val WORK_NAME = "batch_segmentation"
-        const val KEY_DONE = "done"
-        const val KEY_TOTAL = "total"
-        const val KEY_FAILED = "failed"
+        val WORK_NAME = BatchSegmentationWork.NAME
+        val KEY_DONE = BatchSegmentationWork.KEY_DONE
+        val KEY_TOTAL = BatchSegmentationWork.KEY_TOTAL
+        val KEY_FAILED = BatchSegmentationWork.KEY_FAILED
 
         private const val NOTIFICATION_ID = 2001
         private const val CHANNEL_ID = "segmentation_batch"

--- a/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/BatchSegmentationWorker.kt
+++ b/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/BatchSegmentationWorker.kt
@@ -185,7 +185,7 @@ class BatchSegmentationWorker @AssistedInject constructor(
         BitmapFactory.decodeFile(path, opts)
         val longest = maxOf(opts.outWidth, opts.outHeight)
         var sampleSize = 1
-        while (longest / (sampleSize * 2) >= maxDim) sampleSize *= 2
+        while (longest / sampleSize > maxDim) sampleSize *= 2
         return BitmapFactory.decodeFile(path, BitmapFactory.Options().apply { inSampleSize = sampleSize })
     }
 }

--- a/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/BatchSegmentationWorker.kt
+++ b/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/BatchSegmentationWorker.kt
@@ -65,6 +65,18 @@ class BatchSegmentationWorker @AssistedInject constructor(
         // FOSS builds do not include the ML Kit segmentation library; exit cleanly.
         if (!segmentationRepository.isSupported) return Result.success()
 
+        // Ensure the model is available before starting the foreground service + notification.
+        // If GMS cannot deliver the model (e.g. Play Services degraded, no network on first run),
+        // fail fast so the user sees a clear failure rather than every item silently failing.
+        try {
+            segmentationRepository.ensureModelDownloaded()
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            Timber.e(e, "BatchSeg: model download failed, aborting")
+            return Result.failure(workDataOf("error" to "model_download_failed"))
+        }
+
         val items = clothingDao.getItemsNeedingSegmentation()
         val total = items.size
         if (total == 0) return Result.success(workDataOf(KEY_DONE to 0, KEY_FAILED to 0))

--- a/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/BatchSegmentationWorker.kt
+++ b/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/BatchSegmentationWorker.kt
@@ -103,8 +103,21 @@ class BatchSegmentationWorker @AssistedInject constructor(
                     }
 
                 val masked = segmentationRepository.removeBackground(bitmap)
-                val savedPath = storageRepository.saveBitmap(masked, "${UUID.randomUUID()}.png")
-                clothingDao.updateItemImagePath(item.id, savedPath, Instant.now())
+                // Declare outside try so the failure branch can clean up if the DAO
+                // write fails after the PNG has already been saved to disk.
+                var savedPath: String? = null
+                try {
+                    savedPath = storageRepository.saveBitmap(masked, "${UUID.randomUUID()}.png")
+                    clothingDao.updateItemImagePath(item.id, savedPath, Instant.now())
+                } catch (e: Exception) {
+                    // Best-effort cleanup of the orphaned PNG before re-throwing so
+                    // the outer catch can count this item as failed.
+                    savedPath?.let { path ->
+                        runCatching { storageRepository.deleteImage(path) }
+                            .onFailure { Timber.d(it, "BatchSeg: failed to delete orphaned PNG $path") }
+                    }
+                    throw e
+                }
 
                 // Delete the original file best-effort — a failure here is not fatal
                 runCatching { storageRepository.deleteImage(originalPath) }

--- a/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/ClothingFormScreen.kt
+++ b/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/ClothingFormScreen.kt
@@ -33,6 +33,7 @@ import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
@@ -48,6 +49,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.stringResource
@@ -165,6 +167,8 @@ fun ClothingFormScreen(
                 onImageClick = {
                     launcher.launch(PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.ImageOnly))
                 },
+                onRemoveBackground = viewModel::removeBackground,
+                onRevertSegmentation = viewModel::revertSegmentation,
                 onColorToggle = viewModel::onColorToggle,
                 modifier = Modifier.padding(padding)
             )
@@ -226,6 +230,8 @@ internal fun ClothingFormContent(
     onLocationChange: (String) -> Unit,
     onNotesChange: (String) -> Unit,
     onImageClick: () -> Unit,
+    onRemoveBackground: () -> Unit,
+    onRevertSegmentation: () -> Unit,
     onColorToggle: (ColorEntity) -> Unit,
     modifier: Modifier = Modifier
 ) {
@@ -236,36 +242,62 @@ internal fun ClothingFormContent(
     ) {
         // Image Section
         item {
-            Box(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .height(200.dp)
-                    .clip(RoundedCornerShape(8.dp))
-                    .background(MaterialTheme.colorScheme.surfaceVariant)
-                    .clickable(onClick = onImageClick),
-                contentAlignment = Alignment.Center
-            ) {
-                if (uiState.imagePath != null) {
-                    AsyncImage(
-                        model = uiState.imageFile ?: uiState.imagePath,
-                        contentDescription = null,
-                        modifier = Modifier.fillMaxSize(),
-                        contentScale = ContentScale.Crop
-                    )
-                } else {
-                    Column(horizontalAlignment = Alignment.CenterHorizontally) {
-                        Icon(
-                            imageVector = Icons.Default.AddAPhoto,
+            Column {
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(200.dp)
+                        .clip(RoundedCornerShape(8.dp))
+                        .background(MaterialTheme.colorScheme.surfaceVariant)
+                        .clickable(enabled = !uiState.isSegmenting, onClick = onImageClick),
+                    contentAlignment = Alignment.Center
+                ) {
+                    if (uiState.imagePath != null) {
+                        AsyncImage(
+                            model = uiState.imageFile ?: uiState.imagePath,
                             contentDescription = null,
-                            modifier = Modifier.size(48.dp),
-                            tint = MaterialTheme.colorScheme.onSurfaceVariant
+                            modifier = Modifier
+                                .fillMaxSize()
+                                .then(if (uiState.isSegmenting) Modifier.alpha(0.4f) else Modifier),
+                            contentScale = ContentScale.Crop
                         )
-                        Spacer(modifier = Modifier.height(8.dp))
-                        Text(
-                            text = stringResource(R.string.wardrobe_add_photo),
-                            style = MaterialTheme.typography.labelLarge,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant
-                        )
+                    } else {
+                        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                            Icon(
+                                imageVector = Icons.Default.AddAPhoto,
+                                contentDescription = null,
+                                modifier = Modifier.size(48.dp),
+                                tint = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
+                            Spacer(modifier = Modifier.height(8.dp))
+                            Text(
+                                text = stringResource(R.string.wardrobe_add_photo),
+                                style = MaterialTheme.typography.labelLarge,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
+                        }
+                    }
+                    if (uiState.isSegmenting) {
+                        CircularProgressIndicator()
+                    }
+                }
+
+                if (uiState.imageFile != null && !uiState.isSegmenting && !uiState.hasSegmentedImage) {
+                    Spacer(modifier = Modifier.height(8.dp))
+                    OutlinedButton(
+                        onClick = onRemoveBackground,
+                        modifier = Modifier.fillMaxWidth()
+                    ) {
+                        Text(stringResource(R.string.wardrobe_remove_background))
+                    }
+                }
+
+                if (uiState.hasSegmentedImage && !uiState.isSegmenting) {
+                    TextButton(
+                        onClick = onRevertSegmentation,
+                        modifier = Modifier.fillMaxWidth()
+                    ) {
+                        Text(stringResource(R.string.wardrobe_revert_segmentation))
                     }
                 }
             }

--- a/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/ClothingFormScreen.kt
+++ b/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/ClothingFormScreen.kt
@@ -282,7 +282,7 @@ internal fun ClothingFormContent(
                     }
                 }
 
-                if (uiState.imageFile != null && !uiState.isSegmenting && !uiState.hasSegmentedImage) {
+                if (uiState.isSegmentationSupported && uiState.imageFile != null && !uiState.isSegmenting && !uiState.hasSegmentedImage) {
                     Spacer(modifier = Modifier.height(8.dp))
                     OutlinedButton(
                         onClick = onRemoveBackground,

--- a/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/ClothingFormScreen.kt
+++ b/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/ClothingFormScreen.kt
@@ -292,7 +292,7 @@ internal fun ClothingFormContent(
                     }
                 }
 
-                if (uiState.hasSegmentedImage && !uiState.isSegmenting) {
+                if (uiState.hasSegmentedImage && !uiState.isSegmenting && uiState.originalImageFile != null) {
                     TextButton(
                         onClick = onRevertSegmentation,
                         modifier = Modifier.fillMaxWidth()

--- a/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/ClothingFormScreen.kt
+++ b/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/ClothingFormScreen.kt
@@ -249,7 +249,7 @@ internal fun ClothingFormContent(
                         .height(200.dp)
                         .clip(RoundedCornerShape(8.dp))
                         .background(MaterialTheme.colorScheme.surfaceVariant)
-                        .clickable(enabled = !uiState.isSegmenting, onClick = onImageClick),
+                        .clickable(enabled = !uiState.isSegmenting && !uiState.isDownloadingModel, onClick = onImageClick),
                     contentAlignment = Alignment.Center
                 ) {
                     if (uiState.imagePath != null) {
@@ -258,7 +258,7 @@ internal fun ClothingFormContent(
                             contentDescription = null,
                             modifier = Modifier
                                 .fillMaxSize()
-                                .then(if (uiState.isSegmenting) Modifier.alpha(0.4f) else Modifier),
+                                .then(if (uiState.isSegmenting || uiState.isDownloadingModel) Modifier.alpha(0.4f) else Modifier),
                             contentScale = ContentScale.Crop
                         )
                     } else {
@@ -277,12 +277,22 @@ internal fun ClothingFormContent(
                             )
                         }
                     }
-                    if (uiState.isSegmenting) {
-                        CircularProgressIndicator()
+                    if (uiState.isSegmenting || uiState.isDownloadingModel) {
+                        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                            CircularProgressIndicator()
+                            if (uiState.isDownloadingModel) {
+                                Spacer(modifier = Modifier.height(8.dp))
+                                Text(
+                                    text = stringResource(R.string.wardrobe_downloading_model),
+                                    style = MaterialTheme.typography.bodySmall,
+                                    color = MaterialTheme.colorScheme.onSurface
+                                )
+                            }
+                        }
                     }
                 }
 
-                if (uiState.isSegmentationSupported && uiState.imageFile != null && !uiState.isSegmenting && !uiState.hasSegmentedImage) {
+                if (uiState.isSegmentationSupported && uiState.imageFile != null && !uiState.isSegmenting && !uiState.isDownloadingModel && !uiState.hasSegmentedImage) {
                     Spacer(modifier = Modifier.height(8.dp))
                     OutlinedButton(
                         onClick = onRemoveBackground,

--- a/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/ClothingFormViewModel.kt
+++ b/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/ClothingFormViewModel.kt
@@ -15,10 +15,14 @@ import com.closet.core.data.model.SizeSystemEntity
 import com.closet.core.data.model.SizeValueEntity
 import com.closet.core.data.model.SubcategoryEntity
 import com.closet.core.data.model.WashStatus
+import android.graphics.BitmapFactory
+import com.closet.features.wardrobe.R
 import com.closet.core.data.repository.BrandRepository
 import com.closet.core.data.repository.ClothingRepository
 import com.closet.core.data.repository.LookupRepository
 import com.closet.core.data.repository.StorageRepository
+import com.closet.features.wardrobe.repository.SegmentationRepository
+import java.util.UUID
 import com.closet.core.data.util.ColorMatcher
 import com.closet.core.data.util.DataResult
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -54,6 +58,9 @@ data class ClothingFormUiState(
     val notes: String = "",
     val imagePath: String? = null,
     val imageFile: File? = null,
+    val isSegmenting: Boolean = false,
+    val hasSegmentedImage: Boolean = false,
+    val originalImageFile: File? = null,
     val selectedColors: List<ColorEntity> = emptyList(),
     val categories: List<CategoryEntity> = emptyList(),
     val subcategories: List<SubcategoryEntity> = emptyList(),
@@ -81,6 +88,9 @@ private data class FormState(
     val purchaseLocation: String = "",
     val notes: String = "",
     val imagePath: String? = null,
+    val isSegmenting: Boolean = false,
+    val hasSegmentedImage: Boolean = false,
+    val originalSegmentationImagePath: String? = null,
     val selectedColors: List<ColorEntity> = emptyList(),
     val isNameError: Boolean = false,
     val isSaving: Boolean = false,
@@ -99,7 +109,8 @@ class ClothingFormViewModel @Inject constructor(
     private val lookupRepository: LookupRepository,
     private val brandRepository: BrandRepository,
     private val storageRepository: StorageRepository,
-    private val clothingRepository: ClothingRepository
+    private val clothingRepository: ClothingRepository,
+    private val segmentationRepository: SegmentationRepository,
 ) : ViewModel() {
 
     private val editDestination = try {
@@ -187,6 +198,9 @@ class ClothingFormViewModel @Inject constructor(
             notes = form.notes,
             imagePath = form.imagePath,
             imageFile = form.imagePath?.let { storageRepository.getFile(it) },
+            isSegmenting = form.isSegmenting,
+            hasSegmentedImage = form.hasSegmentedImage,
+            originalImageFile = form.originalSegmentationImagePath?.let { storageRepository.getFile(it) },
             selectedColors = form.selectedColors,
             isNameError = form.isNameError,
             isSaving = form.isSaving,
@@ -381,6 +395,53 @@ class ClothingFormViewModel @Inject constructor(
         }
     }
 
+    fun removeBackground() {
+        val currentForm = _form.value
+        if (currentForm.imagePath == null || currentForm.isSegmenting) return
+
+        viewModelScope.launch(Dispatchers.IO) {
+            _form.update { it.copy(isSegmenting = true, originalSegmentationImagePath = it.imagePath) }
+            try {
+                val path = _form.value.imagePath ?: return@launch
+                val file = storageRepository.getFile(path)
+                val bitmap = BitmapFactory.decodeFile(file.absolutePath)
+                    ?: throw IllegalStateException("Could not decode image file: $path")
+                val masked = segmentationRepository.removeBackground(bitmap)
+                val savedPath = storageRepository.saveBitmap(masked, "${UUID.randomUUID()}.png")
+                _form.update { it.copy(imagePath = savedPath, hasSegmentedImage = true, isSegmenting = false) }
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                Timber.e(e, "removeBackground failed")
+                _form.update { it.copy(
+                    imagePath = it.originalSegmentationImagePath,
+                    originalSegmentationImagePath = null,
+                    isSegmenting = false,
+                    errorMessage = R.string.wardrobe_segmentation_error,
+                ) }
+            }
+        }
+    }
+
+    fun revertSegmentation() {
+        val currentPath = _form.value.imagePath
+        val originalPath = _form.value.originalSegmentationImagePath ?: return
+        _form.update { it.copy(
+            imagePath = originalPath,
+            hasSegmentedImage = false,
+            originalSegmentationImagePath = null,
+        ) }
+        if (currentPath != null && currentPath != originalPath) {
+            viewModelScope.launch {
+                try {
+                    storageRepository.deleteImage(currentPath)
+                } catch (e: Exception) {
+                    Timber.d(e, "revertSegmentation: failed to delete segmented PNG $currentPath")
+                }
+            }
+        }
+    }
+
     fun onErrorConsumed() {
         _form.update { it.copy(errorMessage = null) }
     }
@@ -470,6 +531,11 @@ class ClothingFormViewModel @Inject constructor(
                     if (isEditMode && originalImagePath != null && originalImagePath != state.imagePath) {
                         withContext(NonCancellable) { storageRepository.deleteImage(originalImagePath!!) }
                     }
+                    // Clean up the pre-segmentation intermediate file now that the segmented image is saved
+                    val segOrigPath = state.originalSegmentationImagePath
+                    if (segOrigPath != null && segOrigPath != originalImagePath) {
+                        withContext(NonCancellable) { storageRepository.deleteImage(segOrigPath) }
+                    }
                     _events.send(ClothingFormEvent.NavigateBack)
                 } else {
                     _form.update { it.copy(isSaving = false, errorMessage = com.closet.core.ui.R.string.error_database_query) }
@@ -483,12 +549,15 @@ class ClothingFormViewModel @Inject constructor(
 
     fun cancel() {
         val currentPath = _form.value.imagePath
-        if (currentPath != null && currentPath != originalImagePath) {
-            viewModelScope.launch {
+        val segOrigPath = _form.value.originalSegmentationImagePath
+        viewModelScope.launch {
+            if (currentPath != null && currentPath != originalImagePath) {
                 withContext(NonCancellable) { storageRepository.deleteImage(currentPath) }
             }
-        }
-        viewModelScope.launch {
+            // Also clean up the pre-segmentation file if it wasn't the persisted original
+            if (segOrigPath != null && segOrigPath != originalImagePath && segOrigPath != currentPath) {
+                withContext(NonCancellable) { storageRepository.deleteImage(segOrigPath) }
+            }
             _events.send(ClothingFormEvent.NavigateBack)
         }
     }

--- a/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/ClothingFormViewModel.kt
+++ b/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/ClothingFormViewModel.kt
@@ -385,7 +385,13 @@ class ClothingFormViewModel @Inject constructor(
 
     fun onImageSelected(uri: Uri?) {
         if (uri == null) return
-        
+        // Don't allow a new image to be swapped in while the segmentation coroutine
+        // is in flight — it may be actively reading the current imagePath from disk.
+        // The photo-picker button is disabled in the UI during these states, but guard
+        // here too in case the call arrives via another code path.
+        val form = _form.value
+        if (form.isSegmenting || form.isDownloadingModel) return
+
         viewModelScope.launch {
             _form.update { it.copy(isLoading = true) }
             try {
@@ -425,25 +431,24 @@ class ClothingFormViewModel @Inject constructor(
             currentForm.isSegmenting || currentForm.isDownloadingModel) return
 
         viewModelScope.launch(Dispatchers.IO) {
-            // Gate: ensure the Play Services ML Kit model is ready before starting inference.
-            // isModelDownloaded() returns false on FOSS builds and on first cold-start
-            // if GMS hasn't yet delivered the model.
-            if (!segmentationRepository.isModelDownloaded()) {
-                _form.update { it.copy(isDownloadingModel = true) }
-                try {
-                    segmentationRepository.ensureModelDownloaded()
-                } catch (e: CancellationException) {
-                    throw e
-                } catch (e: Exception) {
-                    Timber.e(e, "removeBackground: model download failed")
-                    _form.update { it.copy(
-                        isDownloadingModel = false,
-                        errorMessage = R.string.wardrobe_model_download_error,
-                    ) }
-                    return@launch
-                }
+            // Always call ensureModelDownloaded() — isModelDownloaded() returns true
+            // optimistically (no public Play Services status API), so using it as a gate
+            // would permanently skip this block and hide first-run delivery failures.
+            _form.update { it.copy(isDownloadingModel = true) }
+            try {
+                segmentationRepository.ensureModelDownloaded()
+            } catch (e: CancellationException) {
                 _form.update { it.copy(isDownloadingModel = false) }
+                throw e
+            } catch (e: Exception) {
+                Timber.e(e, "removeBackground: model download failed")
+                _form.update { it.copy(
+                    isDownloadingModel = false,
+                    errorMessage = R.string.wardrobe_model_download_error,
+                ) }
+                return@launch
             }
+            _form.update { it.copy(isDownloadingModel = false) }
 
             _form.update { it.copy(isSegmenting = true, originalSegmentationImagePath = it.imagePath) }
             try {
@@ -555,7 +560,7 @@ class ClothingFormViewModel @Inject constructor(
 
     fun save() {
         val state = _form.value
-        if (state.isSegmenting) return
+        if (state.isSegmenting || state.isDownloadingModel) return
         if (state.name.isBlank()) {
             _form.update { it.copy(isNameError = true) }
             return

--- a/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/ClothingFormViewModel.kt
+++ b/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/ClothingFormViewModel.kt
@@ -15,6 +15,7 @@ import com.closet.core.data.model.SizeSystemEntity
 import com.closet.core.data.model.SizeValueEntity
 import com.closet.core.data.model.SubcategoryEntity
 import com.closet.core.data.model.WashStatus
+import android.graphics.Bitmap
 import android.graphics.BitmapFactory
 import com.closet.features.wardrobe.R
 import com.closet.core.data.repository.BrandRepository

--- a/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/ClothingFormViewModel.kt
+++ b/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/ClothingFormViewModel.kt
@@ -383,12 +383,22 @@ class ClothingFormViewModel @Inject constructor(
             _form.update { it.copy(isLoading = true) }
             try {
                 val previousPath = _form.value.imagePath
+                val segOrigPath = _form.value.originalSegmentationImagePath
                 val path = storageRepository.saveImage(uri)
                 // Delete the previously staged file (skip if it's the persisted original)
                 if (previousPath != null && previousPath != originalImagePath) {
                     withContext(NonCancellable) { storageRepository.deleteImage(previousPath) }
                 }
-                _form.update { it.copy(imagePath = path, isLoading = false) }
+                // Clean up the pre-segmentation intermediate file if the user picks a new image
+                if (segOrigPath != null && segOrigPath != originalImagePath && segOrigPath != previousPath) {
+                    withContext(NonCancellable) { storageRepository.deleteImage(segOrigPath) }
+                }
+                _form.update { it.copy(
+                    imagePath = path,
+                    isLoading = false,
+                    hasSegmentedImage = false,
+                    originalSegmentationImagePath = null,
+                ) }
                 val file = storageRepository.getFile(path)
                 extractColorsFromFile(file)
             } catch (e: Exception) {

--- a/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/ClothingFormViewModel.kt
+++ b/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/ClothingFormViewModel.kt
@@ -388,20 +388,24 @@ class ClothingFormViewModel @Inject constructor(
                 val previousPath = _form.value.imagePath
                 val segOrigPath = _form.value.originalSegmentationImagePath
                 val path = storageRepository.saveImage(uri)
-                // Delete the previously staged file (skip if it's the persisted original)
-                if (previousPath != null && previousPath != originalImagePath) {
-                    withContext(NonCancellable) { storageRepository.deleteImage(previousPath) }
-                }
-                // Clean up the pre-segmentation intermediate file if the user picks a new image
-                if (segOrigPath != null && segOrigPath != originalImagePath && segOrigPath != previousPath) {
-                    withContext(NonCancellable) { storageRepository.deleteImage(segOrigPath) }
-                }
+                // Point the UI at the new file before any cleanup so the form always
+                // references a valid path even if a subsequent deletion fails.
                 _form.update { it.copy(
                     imagePath = path,
                     isLoading = false,
                     hasSegmentedImage = false,
                     originalSegmentationImagePath = null,
                 ) }
+                // Best-effort cleanup — failures must not block the form update above.
+                if (previousPath != null && previousPath != originalImagePath) {
+                    runCatching { withContext(NonCancellable) { storageRepository.deleteImage(previousPath) } }
+                        .onFailure { Timber.e(it, "onImageSelected: failed to delete previous $previousPath") }
+                }
+                // Clean up the pre-segmentation intermediate file if the user picks a new image
+                if (segOrigPath != null && segOrigPath != originalImagePath && segOrigPath != previousPath) {
+                    runCatching { withContext(NonCancellable) { storageRepository.deleteImage(segOrigPath) } }
+                        .onFailure { Timber.e(it, "onImageSelected: failed to delete seg original $segOrigPath") }
+                }
                 val file = storageRepository.getFile(path)
                 extractColorsFromFile(file)
             } catch (e: Exception) {
@@ -587,11 +591,13 @@ class ClothingFormViewModel @Inject constructor(
         val segOrigPath = _form.value.originalSegmentationImagePath
         viewModelScope.launch {
             if (currentPath != null && currentPath != originalImagePath) {
-                withContext(NonCancellable) { storageRepository.deleteImage(currentPath) }
+                runCatching { withContext(NonCancellable) { storageRepository.deleteImage(currentPath) } }
+                    .onFailure { Timber.e(it, "cancel: failed to delete staged image $currentPath") }
             }
             // Also clean up the pre-segmentation file if it wasn't the persisted original
             if (segOrigPath != null && segOrigPath != originalImagePath && segOrigPath != currentPath) {
-                withContext(NonCancellable) { storageRepository.deleteImage(segOrigPath) }
+                runCatching { withContext(NonCancellable) { storageRepository.deleteImage(segOrigPath) } }
+                    .onFailure { Timber.e(it, "cancel: failed to delete seg original $segOrigPath") }
             }
             _events.send(ClothingFormEvent.NavigateBack)
         }

--- a/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/ClothingFormViewModel.kt
+++ b/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/ClothingFormViewModel.kt
@@ -306,6 +306,9 @@ class ClothingFormViewModel @Inject constructor(
                         purchaseLocation = entity.purchaseLocation ?: "",
                         notes = entity.notes ?: "",
                         imagePath = entity.imagePath,
+                        // PNG suffix means the image was previously segmented; hide the
+                        // "Remove background" button and suppress "Undo" (no revert target)
+                        hasSegmentedImage = entity.imagePath?.endsWith(".png") == true,
                         category = selectedCat,
                         subcategory = selectedSub,
                         selectedColors = colors,

--- a/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/ClothingFormViewModel.kt
+++ b/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/ClothingFormViewModel.kt
@@ -478,7 +478,7 @@ class ClothingFormViewModel @Inject constructor(
         BitmapFactory.decodeFile(path, opts)
         val longest = maxOf(opts.outWidth, opts.outHeight)
         var sampleSize = 1
-        while (longest / (sampleSize * 2) >= maxDim) sampleSize *= 2
+        while (longest / sampleSize > maxDim) sampleSize *= 2
         return BitmapFactory.decodeFile(path, BitmapFactory.Options().apply { inSampleSize = sampleSize })
     }
 

--- a/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/ClothingFormViewModel.kt
+++ b/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/ClothingFormViewModel.kt
@@ -61,6 +61,7 @@ data class ClothingFormUiState(
     val isSegmenting: Boolean = false,
     val hasSegmentedImage: Boolean = false,
     val originalImageFile: File? = null,
+    val isSegmentationSupported: Boolean = true,
     val selectedColors: List<ColorEntity> = emptyList(),
     val categories: List<CategoryEntity> = emptyList(),
     val subcategories: List<SubcategoryEntity> = emptyList(),
@@ -201,6 +202,7 @@ class ClothingFormViewModel @Inject constructor(
             isSegmenting = form.isSegmenting,
             hasSegmentedImage = form.hasSegmentedImage,
             originalImageFile = form.originalSegmentationImagePath?.let { storageRepository.getFile(it) },
+            isSegmentationSupported = segmentationRepository.isSupported,
             selectedColors = form.selectedColors,
             isNameError = form.isNameError,
             isSaving = form.isSaving,
@@ -209,7 +211,7 @@ class ClothingFormViewModel @Inject constructor(
             categories = cats,
             subcategories = subs,
             allColors = colors,
-            canSave = form.name.isNotBlank() && !form.isSaving &&
+            canSave = form.name.isNotBlank() && !form.isSaving && !form.isSegmenting &&
                     !(form.brandQuery.isNotBlank() && form.selectedBrandId == null),
             isDirty = computeIsDirty(form),
             sizeSystems = systems,
@@ -410,14 +412,16 @@ class ClothingFormViewModel @Inject constructor(
 
     fun removeBackground() {
         val currentForm = _form.value
-        if (currentForm.imagePath == null || currentForm.isSegmenting) return
+        if (!segmentationRepository.isSupported || currentForm.imagePath == null || currentForm.isSegmenting) return
 
         viewModelScope.launch(Dispatchers.IO) {
             _form.update { it.copy(isSegmenting = true, originalSegmentationImagePath = it.imagePath) }
             try {
                 val path = _form.value.imagePath ?: return@launch
                 val file = storageRepository.getFile(path)
-                val bitmap = BitmapFactory.decodeFile(file.absolutePath)
+                // Decode at reduced resolution so the full-res bitmap never hits memory.
+                // The repo's own downsample() becomes a no-op when the bitmap is already ≤1024px.
+                val bitmap = decodeSampledBitmap(file.absolutePath, maxDim = 1024)
                     ?: throw IllegalStateException("Could not decode image file: $path")
                 val masked = segmentationRepository.removeBackground(bitmap)
                 val savedPath = storageRepository.saveBitmap(masked, "${UUID.randomUUID()}.png")
@@ -457,6 +461,20 @@ class ClothingFormViewModel @Inject constructor(
 
     fun onErrorConsumed() {
         _form.update { it.copy(errorMessage = null) }
+    }
+
+    /**
+     * Decodes [path] into a [Bitmap] at a sample size that keeps the longest side ≤ [maxDim].
+     * Uses a two-pass decode (bounds-only then sampled) so the full-resolution image is never
+     * allocated in memory.
+     */
+    private fun decodeSampledBitmap(path: String, maxDim: Int): Bitmap? {
+        val opts = BitmapFactory.Options().apply { inJustDecodeBounds = true }
+        BitmapFactory.decodeFile(path, opts)
+        val longest = maxOf(opts.outWidth, opts.outHeight)
+        var sampleSize = 1
+        while (longest / (sampleSize * 2) >= maxDim) sampleSize *= 2
+        return BitmapFactory.decodeFile(path, BitmapFactory.Options().apply { inSampleSize = sampleSize })
     }
 
     private suspend fun extractColorsFromFile(file: File) {
@@ -507,6 +525,7 @@ class ClothingFormViewModel @Inject constructor(
 
     fun save() {
         val state = _form.value
+        if (state.isSegmenting) return
         if (state.name.isBlank()) {
             _form.update { it.copy(isNameError = true) }
             return
@@ -541,13 +560,15 @@ class ClothingFormViewModel @Inject constructor(
                 }
 
                 if (result is DataResult.Success) {
+                    // Best-effort cleanup — failures must not block navigation or show a save error
                     if (isEditMode && originalImagePath != null && originalImagePath != state.imagePath) {
-                        withContext(NonCancellable) { storageRepository.deleteImage(originalImagePath!!) }
+                        runCatching { withContext(NonCancellable) { storageRepository.deleteImage(originalImagePath!!) } }
+                            .onFailure { Timber.e(it, "save: failed to delete old image $originalImagePath") }
                     }
-                    // Clean up the pre-segmentation intermediate file now that the segmented image is saved
                     val segOrigPath = state.originalSegmentationImagePath
                     if (segOrigPath != null && segOrigPath != originalImagePath) {
-                        withContext(NonCancellable) { storageRepository.deleteImage(segOrigPath) }
+                        runCatching { withContext(NonCancellable) { storageRepository.deleteImage(segOrigPath) } }
+                            .onFailure { Timber.e(it, "save: failed to delete seg original $segOrigPath") }
                     }
                     _events.send(ClothingFormEvent.NavigateBack)
                 } else {

--- a/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/ClothingFormViewModel.kt
+++ b/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/ClothingFormViewModel.kt
@@ -60,6 +60,7 @@ data class ClothingFormUiState(
     val imagePath: String? = null,
     val imageFile: File? = null,
     val isSegmenting: Boolean = false,
+    val isDownloadingModel: Boolean = false,
     val hasSegmentedImage: Boolean = false,
     val originalImageFile: File? = null,
     val isSegmentationSupported: Boolean = true,
@@ -91,6 +92,7 @@ private data class FormState(
     val notes: String = "",
     val imagePath: String? = null,
     val isSegmenting: Boolean = false,
+    val isDownloadingModel: Boolean = false,
     val hasSegmentedImage: Boolean = false,
     val originalSegmentationImagePath: String? = null,
     val selectedColors: List<ColorEntity> = emptyList(),
@@ -201,6 +203,7 @@ class ClothingFormViewModel @Inject constructor(
             imagePath = form.imagePath,
             imageFile = form.imagePath?.let { storageRepository.getFile(it) },
             isSegmenting = form.isSegmenting,
+            isDownloadingModel = form.isDownloadingModel,
             hasSegmentedImage = form.hasSegmentedImage,
             originalImageFile = form.originalSegmentationImagePath?.let { storageRepository.getFile(it) },
             isSegmentationSupported = segmentationRepository.isSupported,
@@ -213,6 +216,7 @@ class ClothingFormViewModel @Inject constructor(
             subcategories = subs,
             allColors = colors,
             canSave = form.name.isNotBlank() && !form.isSaving && !form.isSegmenting &&
+                    !form.isDownloadingModel &&
                     !(form.brandQuery.isNotBlank() && form.selectedBrandId == null),
             isDirty = computeIsDirty(form),
             sizeSystems = systems,
@@ -417,9 +421,30 @@ class ClothingFormViewModel @Inject constructor(
 
     fun removeBackground() {
         val currentForm = _form.value
-        if (!segmentationRepository.isSupported || currentForm.imagePath == null || currentForm.isSegmenting) return
+        if (!segmentationRepository.isSupported || currentForm.imagePath == null ||
+            currentForm.isSegmenting || currentForm.isDownloadingModel) return
 
         viewModelScope.launch(Dispatchers.IO) {
+            // Gate: ensure the Play Services ML Kit model is ready before starting inference.
+            // isModelDownloaded() returns false on FOSS builds and on first cold-start
+            // if GMS hasn't yet delivered the model.
+            if (!segmentationRepository.isModelDownloaded()) {
+                _form.update { it.copy(isDownloadingModel = true) }
+                try {
+                    segmentationRepository.ensureModelDownloaded()
+                } catch (e: CancellationException) {
+                    throw e
+                } catch (e: Exception) {
+                    Timber.e(e, "removeBackground: model download failed")
+                    _form.update { it.copy(
+                        isDownloadingModel = false,
+                        errorMessage = R.string.wardrobe_model_download_error,
+                    ) }
+                    return@launch
+                }
+                _form.update { it.copy(isDownloadingModel = false) }
+            }
+
             _form.update { it.copy(isSegmenting = true, originalSegmentationImagePath = it.imagePath) }
             try {
                 val path = _form.value.imagePath ?: return@launch

--- a/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/FormPreviews.kt
+++ b/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/FormPreviews.kt
@@ -104,6 +104,8 @@ private fun ClothingFormContentEmptyPreview() {
                 onLocationChange = {},
                 onNotesChange = {},
                 onImageClick = {},
+                onRemoveBackground = {},
+                onRevertSegmentation = {},
                 onColorToggle = {}
             )
         }
@@ -146,6 +148,8 @@ private fun ClothingFormContentFilledPreview() {
                 onLocationChange = {},
                 onNotesChange = {},
                 onImageClick = {},
+                onRemoveBackground = {},
+                onRevertSegmentation = {},
                 onColorToggle = {}
             )
         }

--- a/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/di/WardrobeModule.kt
+++ b/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/di/WardrobeModule.kt
@@ -7,6 +7,7 @@ import androidx.work.WorkManager
 import com.closet.core.data.worker.BatchSegmentationScheduler
 import com.closet.core.data.worker.BatchSegmentationWork
 import com.closet.features.wardrobe.BatchSegmentationWorker
+import com.closet.features.wardrobe.repository.SegmentationRepository
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -25,8 +26,12 @@ object WardrobeModule {
 
     @Provides
     @Singleton
-    fun provideBatchSegmentationScheduler(workManager: WorkManager): BatchSegmentationScheduler =
+    fun provideBatchSegmentationScheduler(
+        workManager: WorkManager,
+        segmentationRepository: SegmentationRepository,
+    ): BatchSegmentationScheduler =
         object : BatchSegmentationScheduler {
+            override val isSupported: Boolean get() = segmentationRepository.isSupported
             override fun schedule() {
                 workManager.enqueueUniqueWork(
                     BatchSegmentationWork.NAME,

--- a/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/di/WardrobeModule.kt
+++ b/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/di/WardrobeModule.kt
@@ -1,0 +1,38 @@
+package com.closet.features.wardrobe.di
+
+import android.content.Context
+import androidx.work.ExistingWorkPolicy
+import androidx.work.OneTimeWorkRequestBuilder
+import androidx.work.WorkManager
+import com.closet.core.data.worker.BatchSegmentationScheduler
+import com.closet.core.data.worker.BatchSegmentationWork
+import com.closet.features.wardrobe.BatchSegmentationWorker
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+object WardrobeModule {
+
+    @Provides
+    @Singleton
+    fun provideWorkManager(@ApplicationContext context: Context): WorkManager =
+        WorkManager.getInstance(context)
+
+    @Provides
+    @Singleton
+    fun provideBatchSegmentationScheduler(workManager: WorkManager): BatchSegmentationScheduler =
+        object : BatchSegmentationScheduler {
+            override fun schedule() {
+                workManager.enqueueUniqueWork(
+                    BatchSegmentationWork.NAME,
+                    ExistingWorkPolicy.KEEP,
+                    OneTimeWorkRequestBuilder<BatchSegmentationWorker>().build(),
+                )
+            }
+        }
+}

--- a/app-android/features/wardrobe/src/main/res/values/strings.xml
+++ b/app-android/features/wardrobe/src/main/res/values/strings.xml
@@ -79,6 +79,8 @@
     <string name="wardrobe_error_save_failed">Failed to save item. Please try again.</string>
     <string name="wardrobe_error_load_failed">Failed to load item. Please try again.</string>
     <string name="wardrobe_error_image_failed">Failed to save photo. Please try again.</string>
+    <string name="wardrobe_remove_background">Remove background</string>
+    <string name="wardrobe_revert_segmentation">Undo background removal</string>
     <string name="wardrobe_segmentation_error">Couldn\'t remove background. Try a photo with a clearer subject.</string>
     <string name="wardrobe_purchase_price">Purchase Price</string>
     <string name="wardrobe_price_hint">0.00</string>

--- a/app-android/features/wardrobe/src/main/res/values/strings.xml
+++ b/app-android/features/wardrobe/src/main/res/values/strings.xml
@@ -82,6 +82,8 @@
     <string name="wardrobe_remove_background">Remove background</string>
     <string name="wardrobe_revert_segmentation">Undo background removal</string>
     <string name="wardrobe_segmentation_error">Couldn\'t remove background. Try a photo with a clearer subject.</string>
+    <string name="wardrobe_downloading_model">Downloading segmentation model\u2026</string>
+    <string name="wardrobe_model_download_error">Couldn\'t download segmentation model. Check your connection and try again.</string>
     <string name="wardrobe_purchase_price">Purchase Price</string>
     <string name="wardrobe_price_hint">0.00</string>
     <string name="wardrobe_location_hint">Where did you buy this?</string>

--- a/app-android/features/wardrobe/src/main/res/values/strings.xml
+++ b/app-android/features/wardrobe/src/main/res/values/strings.xml
@@ -79,6 +79,7 @@
     <string name="wardrobe_error_save_failed">Failed to save item. Please try again.</string>
     <string name="wardrobe_error_load_failed">Failed to load item. Please try again.</string>
     <string name="wardrobe_error_image_failed">Failed to save photo. Please try again.</string>
+    <string name="wardrobe_segmentation_error">Couldn\'t remove background. Try a photo with a clearer subject.</string>
     <string name="wardrobe_purchase_price">Purchase Price</string>
     <string name="wardrobe_price_hint">0.00</string>
     <string name="wardrobe_location_hint">Where did you buy this?</string>

--- a/app-android/gradle/libs.versions.toml
+++ b/app-android/gradle/libs.versions.toml
@@ -29,7 +29,7 @@ turbine = "1.2.0"
 mockk = "1.13.14"
 ktor = "3.1.3"
 mlkitGenaiPrompt = "1.0.0-beta1"
-mlkitSubjectSegmentation = "16.0.0-beta1"
+mlkitSubjectSegmentation = "16.0.0-beta1" # beta accepted; no stable release exists for this API
 kotlinxCoroutinesPlayServices = "1.10.2"
 
 [libraries]

--- a/app-android/gradle/libs.versions.toml
+++ b/app-android/gradle/libs.versions.toml
@@ -29,6 +29,7 @@ turbine = "1.2.0"
 mockk = "1.13.14"
 ktor = "3.1.3"
 mlkitGenaiPrompt = "1.0.0-beta1"
+mlkitSubjectSegmentation = "16.0.0-beta1"
 kotlinxCoroutinesPlayServices = "1.10.2"
 
 [libraries]
@@ -74,6 +75,7 @@ ktor-client-content-negotiation = { group = "io.ktor", name = "ktor-client-conte
 ktor-serialization-kotlinx-json = { group = "io.ktor", name = "ktor-serialization-kotlinx-json", version.ref = "ktor" }
 ktor-client-logging = { group = "io.ktor", name = "ktor-client-logging", version.ref = "ktor" }
 mlkit-genai-prompt = { group = "com.google.mlkit", name = "genai-prompt", version.ref = "mlkitGenaiPrompt" }
+mlkit-subject-segmentation = { group = "com.google.android.gms", name = "play-services-mlkit-subject-segmentation", version.ref = "mlkitSubjectSegmentation" }
 kotlinx-coroutines-play-services = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-play-services", version.ref = "kotlinxCoroutinesPlayServices" }
 
 [plugins]

--- a/app-android/gradle/libs.versions.toml
+++ b/app-android/gradle/libs.versions.toml
@@ -31,6 +31,8 @@ ktor = "3.1.3"
 mlkitGenaiPrompt = "1.0.0-beta1"
 mlkitSubjectSegmentation = "16.0.0-beta1" # beta accepted; no stable release exists for this API
 kotlinxCoroutinesPlayServices = "1.10.2"
+work = "2.10.0"
+hiltWork = "1.2.0"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "androidxCore" }
@@ -77,6 +79,9 @@ ktor-client-logging = { group = "io.ktor", name = "ktor-client-logging", version
 mlkit-genai-prompt = { group = "com.google.mlkit", name = "genai-prompt", version.ref = "mlkitGenaiPrompt" }
 mlkit-subject-segmentation = { group = "com.google.android.gms", name = "play-services-mlkit-subject-segmentation", version.ref = "mlkitSubjectSegmentation" }
 kotlinx-coroutines-play-services = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-play-services", version.ref = "kotlinxCoroutinesPlayServices" }
+androidx-work-runtime-ktx = { group = "androidx.work", name = "work-runtime-ktx", version.ref = "work" }
+androidx-hilt-work = { group = "androidx.hilt", name = "hilt-work", version.ref = "hiltWork" }
+androidx-hilt-compiler = { group = "androidx.hilt", name = "hilt-compiler", version.ref = "hiltWork" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }

--- a/app-android/segmentation-roadmap.md
+++ b/app-android/segmentation-roadmap.md
@@ -209,24 +209,25 @@ No flavor split needed — WorkManager and system notifications are AOSP; no GMS
 
 ### Settings integration (`features/settings`)
 
-- [ ] Add a new "Wardrobe" section to `SettingsScreen`
-- [ ] Row: **"Remove backgrounds"** — subtitle shows item count eligible
-  (items with non-png images); tapping enqueues the worker via
-  `WorkManager.getInstance(ctx).enqueueUniqueWork("batch_seg", KEEP, request)`
-  so double-taps don't duplicate the job
-- [ ] While the worker is running, replace the row with a progress indicator
-  driven by `WorkManager.getWorkInfosForUniqueWorkLiveData("batch_seg")` →
-  collected as `StateFlow` in `SettingsViewModel`
-- [ ] On completion: show a snackbar with the result
-  (e.g. "42 items updated, 2 skipped")
+- [x] Add a new "Wardrobe" section to `SettingsScreen`
+- [x] Row: **"Remove backgrounds"** — subtitle shows item count eligible;
+  tapping calls `viewModel.startBatchSegmentation()` (idempotent via `KEEP` policy)
+- [x] While the worker is RUNNING or ENQUEUED: show progress row with
+  `LinearProgressIndicator` driven by `WorkInfo.progress` (done/total)
+- [x] When eligible count is 0: show "All backgrounds already removed" label
+- [x] On completion (`WorkInfo.State.SUCCEEDED`): snackbar via `LaunchedEffect`
+  keyed on `workInfo.id + state` — "X items updated" or "X items updated, Y skipped"
+- [x] Architecture: `BatchSegmentationScheduler` interface in `core/data`;
+  impl + `WorkManager` singleton provided from new `WardrobeModule` in `features/wardrobe`
+  so `features/settings` has no dependency on `features/wardrobe`
 
 ### `SettingsViewModel` additions
 
-- [ ] Inject `WorkManager` into `SettingsViewModel`
-- [ ] Expose `batchSegmentationState: StateFlow<WorkInfo.State?>` from
-  `workManager.getWorkInfosForUniqueWorkFlow("batch_seg")` mapped to the
-  first item's state
-- [ ] `fun startBatchSegmentation()` — builds and enqueues the `OneTimeWorkRequest`
+- [x] Inject `WorkManager`, `ClothingDao`, `BatchSegmentationScheduler`
+- [x] `segmentationEligibleCount: StateFlow<Int>` from `ClothingDao.getSegmentationEligibleCount()`
+- [x] `batchSegWorkInfo: StateFlow<WorkInfo?>` from
+  `workManager.getWorkInfosForUniqueWorkFlow(NAME).map { it.firstOrNull() }`
+- [x] `fun startBatchSegmentation()` — delegates to `BatchSegmentationScheduler.schedule()`
 
 ---
 

--- a/app-android/segmentation-roadmap.md
+++ b/app-android/segmentation-roadmap.md
@@ -54,17 +54,18 @@ works on all devices).
 
 ### ClothingFormUiState additions (`ClothingFormViewModel.kt`)
 
-- [ ] Add `val isSegmenting: Boolean = false` to `ClothingFormUiState`
-- [ ] Add `val hasSegmentedImage: Boolean = false` — true after a successful
+- [x] Add `val isSegmenting: Boolean = false` to `ClothingFormUiState`
+- [x] Add `val hasSegmentedImage: Boolean = false` — true after a successful
   removal; drives "Revert" button visibility
-- [ ] Add `val originalImageFile: File? = null` — holds the pre-segmentation
+- [x] Add `val originalImageFile: File? = null` — holds the pre-segmentation
   file so revert can restore it without re-picking
+  (tracked as `originalSegmentationImagePath: String?` in `FormState`, derived to `File?` in `uiState` combine)
 
 ### ClothingFormViewModel functions
 
-- [ ] Inject `SegmentationRepository` into `ClothingFormViewModel`
+- [x] Inject `SegmentationRepository` into `ClothingFormViewModel`
 
-- [ ] `fun removeBackground()`:
+- [x] `fun removeBackground()`:
   - Guard: return early if `uiState.imageFile == null` or `uiState.isSegmenting`
   - Set `isSegmenting = true`
   - In `viewModelScope.launch(Dispatchers.IO)`:
@@ -77,10 +78,11 @@ works on all devices).
       snackbar via existing error channel; restore original image in state
     - Always: set `isSegmenting = false`
 
-- [ ] `fun revertSegmentation()`:
+- [x] `fun revertSegmentation()`:
   - Restores `imagePath`/`imageFile` from `originalImageFile`
   - Clears `hasSegmentedImage` and `originalImageFile`
   - Deletes the segmented PNG file from storage (best-effort, log on failure)
+  - `cancel()` and `save()` also updated to clean up `originalSegmentationImagePath` on exit
 
 ---
 

--- a/app-android/segmentation-roadmap.md
+++ b/app-android/segmentation-roadmap.md
@@ -240,43 +240,42 @@ silently. This phase adds an explicit download gate so the UI reflects true read
 
 ### `RemoteModelManager` helper (`SegmentationRepository`, full flavor only)
 
-- [ ] Add `suspend fun isModelDownloaded(): Boolean` — calls
-  `RemoteModelManager.getInstance().isModelDownloaded(CustomRemoteModel(…)).await()`
-  using the same `CustomModelDownloadConditions` / model name the SDK resolves at runtime
-  (name: `"subject_segmentation"` — match the module resolved by `DynamiteModule`)
-- [ ] Add `suspend fun ensureModelDownloaded()` — calls
-  `RemoteModelManager.getInstance().download(model, conditions).await()`; no-op if
-  already downloaded; throws on failure (caller catches)
-- [ ] FOSS stub: `isModelDownloaded()` returns `false`; `ensureModelDownloaded()` no-ops
+- [x] Add `suspend fun isModelDownloaded(): Boolean` — Play Services ML Kit has no public
+  sync API to query model download status (unlike Firebase ML's `RemoteModelManager`);
+  full flavor returns `true` optimistically; `ensureModelDownloaded()` is the real gate
+- [x] Add `suspend fun ensureModelDownloaded()` — creates + immediately closes a
+  `SubjectSegmentation` client, which registers the GMS module dependency and triggers
+  Play Services to prepare the model; throws if GMS client creation fails
+- [x] FOSS stub: `isModelDownloaded()` returns `false`; `ensureModelDownloaded()` no-ops
 
 ### `ClothingFormViewModel` changes
 
-- [ ] On `removeBackground()` entry: call `isModelDownloaded()` before setting
+- [x] On `removeBackground()` entry: call `isModelDownloaded()` before setting
   `isSegmenting = true`
   - If not downloaded: set a new `isDownloadingModel: Boolean = true` state flag,
     call `ensureModelDownloaded()`, then proceed
   - On download failure: emit error snackbar ("Couldn't download segmentation model");
     clear `isDownloadingModel`; return early without segmenting
-- [ ] Add `val isDownloadingModel: Boolean = false` to `ClothingFormUiState`
+- [x] Add `val isDownloadingModel: Boolean = false` to `ClothingFormUiState`
 
 ### UI changes (`ClothingFormScreen.kt`)
 
-- [ ] While `isDownloadingModel == true`: show an indeterminate `CircularProgressIndicator`
+- [x] While `isDownloadingModel == true`: show an indeterminate `CircularProgressIndicator`
   over the photo with label "Downloading model…" (reuse existing segmenting overlay,
   swap the label)
-- [ ] Disable "Remove background" button while `isDownloadingModel == true`
+- [x] Disable "Remove background" button while `isDownloadingModel == true`
 
 ### `BatchSegmentationWorker` changes
 
-- [ ] At the start of `doWork()`, before the item loop: call `ensureModelDownloaded()`
+- [x] At the start of `doWork()`, before the item loop: call `ensureModelDownloaded()`
   - On failure: return `Result.failure(workDataOf("error" to "model_download_failed"))`
   - This prevents starting the foreground service + notification for a run that will
     immediately fail on every item
 
 ### String resources
 
-- [ ] `wardrobe_downloading_model` — "Downloading segmentation model…"
-- [ ] `wardrobe_model_download_error` — "Couldn't download segmentation model. Check your connection and try again."
+- [x] `wardrobe_downloading_model` — "Downloading segmentation model…"
+- [x] `wardrobe_model_download_error` — "Couldn't download segmentation model. Check your connection and try again."
 
 ---
 

--- a/app-android/segmentation-roadmap.md
+++ b/app-android/segmentation-roadmap.md
@@ -230,6 +230,55 @@ No flavor split needed — WorkManager and system notifications are AOSP; no GMS
 
 ---
 
+## Phase 7 — Model readiness (first-run download gate)
+
+The Play Services ML Kit model (`mobile_bg_removal_v8.f16.tflite`) is **not bundled in
+the APK** — it is downloaded in the background by Google Play Services on first use.
+If the user taps "Remove background" before the download completes, the Task fails
+silently. This phase adds an explicit download gate so the UI reflects true readiness.
+
+### `RemoteModelManager` helper (`SegmentationRepository`, full flavor only)
+
+- [ ] Add `suspend fun isModelDownloaded(): Boolean` — calls
+  `RemoteModelManager.getInstance().isModelDownloaded(CustomRemoteModel(…)).await()`
+  using the same `CustomModelDownloadConditions` / model name the SDK resolves at runtime
+  (name: `"subject_segmentation"` — match the module resolved by `DynamiteModule`)
+- [ ] Add `suspend fun ensureModelDownloaded()` — calls
+  `RemoteModelManager.getInstance().download(model, conditions).await()`; no-op if
+  already downloaded; throws on failure (caller catches)
+- [ ] FOSS stub: `isModelDownloaded()` returns `false`; `ensureModelDownloaded()` no-ops
+
+### `ClothingFormViewModel` changes
+
+- [ ] On `removeBackground()` entry: call `isModelDownloaded()` before setting
+  `isSegmenting = true`
+  - If not downloaded: set a new `isDownloadingModel: Boolean = true` state flag,
+    call `ensureModelDownloaded()`, then proceed
+  - On download failure: emit error snackbar ("Couldn't download segmentation model");
+    clear `isDownloadingModel`; return early without segmenting
+- [ ] Add `val isDownloadingModel: Boolean = false` to `ClothingFormUiState`
+
+### UI changes (`ClothingFormScreen.kt`)
+
+- [ ] While `isDownloadingModel == true`: show an indeterminate `CircularProgressIndicator`
+  over the photo with label "Downloading model…" (reuse existing segmenting overlay,
+  swap the label)
+- [ ] Disable "Remove background" button while `isDownloadingModel == true`
+
+### `BatchSegmentationWorker` changes
+
+- [ ] At the start of `doWork()`, before the item loop: call `ensureModelDownloaded()`
+  - On failure: return `Result.failure(workDataOf("error" to "model_download_failed"))`
+  - This prevents starting the foreground service + notification for a run that will
+    immediately fail on every item
+
+### String resources
+
+- [ ] `wardrobe_downloading_model` — "Downloading segmentation model…"
+- [ ] `wardrobe_model_download_error` — "Couldn't download segmentation model. Check your connection and try again."
+
+---
+
 ## Deferred / out of scope
 
 - **Manual touch-up** (paint-to-include / paint-to-exclude brush strokes) — custom

--- a/app-android/segmentation-roadmap.md
+++ b/app-android/segmentation-roadmap.md
@@ -10,17 +10,18 @@ works on all devices).
 
 ### Dependency
 
-- [ ] Add `mlkitSubjectSegmentation = "16.0.0-beta1"` version to `gradle/libs.versions.toml`
-- [ ] Add library alias to `[libraries]` block:
+- [x] Add `mlkitSubjectSegmentation = "16.0.0-beta1"` version to `gradle/libs.versions.toml`
+- [x] Add library alias to `[libraries]` block:
   `mlkit-subject-segmentation = { group = "com.google.android.gms", name = "play-services-mlkit-subject-segmentation", version.ref = "mlkitSubjectSegmentation" }`
   (note: `play-services-mlkit-*`, not `com.google.mlkit:*`)
-- [ ] Add dependency to `features/wardrobe/build.gradle.kts`
-- [ ] No model download flow needed — the ~200 KB model is delivered automatically
+- [x] Add `"fullImplementation"` dep to `features/wardrobe/build.gradle.kts` + flavor dims (full/foss)
+- [x] No model download flow needed — the ~200 KB model is delivered automatically
   via Google Play Services on first use
 
 ### SegmentationRepository
 
-- [ ] Create `core/data/src/main/kotlin/com/closet/core/data/repository/SegmentationRepository.kt`
+- [x] Create `features/wardrobe/src/full/kotlin/…/repository/SegmentationRepository.kt` (real impl)
+      + `features/wardrobe/src/foss/kotlin/…/repository/SegmentationRepository.kt` (stub — throws UnsupportedOperationException)
   - `@Singleton`, `@Inject constructor(@ApplicationContext context: Context)`
   - Single public method: `suspend fun removeBackground(bitmap: Bitmap): Bitmap`
     - Creates `SubjectSegmenterOptions` with **`enableForegroundBitmap()`**
@@ -36,15 +37,15 @@ works on all devices).
     512×512 required for accuracy per docs); the stored image will be the
     downsampled+masked PNG, original dimensions are not restored
 
-- [ ] Add `SegmentationRepository` provider to `core/data/src/main/kotlin/com/closet/core/data/di/DataModule.kt`
+- [x] `SegmentationRepository` uses `@Singleton @Inject constructor` — Hilt resolves from whichever source set is active (full/foss), no `@Provides` in `DataModule` needed
 
 ### StorageRepository — PNG save support
 
-- [ ] Add `suspend fun saveBitmap(bitmap: Bitmap, filename: String): String` to
+- [x] Add `suspend fun saveBitmap(bitmap: Bitmap, filename: String): String` to
   `core/data/src/main/kotlin/com/closet/core/data/repository/StorageRepository.kt`
-  - Saves to the same app-owned images directory used by `copyImage()`
+  - Saves to the same app-owned images directory used by `saveImage()`
   - Compresses as `Bitmap.CompressFormat.PNG` (quality param ignored by PNG encoder)
-  - Returns a relative path (same convention as `copyImage()` — just the filename,
+  - Returns a relative path (same convention as `saveImage()` — just the filename,
     no leading slash) so the rest of the pipeline is unchanged
 
 ---

--- a/app-android/segmentation-roadmap.md
+++ b/app-android/segmentation-roadmap.md
@@ -173,29 +173,29 @@ notification fallback for older devices.
 
 No flavor split needed — WorkManager and system notifications are AOSP; no GMS.
 
-### Dependencies (`gradle/libs.versions.toml` + `core/data/build.gradle.kts`)
+### Dependencies (`gradle/libs.versions.toml` + `features/wardrobe/build.gradle.kts`)
 
-- [ ] `androidx.work:work-runtime-ktx` — `WorkManager` + `CoroutineWorker`
-- [ ] No new MLKit dependency — reuses `play-services-mlkit-subject-segmentation`
+- [x] `androidx.work:work-runtime-ktx` + `androidx-hilt-work` added to version catalog
+  and `features/wardrobe/build.gradle.kts`; `ksp(androidx-hilt-compiler)` added to both
+  `features/wardrobe` and `app`
+- [x] No new MLKit dependency — reuses `play-services-mlkit-subject-segmentation`
   already on `features/wardrobe`
 
 ### `BatchSegmentationWorker` (`features/wardrobe/src/main/kotlin/…`)
 
-- [ ] `class BatchSegmentationWorker(ctx, params) : CoroutineWorker`
-- [ ] Declare as a `ForegroundService` worker (required for long-running work):
-  `setForeground(createForegroundInfo(done, total))`
-- [ ] Query all clothing items where `imagePath IS NOT NULL AND imagePath NOT LIKE '%.png'`
-  via `ClothingDao` (inject via `HiltWorkerFactory`)
-- [ ] Create a **single** `SubjectSegmentation` client before the loop; `close()` in
-  `finally` — do not open/close per image (performance)
-- [ ] For each item:
-  - `setProgress(workDataOf(KEY_DONE to i, KEY_TOTAL to n))` — drives UI progress
-  - Decode → `removeBackground()` → `storageRepository.saveBitmap()` →
-    `clothingRepository.updateItemImagePath(id, newPath)`
-  - On exception: `Timber.e(...)` + `continue` — never abort the whole batch
-    for a single bad image; accumulate a failed-count
-  - Skip items whose `imagePath` already ends with `.png`
-- [ ] Return `Result.success(workDataOf(KEY_FAILED to failedCount))`
+- [x] `@HiltWorker class BatchSegmentationWorker @AssistedInject constructor` — `CoroutineWorker`
+- [x] `setForeground(createForegroundInfo(done, total))` foreground service wiring;
+  `FOREGROUND_SERVICE`, `FOREGROUND_SERVICE_DATA_SYNC`, `POST_NOTIFICATIONS` perms in manifest;
+  default WorkManager initializer disabled; `ClosetApp` implements `Configuration.Provider`
+- [x] Queries `ClothingDao.getItemsNeedingSegmentation()` (non-PNG items with an image)
+- [x] Per-item loop: `decodeSampledBitmap` → `removeBackground()` → `saveBitmap()` →
+  `updateItemImagePath()`; per-item exception isolation (`catch → Timber.e → failed++`);
+  `CancellationException` re-thrown
+- [x] `setProgress(workDataOf(KEY_DONE to done, KEY_TOTAL to total))` after each item
+- [x] Returns `Result.success(workDataOf(KEY_DONE to done, KEY_FAILED to failed))`
+- [x] Constants (`NAME`, `KEY_DONE`, `KEY_TOTAL`, `KEY_FAILED`) extracted to
+  `core/data/.../worker/BatchSegmentationWork.kt` so settings module can reference them
+  without depending on `features/wardrobe`
 
 ### Live Update notification (`createForegroundInfo`)
 

--- a/app-android/segmentation-roadmap.md
+++ b/app-android/segmentation-roadmap.md
@@ -199,14 +199,13 @@ No flavor split needed — WorkManager and system notifications are AOSP; no GMS
 
 ### Live Update notification (`createForegroundInfo`)
 
-- [ ] **API 36+ (Android 16)**: use `Notification.LiveUpdateExtras` / the
-  Live Update notification style to show determinate progress in the system
-  notification shade with the standardised look
+- [x] **API 36+ (Android 16)**: `Notification.Builder` + `Notification.ProgressStyle`
+  with `setProgress(done * 10_000 / total)` — standardised Live Update appearance
   (ref: https://developer.android.com/develop/ui/views/notifications/live-update)
-- [ ] **API < 36 fallback**: `NotificationCompat.Builder` with
+- [x] **API < 36 fallback**: `NotificationCompat.Builder` with
   `setProgress(total, done, false)` — standard determinate progress bar
-- [ ] Branch at runtime: `if (Build.VERSION.SDK_INT >= 36) { … } else { … }`
-- [ ] Notification channel: `"segmentation_batch"` — importance LOW (silent, no sound)
+- [x] Branch at runtime via `Build.VERSION_CODES.BAKLAVA` (= 36)
+- [x] Notification channel: `"segmentation_batch"` — importance LOW (silent, no sound)
 
 ### Settings integration (`features/settings`)
 

--- a/app-android/segmentation-roadmap.md
+++ b/app-android/segmentation-roadmap.md
@@ -143,11 +143,98 @@ When the user opens an existing item with a segmented PNG in edit mode, the
 
 ---
 
+## Phase 5 — Edge quality (confidence mask)
+
+Replace the hard-cut `enableForegroundBitmap()` with `enableForegroundConfidenceMask()`
+so edge pixels (collar, cuffs, loose fabric) get partial alpha instead of a binary cut.
+No new dependency needed — same `play-services-mlkit-subject-segmentation` library.
+
+### SegmentationRepository (full flavor)
+
+- [ ] Change `SubjectSegmenterOptions` to use `.enableForegroundConfidenceMask()` instead
+  of `.enableForegroundBitmap()`
+- [ ] After `.await()`, read `result.foregroundConfidenceMask!!` (a `FloatBuffer`, row-major)
+- [ ] Build the output bitmap manually:
+  - Copy input to an `ARGB_8888` mutable bitmap
+  - `getPixels()` into an `IntArray`
+  - For each pixel `i`: `alpha = (mask.get() * 255).toInt().coerceIn(0, 255)`
+  - Write alpha: `pixels[i] = (pixels[i] and 0x00FFFFFF) or (alpha shl 24)`
+  - `setPixels()` back; `mask.rewind()`
+- [ ] Remove the `foregroundBitmap` null-check (no longer used)
+
+---
+
+## Phase 6 — Batch segmentation
+
+Process all existing wardrobe items in the background. Triggered from Settings;
+survives the app being killed via WorkManager. Progress is surfaced as a
+**Live Update** notification (Android 16 / API 36+) with a standard progress
+notification fallback for older devices.
+
+No flavor split needed — WorkManager and system notifications are AOSP; no GMS.
+
+### Dependencies (`gradle/libs.versions.toml` + `core/data/build.gradle.kts`)
+
+- [ ] `androidx.work:work-runtime-ktx` — `WorkManager` + `CoroutineWorker`
+- [ ] No new MLKit dependency — reuses `play-services-mlkit-subject-segmentation`
+  already on `features/wardrobe`
+
+### `BatchSegmentationWorker` (`features/wardrobe/src/main/kotlin/…`)
+
+- [ ] `class BatchSegmentationWorker(ctx, params) : CoroutineWorker`
+- [ ] Declare as a `ForegroundService` worker (required for long-running work):
+  `setForeground(createForegroundInfo(done, total))`
+- [ ] Query all clothing items where `imagePath IS NOT NULL AND imagePath NOT LIKE '%.png'`
+  via `ClothingDao` (inject via `HiltWorkerFactory`)
+- [ ] Create a **single** `SubjectSegmentation` client before the loop; `close()` in
+  `finally` — do not open/close per image (performance)
+- [ ] For each item:
+  - `setProgress(workDataOf(KEY_DONE to i, KEY_TOTAL to n))` — drives UI progress
+  - Decode → `removeBackground()` → `storageRepository.saveBitmap()` →
+    `clothingRepository.updateItemImagePath(id, newPath)`
+  - On exception: `Timber.e(...)` + `continue` — never abort the whole batch
+    for a single bad image; accumulate a failed-count
+  - Skip items whose `imagePath` already ends with `.png`
+- [ ] Return `Result.success(workDataOf(KEY_FAILED to failedCount))`
+
+### Live Update notification (`createForegroundInfo`)
+
+- [ ] **API 36+ (Android 16)**: use `Notification.LiveUpdateExtras` / the
+  Live Update notification style to show determinate progress in the system
+  notification shade with the standardised look
+  (ref: https://developer.android.com/develop/ui/views/notifications/live-update)
+- [ ] **API < 36 fallback**: `NotificationCompat.Builder` with
+  `setProgress(total, done, false)` — standard determinate progress bar
+- [ ] Branch at runtime: `if (Build.VERSION.SDK_INT >= 36) { … } else { … }`
+- [ ] Notification channel: `"segmentation_batch"` — importance LOW (silent, no sound)
+
+### Settings integration (`features/settings`)
+
+- [ ] Add a new "Wardrobe" section to `SettingsScreen`
+- [ ] Row: **"Remove backgrounds"** — subtitle shows item count eligible
+  (items with non-png images); tapping enqueues the worker via
+  `WorkManager.getInstance(ctx).enqueueUniqueWork("batch_seg", KEEP, request)`
+  so double-taps don't duplicate the job
+- [ ] While the worker is running, replace the row with a progress indicator
+  driven by `WorkManager.getWorkInfosForUniqueWorkLiveData("batch_seg")` →
+  collected as `StateFlow` in `SettingsViewModel`
+- [ ] On completion: show a snackbar with the result
+  (e.g. "42 items updated, 2 skipped")
+
+### `SettingsViewModel` additions
+
+- [ ] Inject `WorkManager` into `SettingsViewModel`
+- [ ] Expose `batchSegmentationState: StateFlow<WorkInfo.State?>` from
+  `workManager.getWorkInfosForUniqueWorkFlow("batch_seg")` mapped to the
+  first item's state
+- [ ] `fun startBatchSegmentation()` — builds and enqueues the `OneTimeWorkRequest`
+
+---
+
 ## Deferred / out of scope
 
-- **Batch segmentation** on existing wardrobe items — deferred; the UX for
-  applying this retroactively needs separate design work
-- **Edge refinement** (feathering, manual touch-up) — out of scope
+- **Manual touch-up** (paint-to-include / paint-to-exclude brush strokes) — custom
+  canvas compositing; significant UI work with no MLKit support
 - **AICore** — Subject Segmentation is a traditional ML Kit Vision API, not an
   AICore feature. There is no AICore variant of it. The `play-services-mlkit`
   implementation is the only backend and works on all devices (API 24+)

--- a/app-android/segmentation-roadmap.md
+++ b/app-android/segmentation-roadmap.md
@@ -137,7 +137,7 @@ the detail screen hero). No changes required to display code.
 When the user opens an existing item with a segmented PNG in edit mode, the
 "Remove background" button must not reappear (the image is already clean).
 
-- [ ] In `loadItemForEditing()`, if the stored `imagePath` ends with `.png`,
+- [x] In `loadItemForEditing()`, if the stored `imagePath` ends with `.png`,
   set `hasSegmentedImage = true` in the initial state so the button stays hidden
   and "Undo" is not shown (the original is gone — no revert target)
 

--- a/app-android/segmentation-roadmap.md
+++ b/app-android/segmentation-roadmap.md
@@ -151,16 +151,16 @@ No new dependency needed — same `play-services-mlkit-subject-segmentation` lib
 
 ### SegmentationRepository (full flavor)
 
-- [ ] Change `SubjectSegmenterOptions` to use `.enableForegroundConfidenceMask()` instead
+- [x] Change `SubjectSegmenterOptions` to use `.enableForegroundConfidenceMask()` instead
   of `.enableForegroundBitmap()`
-- [ ] After `.await()`, read `result.foregroundConfidenceMask!!` (a `FloatBuffer`, row-major)
-- [ ] Build the output bitmap manually:
+- [x] After `.await()`, read `result.foregroundConfidenceMask!!` (a `FloatBuffer`, row-major)
+- [x] Build the output bitmap manually:
   - Copy input to an `ARGB_8888` mutable bitmap
   - `getPixels()` into an `IntArray`
   - For each pixel `i`: `alpha = (mask.get() * 255).toInt().coerceIn(0, 255)`
   - Write alpha: `pixels[i] = (pixels[i] and 0x00FFFFFF) or (alpha shl 24)`
   - `setPixels()` back; `mask.rewind()`
-- [ ] Remove the `foregroundBitmap` null-check (no longer used)
+- [x] Remove the `foregroundBitmap` null-check (no longer used)
 
 ---
 

--- a/app-android/segmentation-roadmap.md
+++ b/app-android/segmentation-roadmap.md
@@ -93,29 +93,29 @@ works on all devices).
 Locate the existing photo `Box`/`AsyncImage` block. The changes all live inside
 or directly below that block.
 
-- [ ] Overlay a `CircularProgressIndicator` centered over the photo `Box` when
+- [x] Overlay a `CircularProgressIndicator` centered over the photo `Box` when
   `uiState.isSegmenting == true`; dim the image with `Modifier.alpha(0.4f)` while
   segmenting so the spinner is readable
 
-- [ ] Show a **"Remove background"** `OutlinedButton` below the photo when:
+- [x] Show a **"Remove background"** `OutlinedButton` below the photo when:
   - `uiState.imageFile != null`
   - `uiState.isSegmenting == false`
   - `uiState.hasSegmentedImage == false`
   - `onClick = { viewModel.removeBackground() }`
 
-- [ ] Show a **"Revert"** `TextButton` (or secondary label) below the photo when
+- [x] Show a **"Revert"** `TextButton` (or secondary label) below the photo when
   `uiState.hasSegmentedImage == true && !uiState.isSegmenting`
   - `onClick = { viewModel.revertSegmentation() }`
   - Label: "Undo background removal"
 
-- [ ] Disable the photo-picker launcher button (`Add Photo` / `Change Photo`)
+- [x] Disable the photo-picker launcher button (`Add Photo` / `Change Photo`)
   while `uiState.isSegmenting == true`
 
 ### String resources (`features/wardrobe/src/main/res/values/strings.xml`)
 
-- [ ] `wardrobe_remove_background` — "Remove background"
-- [ ] `wardrobe_revert_segmentation` — "Undo background removal"
-- [ ] `wardrobe_segmentation_error` — "Couldn't remove background. Try a photo with a clearer subject."
+- [x] `wardrobe_remove_background` — "Remove background"
+- [x] `wardrobe_revert_segmentation` — "Undo background removal"
+- [x] `wardrobe_segmentation_error` — "Couldn't remove background. Try a photo with a clearer subject." (added in Phase 2)
 
 ---
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-image background removal and undo in Wardrobe with model-download state, UI dimming/spinner, picker-disable while working, and a batch "Remove backgrounds" job with progress, notifications, eligibility counts, and Settings control (with confirmation).

* **Documentation**
  * Updated Android flavor documentation and expanded segmentation roadmap.

* **Chores**
  * App version bumped to 0.1.0; added runtime permissions and new user-facing strings for segmentation and batch workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->