### PR TITLE
Add on-device embedding infrastructure with ONNX

### DIFF
--- a/app-android/CHANGELOG.md
+++ b/app-android/CHANGELOG.md
@@ -1,0 +1,89 @@
+# Changelog
+
+All notable changes to hangr (Android) are documented here.
+Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+Versions correspond to `versionName` in `app/build.gradle.kts`.
+
+---
+
+## [Unreleased]
+
+---
+
+## [0.1.1] — 2026-03-30
+
+Phase 2A + Phase 3 of the RAG pipeline: on-device embedding storage and the
+background embedding worker. Items now get a 384-float semantic vector written
+to `item_embeddings` whenever their `semantic_description` changes, enabling
+future cosine-similarity search without a network call.
+
+### Added
+- **Migration 4 → 5** — `item_embeddings` table: stores a little-endian float32
+  BLOB (384 dims), `model_version`, `input_snapshot` (for staleness detection),
+  and `embedded_at` timestamp.
+- **`EmbeddingWorker`** — periodic background worker (charging + idle) that
+  tokenises `semantic_description + image_caption` with a BERT WordPiece
+  tokenizer, runs `snowflake-arctic-embed-xs` INT8 ONNX inference, mean-pools
+  the `last_hidden_state`, L2-normalises to a unit vector, and upserts into
+  `item_embeddings`. Reports `done / total / failed` progress via WorkManager.
+- **`WordPieceTokenizer`** — pure-Kotlin BERT WordPiece tokenizer reading
+  `assets/models/vocab.txt`; pads/truncates to 128 tokens.
+- **`EmbeddingScheduler`** — schedules `EmbeddingWorker` as unique periodic
+  work (1-hour interval) via WorkManager.
+- **`SemanticDebugCard`** — debug-only UI card on the item detail screen that
+  surfaces `semantic_description` and `image_caption` with copy-to-clipboard,
+  shown only in `BuildConfig.DEBUG` builds.
+
+### Fixed
+- **Colour re-extraction after background removal** — `ClothingFormViewModel`
+  now re-runs Android Palette on the segmented PNG after `removeBackground()`
+  completes (transparent pixels are skipped so only subject colours are
+  sampled). The colour junction table and `semantic_description` are updated
+  to reflect the post-segmentation state.
+- **`BatchSegmentationWorker` colour gap** — batch background removal now also
+  re-extracts colours from the in-memory masked bitmap, updates the junction
+  table, and calls `revectorizeItem` after each successful PNG save.
+- **`OnnxTensor` partial-creation leak** — tensors are now created inside
+  nested `use {}` blocks so a failure during the second or third
+  `createTensor` call cannot leave earlier tensors unclosed.
+- **`OrtSession.SessionOptions` resource leak** — `SessionOptions` is now
+  wrapped in `use {}` so the native handle is always released.
+- **`KEY_TOTAL` missing from `EmbeddingWorker` success results** — both
+  `Result.success()` return sites now include `KEY_TOTAL` for consistent
+  progress data.
+- **`vectorizeItem` silent on success** — now logs item ID, description
+  length, and full description text at DEBUG level under `ClothingRepository`.
+
+---
+
+## [0.1.0] — 2026-03-22
+
+Initial working release. Core wardrobe management, background removal, and
+Phase 1 of the RAG pipeline (semantic descriptions + image captions).
+
+### Added
+- Full wardrobe CRUD (add / edit / delete clothing items with photos).
+- Category, subcategory, colour, material, season, occasion, and pattern
+  tagging with junction-table storage.
+- Outfit builder and OOTD logging with a partial-index uniqueness constraint.
+- Stats screen: wear counts, cost-per-wear, breakdowns by category / colour /
+  occasion with Vico column charts.
+- **Subject segmentation** — ML Kit Subject Segmentation removes image
+  backgrounds in-form and via `BatchSegmentationWorker` for existing items.
+  Model readiness gate prevents silent per-item failures.
+- **Migration 3 → 4** — `semantic_description` and `image_caption` shadow
+  columns on `clothing_items` for RAG input.
+- **`ItemVectorizer`** — deterministic prose generator that serialises a
+  `ClothingItemDetail` into a natural-language description; output written to
+  `semantic_description` after every insert or update.
+- **`ImageCaptionRepository`** — wraps ML Kit Image Description API
+  (Gemini Nano / AICore) to generate a short caption at image-capture time;
+  FOSS stub provided for F-Droid builds.
+- **Batch caption enrichment** — Settings screen action to backfill
+  `image_caption` for existing items that pre-date at-capture captioning.
+- Two product flavors: `full` (GMS / Play Services) and `foss` (no GMS,
+  F-Droid target).
+
+[Unreleased]: https://github.com/Masked-Kunsiquat/closet/compare/v0.1.1...HEAD
+[0.1.1]: https://github.com/Masked-Kunsiquat/closet/compare/v0.1.0...v0.1.1
+[0.1.0]: https://github.com/Masked-Kunsiquat/closet/releases/tag/v0.1.0

--- a/app-android/app/build.gradle.kts
+++ b/app-android/app/build.gradle.kts
@@ -15,8 +15,8 @@ android {
         applicationId = "com.closet"
         minSdk = libs.versions.minSdk.get().toInt()
         targetSdk = libs.versions.targetSdk.get().toInt()
-        versionCode = 1
-        versionName = "0.1.0"
+        versionCode = 2
+        versionName = "0.1.1"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {

--- a/app-android/app/src/main/kotlin/com/closet/ClosetApp.kt
+++ b/app-android/app/src/main/kotlin/com/closet/ClosetApp.kt
@@ -4,6 +4,7 @@ import android.app.Application
 import androidx.hilt.work.HiltWorkerFactory
 import androidx.work.Configuration
 import com.closet.core.data.repository.AiPreferencesRepository
+import com.closet.core.data.worker.EmbeddingScheduler
 import dagger.hilt.android.HiltAndroidApp
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -25,6 +26,7 @@ class ClosetApp : Application(), Configuration.Provider {
 
     @Inject lateinit var aiPreferencesRepository: AiPreferencesRepository
     @Inject lateinit var workerFactory: HiltWorkerFactory
+    @Inject lateinit var embeddingScheduler: EmbeddingScheduler
 
     override fun getWorkManagerConfiguration(): Configuration =
         Configuration.Builder().setWorkerFactory(workerFactory).build()
@@ -36,6 +38,9 @@ class ClosetApp : Application(), Configuration.Provider {
         if (BuildConfig.DEBUG) {
             Timber.plant(Timber.DebugTree())
         }
+        // Register the periodic embedding worker (charging + idle; no-op if already queued).
+        embeddingScheduler.schedule()
+
         // Migrate any API keys previously stored as plaintext in DataStore to EncryptedKeyStore.
         // No-op after the first run or if keys were never set.
         applicationScope.launch {

--- a/app-android/core/data/build.gradle.kts
+++ b/app-android/core/data/build.gradle.kts
@@ -68,6 +68,14 @@ dependencies {
     implementation(libs.ktor.serialization.kotlinx.json)
     implementation(libs.ktor.client.logging)
 
+    // WorkManager + Hilt-Work (for EmbeddingWorker)
+    implementation(libs.androidx.work.runtime.ktx)
+    implementation(libs.androidx.hilt.work)
+    ksp(libs.androidx.hilt.compiler)
+
+    // ONNX Runtime (sentence embedding inference, Phase 3)
+    implementation(libs.onnx.runtime.android)
+
     // Logging
     implementation(libs.timber)
 

--- a/app-android/core/data/schemas/com.closet.core.data.ClothingDatabase/5.json
+++ b/app-android/core/data/schemas/com.closet.core.data.ClothingDatabase/5.json
@@ -1,0 +1,1309 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 5,
+    "identityHash": "c54995f0a6f56b4f5e7223167ddf5a1c",
+    "entities": [
+      {
+        "tableName": "clothing_items",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `brand` TEXT, `brand_id` INTEGER, `category_id` INTEGER, `subcategory_id` INTEGER, `size_value_id` INTEGER, `waist` REAL, `inseam` REAL, `purchase_price` REAL, `purchase_date` TEXT, `purchase_location` TEXT, `image_path` TEXT, `notes` TEXT, `status` TEXT NOT NULL DEFAULT 'Active', `wash_status` TEXT NOT NULL DEFAULT 'Clean', `is_favorite` INTEGER NOT NULL, `semantic_description` TEXT, `image_caption` TEXT, `created_at` TEXT NOT NULL, `updated_at` TEXT NOT NULL, FOREIGN KEY(`category_id`) REFERENCES `categories`(`id`) ON UPDATE NO ACTION ON DELETE SET NULL , FOREIGN KEY(`subcategory_id`) REFERENCES `subcategories`(`id`) ON UPDATE NO ACTION ON DELETE SET NULL , FOREIGN KEY(`size_value_id`) REFERENCES `size_values`(`id`) ON UPDATE NO ACTION ON DELETE SET NULL , FOREIGN KEY(`brand_id`) REFERENCES `brands`(`id`) ON UPDATE NO ACTION ON DELETE SET NULL )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "brand",
+            "columnName": "brand",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "brandId",
+            "columnName": "brand_id",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "categoryId",
+            "columnName": "category_id",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "subcategoryId",
+            "columnName": "subcategory_id",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "sizeValueId",
+            "columnName": "size_value_id",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "waist",
+            "columnName": "waist",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "inseam",
+            "columnName": "inseam",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "purchasePrice",
+            "columnName": "purchase_price",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "purchaseDate",
+            "columnName": "purchase_date",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "purchaseLocation",
+            "columnName": "purchase_location",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "imagePath",
+            "columnName": "image_path",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "notes",
+            "columnName": "notes",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'Active'"
+          },
+          {
+            "fieldPath": "washStatus",
+            "columnName": "wash_status",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'Clean'"
+          },
+          {
+            "fieldPath": "isFavorite",
+            "columnName": "is_favorite",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "semanticDescription",
+            "columnName": "semantic_description",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "imageCaption",
+            "columnName": "image_caption",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_clothing_items_category_id",
+            "unique": false,
+            "columnNames": [
+              "category_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_clothing_items_category_id` ON `${TABLE_NAME}` (`category_id`)"
+          },
+          {
+            "name": "index_clothing_items_subcategory_id",
+            "unique": false,
+            "columnNames": [
+              "subcategory_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_clothing_items_subcategory_id` ON `${TABLE_NAME}` (`subcategory_id`)"
+          },
+          {
+            "name": "index_clothing_items_size_value_id",
+            "unique": false,
+            "columnNames": [
+              "size_value_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_clothing_items_size_value_id` ON `${TABLE_NAME}` (`size_value_id`)"
+          },
+          {
+            "name": "index_clothing_items_brand_id",
+            "unique": false,
+            "columnNames": [
+              "brand_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_clothing_items_brand_id` ON `${TABLE_NAME}` (`brand_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "categories",
+            "onDelete": "SET NULL",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "category_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "subcategories",
+            "onDelete": "SET NULL",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "subcategory_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "size_values",
+            "onDelete": "SET NULL",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "size_value_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "brands",
+            "onDelete": "SET NULL",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "brand_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "brands",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `normalized_name` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "normalizedName",
+            "columnName": "normalized_name",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_brands_normalized_name",
+            "unique": true,
+            "columnNames": [
+              "normalized_name"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_brands_normalized_name` ON `${TABLE_NAME}` (`normalized_name`)"
+          }
+        ]
+      },
+      {
+        "tableName": "categories",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `icon` TEXT, `sort_order` INTEGER NOT NULL, `warmth_layer` TEXT NOT NULL DEFAULT 'None', `outfit_role` TEXT NOT NULL DEFAULT 'Other')",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "icon",
+            "columnName": "icon",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sortOrder",
+            "columnName": "sort_order",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "warmthLayer",
+            "columnName": "warmth_layer",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'None'"
+          },
+          {
+            "fieldPath": "outfitRole",
+            "columnName": "outfit_role",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'Other'"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "subcategories",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `category_id` INTEGER NOT NULL, `name` TEXT NOT NULL, `sort_order` INTEGER NOT NULL, FOREIGN KEY(`category_id`) REFERENCES `categories`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "categoryId",
+            "columnName": "category_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sortOrder",
+            "columnName": "sort_order",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_subcategories_category_id",
+            "unique": false,
+            "columnNames": [
+              "category_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_subcategories_category_id` ON `${TABLE_NAME}` (`category_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "categories",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "category_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "seasons",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `icon` TEXT, `temp_low_c` REAL, `temp_high_c` REAL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "icon",
+            "columnName": "icon",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "tempLowC",
+            "columnName": "temp_low_c",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "tempHighC",
+            "columnName": "temp_high_c",
+            "affinity": "REAL"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "occasions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `icon` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "icon",
+            "columnName": "icon",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "colors",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `hex` TEXT, `color_family` TEXT NOT NULL DEFAULT 'Neutral')",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hex",
+            "columnName": "hex",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "colorFamily",
+            "columnName": "color_family",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'Neutral'"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "materials",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "patterns",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `icon` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "icon",
+            "columnName": "icon",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "size_systems",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "size_values",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `size_system_id` INTEGER NOT NULL, `value` TEXT NOT NULL, `sort_order` INTEGER NOT NULL, FOREIGN KEY(`size_system_id`) REFERENCES `size_systems`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sizeSystemId",
+            "columnName": "size_system_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "value",
+            "columnName": "value",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sortOrder",
+            "columnName": "sort_order",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_size_values_size_system_id",
+            "unique": false,
+            "columnNames": [
+              "size_system_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_size_values_size_system_id` ON `${TABLE_NAME}` (`size_system_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "size_systems",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "size_system_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "outfits",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT, `notes` TEXT, `created_at` TEXT NOT NULL, `updated_at` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "notes",
+            "columnName": "notes",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "outfit_items",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`outfit_id` INTEGER NOT NULL, `clothing_item_id` INTEGER NOT NULL, `pos_x` REAL, `pos_y` REAL, `scale` REAL, `z_index` INTEGER, PRIMARY KEY(`outfit_id`, `clothing_item_id`), FOREIGN KEY(`outfit_id`) REFERENCES `outfits`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`clothing_item_id`) REFERENCES `clothing_items`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "outfitId",
+            "columnName": "outfit_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "clothingItemId",
+            "columnName": "clothing_item_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "posX",
+            "columnName": "pos_x",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "posY",
+            "columnName": "pos_y",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "scale",
+            "columnName": "scale",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "zIndex",
+            "columnName": "z_index",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "outfit_id",
+            "clothing_item_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_outfit_items_clothing_item_id",
+            "unique": false,
+            "columnNames": [
+              "clothing_item_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_outfit_items_clothing_item_id` ON `${TABLE_NAME}` (`clothing_item_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "outfits",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "outfit_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "clothing_items",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "clothing_item_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "outfit_logs",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `outfit_id` INTEGER, `date` TEXT NOT NULL, `is_ootd` INTEGER NOT NULL, `notes` TEXT, `temperature_low` REAL, `temperature_high` REAL, `weather_condition` TEXT, `precipitation_mm` REAL, `wind_speed_kmh` REAL, `created_at` TEXT NOT NULL, FOREIGN KEY(`outfit_id`) REFERENCES `outfits`(`id`) ON UPDATE NO ACTION ON DELETE SET NULL )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "outfitId",
+            "columnName": "outfit_id",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "date",
+            "columnName": "date",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isOotd",
+            "columnName": "is_ootd",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "notes",
+            "columnName": "notes",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "temperatureLow",
+            "columnName": "temperature_low",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "temperatureHigh",
+            "columnName": "temperature_high",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "weatherCondition",
+            "columnName": "weather_condition",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "precipitationMm",
+            "columnName": "precipitation_mm",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "windSpeedKmh",
+            "columnName": "wind_speed_kmh",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_outfit_logs_outfit_id",
+            "unique": false,
+            "columnNames": [
+              "outfit_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_outfit_logs_outfit_id` ON `${TABLE_NAME}` (`outfit_id`)"
+          },
+          {
+            "name": "index_outfit_logs_date",
+            "unique": false,
+            "columnNames": [
+              "date"
+            ],
+            "orders": [
+              "ASC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_outfit_logs_date` ON `${TABLE_NAME}` (`date` ASC)"
+          },
+          {
+            "name": "index_outfit_logs_outfit_id_date",
+            "unique": true,
+            "columnNames": [
+              "outfit_id",
+              "date"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_outfit_logs_outfit_id_date` ON `${TABLE_NAME}` (`outfit_id`, `date`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "outfits",
+            "onDelete": "SET NULL",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "outfit_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "outfit_log_items",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`outfit_log_id` INTEGER NOT NULL, `clothing_item_id` INTEGER NOT NULL, `outfit_name` TEXT, PRIMARY KEY(`outfit_log_id`, `clothing_item_id`), FOREIGN KEY(`outfit_log_id`) REFERENCES `outfit_logs`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "outfitLogId",
+            "columnName": "outfit_log_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "clothingItemId",
+            "columnName": "clothing_item_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "outfitName",
+            "columnName": "outfit_name",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "outfit_log_id",
+            "clothing_item_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_outfit_log_items_clothing_item_id",
+            "unique": false,
+            "columnNames": [
+              "clothing_item_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_outfit_log_items_clothing_item_id` ON `${TABLE_NAME}` (`clothing_item_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "outfit_logs",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "outfit_log_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "clothing_item_colors",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`clothing_item_id` INTEGER NOT NULL, `color_id` INTEGER NOT NULL, PRIMARY KEY(`clothing_item_id`, `color_id`), FOREIGN KEY(`clothing_item_id`) REFERENCES `clothing_items`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`color_id`) REFERENCES `colors`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "clothingItemId",
+            "columnName": "clothing_item_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "colorId",
+            "columnName": "color_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "clothing_item_id",
+            "color_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_clothing_item_colors_color_id",
+            "unique": false,
+            "columnNames": [
+              "color_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_clothing_item_colors_color_id` ON `${TABLE_NAME}` (`color_id`)"
+          },
+          {
+            "name": "index_clothing_item_colors_clothing_item_id",
+            "unique": false,
+            "columnNames": [
+              "clothing_item_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_clothing_item_colors_clothing_item_id` ON `${TABLE_NAME}` (`clothing_item_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "clothing_items",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "clothing_item_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "colors",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "color_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "clothing_item_materials",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`clothing_item_id` INTEGER NOT NULL, `material_id` INTEGER NOT NULL, PRIMARY KEY(`clothing_item_id`, `material_id`), FOREIGN KEY(`clothing_item_id`) REFERENCES `clothing_items`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`material_id`) REFERENCES `materials`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "clothingItemId",
+            "columnName": "clothing_item_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "materialId",
+            "columnName": "material_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "clothing_item_id",
+            "material_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_clothing_item_materials_material_id",
+            "unique": false,
+            "columnNames": [
+              "material_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_clothing_item_materials_material_id` ON `${TABLE_NAME}` (`material_id`)"
+          },
+          {
+            "name": "index_clothing_item_materials_clothing_item_id",
+            "unique": false,
+            "columnNames": [
+              "clothing_item_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_clothing_item_materials_clothing_item_id` ON `${TABLE_NAME}` (`clothing_item_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "clothing_items",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "clothing_item_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "materials",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "material_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "clothing_item_seasons",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`clothing_item_id` INTEGER NOT NULL, `season_id` INTEGER NOT NULL, PRIMARY KEY(`clothing_item_id`, `season_id`), FOREIGN KEY(`clothing_item_id`) REFERENCES `clothing_items`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`season_id`) REFERENCES `seasons`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "clothingItemId",
+            "columnName": "clothing_item_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "seasonId",
+            "columnName": "season_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "clothing_item_id",
+            "season_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_clothing_item_seasons_season_id",
+            "unique": false,
+            "columnNames": [
+              "season_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_clothing_item_seasons_season_id` ON `${TABLE_NAME}` (`season_id`)"
+          },
+          {
+            "name": "index_clothing_item_seasons_clothing_item_id",
+            "unique": false,
+            "columnNames": [
+              "clothing_item_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_clothing_item_seasons_clothing_item_id` ON `${TABLE_NAME}` (`clothing_item_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "clothing_items",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "clothing_item_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "seasons",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "season_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "clothing_item_occasions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`clothing_item_id` INTEGER NOT NULL, `occasion_id` INTEGER NOT NULL, PRIMARY KEY(`clothing_item_id`, `occasion_id`), FOREIGN KEY(`clothing_item_id`) REFERENCES `clothing_items`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`occasion_id`) REFERENCES `occasions`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "clothingItemId",
+            "columnName": "clothing_item_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "occasionId",
+            "columnName": "occasion_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "clothing_item_id",
+            "occasion_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_clothing_item_occasions_occasion_id",
+            "unique": false,
+            "columnNames": [
+              "occasion_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_clothing_item_occasions_occasion_id` ON `${TABLE_NAME}` (`occasion_id`)"
+          },
+          {
+            "name": "index_clothing_item_occasions_clothing_item_id",
+            "unique": false,
+            "columnNames": [
+              "clothing_item_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_clothing_item_occasions_clothing_item_id` ON `${TABLE_NAME}` (`clothing_item_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "clothing_items",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "clothing_item_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "occasions",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "occasion_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "clothing_item_patterns",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`clothing_item_id` INTEGER NOT NULL, `pattern_id` INTEGER NOT NULL, PRIMARY KEY(`clothing_item_id`, `pattern_id`), FOREIGN KEY(`clothing_item_id`) REFERENCES `clothing_items`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`pattern_id`) REFERENCES `patterns`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "clothingItemId",
+            "columnName": "clothing_item_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "patternId",
+            "columnName": "pattern_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "clothing_item_id",
+            "pattern_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_clothing_item_patterns_pattern_id",
+            "unique": false,
+            "columnNames": [
+              "pattern_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_clothing_item_patterns_pattern_id` ON `${TABLE_NAME}` (`pattern_id`)"
+          },
+          {
+            "name": "index_clothing_item_patterns_clothing_item_id",
+            "unique": false,
+            "columnNames": [
+              "clothing_item_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_clothing_item_patterns_clothing_item_id` ON `${TABLE_NAME}` (`clothing_item_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "clothing_items",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "clothing_item_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "patterns",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "pattern_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "item_embeddings",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`item_id` INTEGER NOT NULL, `embedding_blob` BLOB NOT NULL, `model_version` TEXT NOT NULL, `embedded_at` TEXT NOT NULL, PRIMARY KEY(`item_id`), FOREIGN KEY(`item_id`) REFERENCES `clothing_items`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "itemId",
+            "columnName": "item_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "embeddingBlob",
+            "columnName": "embedding_blob",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modelVersion",
+            "columnName": "model_version",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "embeddedAt",
+            "columnName": "embedded_at",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "item_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_item_embeddings_item_id",
+            "unique": true,
+            "columnNames": [
+              "item_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_item_embeddings_item_id` ON `${TABLE_NAME}` (`item_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "clothing_items",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "item_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'c54995f0a6f56b4f5e7223167ddf5a1c')"
+    ]
+  }
+}

--- a/app-android/core/data/schemas/com.closet.core.data.ClothingDatabase/6.json
+++ b/app-android/core/data/schemas/com.closet.core.data.ClothingDatabase/6.json
@@ -1,0 +1,1314 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 6,
+    "identityHash": "dd9d5ffc89fb082e41bc696348f1c0c3",
+    "entities": [
+      {
+        "tableName": "clothing_items",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `brand` TEXT, `brand_id` INTEGER, `category_id` INTEGER, `subcategory_id` INTEGER, `size_value_id` INTEGER, `waist` REAL, `inseam` REAL, `purchase_price` REAL, `purchase_date` TEXT, `purchase_location` TEXT, `image_path` TEXT, `notes` TEXT, `status` TEXT NOT NULL DEFAULT 'Active', `wash_status` TEXT NOT NULL DEFAULT 'Clean', `is_favorite` INTEGER NOT NULL, `semantic_description` TEXT, `image_caption` TEXT, `created_at` TEXT NOT NULL, `updated_at` TEXT NOT NULL, FOREIGN KEY(`category_id`) REFERENCES `categories`(`id`) ON UPDATE NO ACTION ON DELETE SET NULL , FOREIGN KEY(`subcategory_id`) REFERENCES `subcategories`(`id`) ON UPDATE NO ACTION ON DELETE SET NULL , FOREIGN KEY(`size_value_id`) REFERENCES `size_values`(`id`) ON UPDATE NO ACTION ON DELETE SET NULL , FOREIGN KEY(`brand_id`) REFERENCES `brands`(`id`) ON UPDATE NO ACTION ON DELETE SET NULL )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "brand",
+            "columnName": "brand",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "brandId",
+            "columnName": "brand_id",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "categoryId",
+            "columnName": "category_id",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "subcategoryId",
+            "columnName": "subcategory_id",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "sizeValueId",
+            "columnName": "size_value_id",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "waist",
+            "columnName": "waist",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "inseam",
+            "columnName": "inseam",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "purchasePrice",
+            "columnName": "purchase_price",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "purchaseDate",
+            "columnName": "purchase_date",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "purchaseLocation",
+            "columnName": "purchase_location",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "imagePath",
+            "columnName": "image_path",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "notes",
+            "columnName": "notes",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'Active'"
+          },
+          {
+            "fieldPath": "washStatus",
+            "columnName": "wash_status",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'Clean'"
+          },
+          {
+            "fieldPath": "isFavorite",
+            "columnName": "is_favorite",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "semanticDescription",
+            "columnName": "semantic_description",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "imageCaption",
+            "columnName": "image_caption",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_clothing_items_category_id",
+            "unique": false,
+            "columnNames": [
+              "category_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_clothing_items_category_id` ON `${TABLE_NAME}` (`category_id`)"
+          },
+          {
+            "name": "index_clothing_items_subcategory_id",
+            "unique": false,
+            "columnNames": [
+              "subcategory_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_clothing_items_subcategory_id` ON `${TABLE_NAME}` (`subcategory_id`)"
+          },
+          {
+            "name": "index_clothing_items_size_value_id",
+            "unique": false,
+            "columnNames": [
+              "size_value_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_clothing_items_size_value_id` ON `${TABLE_NAME}` (`size_value_id`)"
+          },
+          {
+            "name": "index_clothing_items_brand_id",
+            "unique": false,
+            "columnNames": [
+              "brand_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_clothing_items_brand_id` ON `${TABLE_NAME}` (`brand_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "categories",
+            "onDelete": "SET NULL",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "category_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "subcategories",
+            "onDelete": "SET NULL",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "subcategory_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "size_values",
+            "onDelete": "SET NULL",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "size_value_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "brands",
+            "onDelete": "SET NULL",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "brand_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "brands",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `normalized_name` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "normalizedName",
+            "columnName": "normalized_name",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_brands_normalized_name",
+            "unique": true,
+            "columnNames": [
+              "normalized_name"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_brands_normalized_name` ON `${TABLE_NAME}` (`normalized_name`)"
+          }
+        ]
+      },
+      {
+        "tableName": "categories",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `icon` TEXT, `sort_order` INTEGER NOT NULL, `warmth_layer` TEXT NOT NULL DEFAULT 'None', `outfit_role` TEXT NOT NULL DEFAULT 'Other')",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "icon",
+            "columnName": "icon",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "sortOrder",
+            "columnName": "sort_order",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "warmthLayer",
+            "columnName": "warmth_layer",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'None'"
+          },
+          {
+            "fieldPath": "outfitRole",
+            "columnName": "outfit_role",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'Other'"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "subcategories",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `category_id` INTEGER NOT NULL, `name` TEXT NOT NULL, `sort_order` INTEGER NOT NULL, FOREIGN KEY(`category_id`) REFERENCES `categories`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "categoryId",
+            "columnName": "category_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sortOrder",
+            "columnName": "sort_order",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_subcategories_category_id",
+            "unique": false,
+            "columnNames": [
+              "category_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_subcategories_category_id` ON `${TABLE_NAME}` (`category_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "categories",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "category_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "seasons",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `icon` TEXT, `temp_low_c` REAL, `temp_high_c` REAL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "icon",
+            "columnName": "icon",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "tempLowC",
+            "columnName": "temp_low_c",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "tempHighC",
+            "columnName": "temp_high_c",
+            "affinity": "REAL"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "occasions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `icon` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "icon",
+            "columnName": "icon",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "colors",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `hex` TEXT, `color_family` TEXT NOT NULL DEFAULT 'Neutral')",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hex",
+            "columnName": "hex",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "colorFamily",
+            "columnName": "color_family",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'Neutral'"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "materials",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "patterns",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL, `icon` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "icon",
+            "columnName": "icon",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "size_systems",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "size_values",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `size_system_id` INTEGER NOT NULL, `value` TEXT NOT NULL, `sort_order` INTEGER NOT NULL, FOREIGN KEY(`size_system_id`) REFERENCES `size_systems`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sizeSystemId",
+            "columnName": "size_system_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "value",
+            "columnName": "value",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sortOrder",
+            "columnName": "sort_order",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_size_values_size_system_id",
+            "unique": false,
+            "columnNames": [
+              "size_system_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_size_values_size_system_id` ON `${TABLE_NAME}` (`size_system_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "size_systems",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "size_system_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "outfits",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `name` TEXT, `notes` TEXT, `created_at` TEXT NOT NULL, `updated_at` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "notes",
+            "columnName": "notes",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "outfit_items",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`outfit_id` INTEGER NOT NULL, `clothing_item_id` INTEGER NOT NULL, `pos_x` REAL, `pos_y` REAL, `scale` REAL, `z_index` INTEGER, PRIMARY KEY(`outfit_id`, `clothing_item_id`), FOREIGN KEY(`outfit_id`) REFERENCES `outfits`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`clothing_item_id`) REFERENCES `clothing_items`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "outfitId",
+            "columnName": "outfit_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "clothingItemId",
+            "columnName": "clothing_item_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "posX",
+            "columnName": "pos_x",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "posY",
+            "columnName": "pos_y",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "scale",
+            "columnName": "scale",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "zIndex",
+            "columnName": "z_index",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "outfit_id",
+            "clothing_item_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_outfit_items_clothing_item_id",
+            "unique": false,
+            "columnNames": [
+              "clothing_item_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_outfit_items_clothing_item_id` ON `${TABLE_NAME}` (`clothing_item_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "outfits",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "outfit_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "clothing_items",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "clothing_item_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "outfit_logs",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `outfit_id` INTEGER, `date` TEXT NOT NULL, `is_ootd` INTEGER NOT NULL, `notes` TEXT, `temperature_low` REAL, `temperature_high` REAL, `weather_condition` TEXT, `precipitation_mm` REAL, `wind_speed_kmh` REAL, `created_at` TEXT NOT NULL, FOREIGN KEY(`outfit_id`) REFERENCES `outfits`(`id`) ON UPDATE NO ACTION ON DELETE SET NULL )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "outfitId",
+            "columnName": "outfit_id",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "date",
+            "columnName": "date",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isOotd",
+            "columnName": "is_ootd",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "notes",
+            "columnName": "notes",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "temperatureLow",
+            "columnName": "temperature_low",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "temperatureHigh",
+            "columnName": "temperature_high",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "weatherCondition",
+            "columnName": "weather_condition",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "precipitationMm",
+            "columnName": "precipitation_mm",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "windSpeedKmh",
+            "columnName": "wind_speed_kmh",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_outfit_logs_outfit_id",
+            "unique": false,
+            "columnNames": [
+              "outfit_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_outfit_logs_outfit_id` ON `${TABLE_NAME}` (`outfit_id`)"
+          },
+          {
+            "name": "index_outfit_logs_date",
+            "unique": false,
+            "columnNames": [
+              "date"
+            ],
+            "orders": [
+              "ASC"
+            ],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_outfit_logs_date` ON `${TABLE_NAME}` (`date` ASC)"
+          },
+          {
+            "name": "index_outfit_logs_outfit_id_date",
+            "unique": true,
+            "columnNames": [
+              "outfit_id",
+              "date"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_outfit_logs_outfit_id_date` ON `${TABLE_NAME}` (`outfit_id`, `date`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "outfits",
+            "onDelete": "SET NULL",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "outfit_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "outfit_log_items",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`outfit_log_id` INTEGER NOT NULL, `clothing_item_id` INTEGER NOT NULL, `outfit_name` TEXT, PRIMARY KEY(`outfit_log_id`, `clothing_item_id`), FOREIGN KEY(`outfit_log_id`) REFERENCES `outfit_logs`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "outfitLogId",
+            "columnName": "outfit_log_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "clothingItemId",
+            "columnName": "clothing_item_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "outfitName",
+            "columnName": "outfit_name",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "outfit_log_id",
+            "clothing_item_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_outfit_log_items_clothing_item_id",
+            "unique": false,
+            "columnNames": [
+              "clothing_item_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_outfit_log_items_clothing_item_id` ON `${TABLE_NAME}` (`clothing_item_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "outfit_logs",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "outfit_log_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "clothing_item_colors",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`clothing_item_id` INTEGER NOT NULL, `color_id` INTEGER NOT NULL, PRIMARY KEY(`clothing_item_id`, `color_id`), FOREIGN KEY(`clothing_item_id`) REFERENCES `clothing_items`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`color_id`) REFERENCES `colors`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "clothingItemId",
+            "columnName": "clothing_item_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "colorId",
+            "columnName": "color_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "clothing_item_id",
+            "color_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_clothing_item_colors_color_id",
+            "unique": false,
+            "columnNames": [
+              "color_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_clothing_item_colors_color_id` ON `${TABLE_NAME}` (`color_id`)"
+          },
+          {
+            "name": "index_clothing_item_colors_clothing_item_id",
+            "unique": false,
+            "columnNames": [
+              "clothing_item_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_clothing_item_colors_clothing_item_id` ON `${TABLE_NAME}` (`clothing_item_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "clothing_items",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "clothing_item_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "colors",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "color_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "clothing_item_materials",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`clothing_item_id` INTEGER NOT NULL, `material_id` INTEGER NOT NULL, PRIMARY KEY(`clothing_item_id`, `material_id`), FOREIGN KEY(`clothing_item_id`) REFERENCES `clothing_items`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`material_id`) REFERENCES `materials`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "clothingItemId",
+            "columnName": "clothing_item_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "materialId",
+            "columnName": "material_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "clothing_item_id",
+            "material_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_clothing_item_materials_material_id",
+            "unique": false,
+            "columnNames": [
+              "material_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_clothing_item_materials_material_id` ON `${TABLE_NAME}` (`material_id`)"
+          },
+          {
+            "name": "index_clothing_item_materials_clothing_item_id",
+            "unique": false,
+            "columnNames": [
+              "clothing_item_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_clothing_item_materials_clothing_item_id` ON `${TABLE_NAME}` (`clothing_item_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "clothing_items",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "clothing_item_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "materials",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "material_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "clothing_item_seasons",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`clothing_item_id` INTEGER NOT NULL, `season_id` INTEGER NOT NULL, PRIMARY KEY(`clothing_item_id`, `season_id`), FOREIGN KEY(`clothing_item_id`) REFERENCES `clothing_items`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`season_id`) REFERENCES `seasons`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "clothingItemId",
+            "columnName": "clothing_item_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "seasonId",
+            "columnName": "season_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "clothing_item_id",
+            "season_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_clothing_item_seasons_season_id",
+            "unique": false,
+            "columnNames": [
+              "season_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_clothing_item_seasons_season_id` ON `${TABLE_NAME}` (`season_id`)"
+          },
+          {
+            "name": "index_clothing_item_seasons_clothing_item_id",
+            "unique": false,
+            "columnNames": [
+              "clothing_item_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_clothing_item_seasons_clothing_item_id` ON `${TABLE_NAME}` (`clothing_item_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "clothing_items",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "clothing_item_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "seasons",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "season_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "clothing_item_occasions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`clothing_item_id` INTEGER NOT NULL, `occasion_id` INTEGER NOT NULL, PRIMARY KEY(`clothing_item_id`, `occasion_id`), FOREIGN KEY(`clothing_item_id`) REFERENCES `clothing_items`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`occasion_id`) REFERENCES `occasions`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "clothingItemId",
+            "columnName": "clothing_item_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "occasionId",
+            "columnName": "occasion_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "clothing_item_id",
+            "occasion_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_clothing_item_occasions_occasion_id",
+            "unique": false,
+            "columnNames": [
+              "occasion_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_clothing_item_occasions_occasion_id` ON `${TABLE_NAME}` (`occasion_id`)"
+          },
+          {
+            "name": "index_clothing_item_occasions_clothing_item_id",
+            "unique": false,
+            "columnNames": [
+              "clothing_item_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_clothing_item_occasions_clothing_item_id` ON `${TABLE_NAME}` (`clothing_item_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "clothing_items",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "clothing_item_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "occasions",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "occasion_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "clothing_item_patterns",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`clothing_item_id` INTEGER NOT NULL, `pattern_id` INTEGER NOT NULL, PRIMARY KEY(`clothing_item_id`, `pattern_id`), FOREIGN KEY(`clothing_item_id`) REFERENCES `clothing_items`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`pattern_id`) REFERENCES `patterns`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "clothingItemId",
+            "columnName": "clothing_item_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "patternId",
+            "columnName": "pattern_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "clothing_item_id",
+            "pattern_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_clothing_item_patterns_pattern_id",
+            "unique": false,
+            "columnNames": [
+              "pattern_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_clothing_item_patterns_pattern_id` ON `${TABLE_NAME}` (`pattern_id`)"
+          },
+          {
+            "name": "index_clothing_item_patterns_clothing_item_id",
+            "unique": false,
+            "columnNames": [
+              "clothing_item_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_clothing_item_patterns_clothing_item_id` ON `${TABLE_NAME}` (`clothing_item_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "clothing_items",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "clothing_item_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "patterns",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "pattern_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "item_embeddings",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`item_id` INTEGER NOT NULL, `embedding_blob` BLOB NOT NULL, `model_version` TEXT NOT NULL, `input_snapshot` TEXT, `embedded_at` TEXT NOT NULL, PRIMARY KEY(`item_id`), FOREIGN KEY(`item_id`) REFERENCES `clothing_items`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "itemId",
+            "columnName": "item_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "embeddingBlob",
+            "columnName": "embedding_blob",
+            "affinity": "BLOB",
+            "notNull": true
+          },
+          {
+            "fieldPath": "modelVersion",
+            "columnName": "model_version",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "inputSnapshot",
+            "columnName": "input_snapshot",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "embeddedAt",
+            "columnName": "embedded_at",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "item_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_item_embeddings_item_id",
+            "unique": true,
+            "columnNames": [
+              "item_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_item_embeddings_item_id` ON `${TABLE_NAME}` (`item_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "clothing_items",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "item_id"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'dd9d5ffc89fb082e41bc696348f1c0c3')"
+    ]
+  }
+}

--- a/app-android/core/data/src/main/kotlin/com/closet/core/data/ClothingDatabase.kt
+++ b/app-android/core/data/src/main/kotlin/com/closet/core/data/ClothingDatabase.kt
@@ -11,6 +11,7 @@ import com.closet.core.data.migrations.MIGRATION_1_2
 import com.closet.core.data.migrations.MIGRATION_2_3
 import com.closet.core.data.migrations.MIGRATION_3_4
 import com.closet.core.data.migrations.MIGRATION_4_5
+import com.closet.core.data.migrations.MIGRATION_5_6
 import com.closet.core.data.model.*
 
 /**
@@ -42,7 +43,7 @@ import com.closet.core.data.model.*
         ClothingItemPatternEntity::class,
         ItemEmbeddingEntity::class
     ],
-    version = 5,
+    version = 6,
     exportSchema = true
 )
 @TypeConverters(Converters::class)
@@ -98,7 +99,7 @@ abstract class ClothingDatabase : RoomDatabase() {
                         db.execSQL("CREATE UNIQUE INDEX IF NOT EXISTS one_ootd_per_day ON outfit_logs(date) WHERE is_ootd = 1")
                     }
                 })
-                .addMigrations(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5)
+                .addMigrations(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5, MIGRATION_5_6)
                 .build()
                 INSTANCE = instance
                 instance

--- a/app-android/core/data/src/main/kotlin/com/closet/core/data/ClothingDatabase.kt
+++ b/app-android/core/data/src/main/kotlin/com/closet/core/data/ClothingDatabase.kt
@@ -10,6 +10,7 @@ import com.closet.core.data.dao.*
 import com.closet.core.data.migrations.MIGRATION_1_2
 import com.closet.core.data.migrations.MIGRATION_2_3
 import com.closet.core.data.migrations.MIGRATION_3_4
+import com.closet.core.data.migrations.MIGRATION_4_5
 import com.closet.core.data.model.*
 
 /**
@@ -38,9 +39,10 @@ import com.closet.core.data.model.*
         ClothingItemMaterialEntity::class,
         ClothingItemSeasonEntity::class,
         ClothingItemOccasionEntity::class,
-        ClothingItemPatternEntity::class
+        ClothingItemPatternEntity::class,
+        ItemEmbeddingEntity::class
     ],
-    version = 4,
+    version = 5,
     exportSchema = true
 )
 @TypeConverters(Converters::class)
@@ -59,6 +61,8 @@ abstract class ClothingDatabase : RoomDatabase() {
     abstract fun statsDao(): StatsDao
     /** @return [RecommendationDao] for the outfit recommendation pipeline. */
     abstract fun recommendationDao(): RecommendationDao
+    /** @return [EmbeddingDao] for RAG vector storage (Phase 2A). */
+    abstract fun embeddingDao(): EmbeddingDao
 
     companion object {
         private const val DATABASE_NAME = "closet.db"
@@ -94,7 +98,7 @@ abstract class ClothingDatabase : RoomDatabase() {
                         db.execSQL("CREATE UNIQUE INDEX IF NOT EXISTS one_ootd_per_day ON outfit_logs(date) WHERE is_ootd = 1")
                     }
                 })
-                .addMigrations(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4)
+                .addMigrations(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5)
                 .build()
                 INSTANCE = instance
                 instance

--- a/app-android/core/data/src/main/kotlin/com/closet/core/data/dao/EmbeddingDao.kt
+++ b/app-android/core/data/src/main/kotlin/com/closet/core/data/dao/EmbeddingDao.kt
@@ -1,0 +1,51 @@
+package com.closet.core.data.dao
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import com.closet.core.data.model.ItemEmbeddingEntity
+
+/**
+ * DAO for the `item_embeddings` table (Phase 2A vector storage).
+ *
+ * All writes go through [upsert] — re-embedding an item simply overwrites the
+ * previous row. Reads are either full-table (for in-memory cosine search at query
+ * time) or filtered by [modelVersion] to find items that need (re-)embedding.
+ */
+@Dao
+interface EmbeddingDao {
+
+    /**
+     * Inserts or replaces the embedding for an item.
+     * Called by `EmbeddingWorker` after each successful ONNX inference.
+     */
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun upsert(embedding: ItemEmbeddingEntity)
+
+    /**
+     * Returns all stored embeddings.
+     *
+     * Loaded once at query time into an in-memory `List<Pair<Long, FloatArray>>`
+     * for cosine similarity search. At 300 items × 384 dims × 4 bytes ≈ 460 KB
+     * this is negligible; remains appropriate until ~2,000 items (Phase 2B threshold).
+     */
+    @Query("SELECT * FROM item_embeddings")
+    suspend fun getAll(): List<ItemEmbeddingEntity>
+
+    /**
+     * Returns the IDs of clothing items that have a `semantic_description` but either
+     * have no embedding yet or whose embedding was produced by an older model version.
+     *
+     * Used by `EmbeddingWorker` to build its work queue before each run.
+     *
+     * @param modelVersion the current model identifier (e.g. [EmbeddingWork.MODEL_VERSION])
+     */
+    @Query("""
+        SELECT ci.id FROM clothing_items ci
+        LEFT JOIN item_embeddings ie ON ci.id = ie.item_id
+        WHERE ci.semantic_description IS NOT NULL
+          AND (ie.item_id IS NULL OR ie.model_version != :modelVersion)
+    """)
+    suspend fun getItemIdsNeedingEmbedding(modelVersion: String): List<Long>
+}

--- a/app-android/core/data/src/main/kotlin/com/closet/core/data/dao/EmbeddingDao.kt
+++ b/app-android/core/data/src/main/kotlin/com/closet/core/data/dao/EmbeddingDao.kt
@@ -1,10 +1,24 @@
 package com.closet.core.data.dao
 
+import androidx.room.ColumnInfo
 import androidx.room.Dao
 import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
 import com.closet.core.data.model.ItemEmbeddingEntity
+
+/**
+ * Lightweight projection of the text fields needed to produce an embedding.
+ * Returned by [EmbeddingDao.getTextsForEmbedding] so [EmbeddingWorker] avoids
+ * loading the full [ClothingItemEntity].
+ */
+data class ItemTextForEmbedding(
+    @ColumnInfo(name = "id") val id: Long,
+    /** Structured prose paragraph from `ItemVectorizer` — guaranteed non-null by the query. */
+    @ColumnInfo(name = "semantic_description") val semanticDescription: String,
+    /** AI photo caption from `ImageCaptionRepository`; null if not yet enriched. */
+    @ColumnInfo(name = "image_caption") val imageCaption: String?,
+)
 
 /**
  * DAO for the `item_embeddings` table (Phase 2A vector storage).
@@ -48,4 +62,16 @@ interface EmbeddingDao {
           AND (ie.item_id IS NULL OR ie.model_version != :modelVersion)
     """)
     suspend fun getItemIdsNeedingEmbedding(modelVersion: String): List<Long>
+
+    /**
+     * Fetches the text fields needed to produce an embedding for the given item IDs.
+     * Only returns rows where `semantic_description IS NOT NULL` — the caller can pass
+     * any list of IDs and null-description rows are silently excluded.
+     */
+    @Query("""
+        SELECT id, semantic_description, image_caption
+        FROM clothing_items
+        WHERE id IN (:ids) AND semantic_description IS NOT NULL
+    """)
+    suspend fun getTextsForEmbedding(ids: List<Long>): List<ItemTextForEmbedding>
 }

--- a/app-android/core/data/src/main/kotlin/com/closet/core/data/dao/EmbeddingDao.kt
+++ b/app-android/core/data/src/main/kotlin/com/closet/core/data/dao/EmbeddingDao.kt
@@ -48,10 +48,15 @@ interface EmbeddingDao {
     suspend fun getAll(): List<ItemEmbeddingEntity>
 
     /**
-     * Returns the IDs of clothing items that have a `semantic_description` but either
-     * have no embedding yet or whose embedding was produced by an older model version.
+     * Returns the IDs of clothing items whose embedding is missing or stale.
      *
-     * Used by `EmbeddingWorker` to build its work queue before each run.
+     * An embedding is stale when any of the following is true:
+     * - No row exists in `item_embeddings` for the item.
+     * - The stored [model_version] differs from [modelVersion] (ONNX model was updated).
+     * - The stored [input_snapshot] is NULL (migrated from v5 before the column was added).
+     * - The stored [input_snapshot] differs from the item's current combined text
+     *   (`semantic_description || COALESCE(' ' || image_caption, '')`) — i.e. the item's
+     *   text was enriched or edited after the last embedding run.
      *
      * @param modelVersion the current model identifier (e.g. [EmbeddingWork.MODEL_VERSION])
      */
@@ -59,7 +64,12 @@ interface EmbeddingDao {
         SELECT ci.id FROM clothing_items ci
         LEFT JOIN item_embeddings ie ON ci.id = ie.item_id
         WHERE ci.semantic_description IS NOT NULL
-          AND (ie.item_id IS NULL OR ie.model_version != :modelVersion)
+          AND (
+            ie.item_id IS NULL
+            OR ie.model_version != :modelVersion
+            OR ie.input_snapshot IS NULL
+            OR ie.input_snapshot != (ci.semantic_description || COALESCE(' ' || ci.image_caption, ''))
+          )
     """)
     suspend fun getItemIdsNeedingEmbedding(modelVersion: String): List<Long>
 

--- a/app-android/core/data/src/main/kotlin/com/closet/core/data/dao/LookupDao.kt
+++ b/app-android/core/data/src/main/kotlin/com/closet/core/data/dao/LookupDao.kt
@@ -49,6 +49,13 @@ interface LookupDao {
     fun getColors(): Flow<List<ColorEntity>>
 
     /**
+     * One-shot fetch of all colors. Intended for background workers that cannot
+     * collect a [Flow] (e.g. [com.closet.features.wardrobe.BatchSegmentationWorker]).
+     */
+    @Query("SELECT * FROM colors ORDER BY name")
+    suspend fun getAllColors(): List<ColorEntity>
+
+    /**
      * Retrieves all materials ordered alphabetically by name.
      * @return A [Flow] emitting a list of [MaterialEntity].
      */

--- a/app-android/core/data/src/main/kotlin/com/closet/core/data/di/DataModule.kt
+++ b/app-android/core/data/src/main/kotlin/com/closet/core/data/di/DataModule.kt
@@ -1,6 +1,11 @@
 package com.closet.core.data.di
 
 import android.content.Context
+import androidx.work.Constraints
+import androidx.work.ExistingPeriodicWorkPolicy
+import androidx.work.NetworkType
+import androidx.work.PeriodicWorkRequestBuilder
+import androidx.work.WorkManager
 import com.closet.core.data.BuildConfig
 import com.closet.core.data.ClothingDatabase
 import com.closet.core.data.dao.*
@@ -8,12 +13,16 @@ import com.closet.core.data.repository.AiPreferencesRepository
 import com.closet.core.data.repository.EncryptedKeyStore
 import com.closet.core.data.repository.RecommendationRepository
 import com.closet.core.data.repository.WeatherPreferencesRepository
+import com.closet.core.data.worker.EmbeddingScheduler
+import com.closet.core.data.worker.EmbeddingWork
+import com.closet.core.data.worker.EmbeddingWorker
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
 import io.ktor.client.HttpClient
+import java.util.concurrent.TimeUnit
 import io.ktor.client.engine.okhttp.OkHttp
 import io.ktor.client.plugins.HttpTimeout
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
@@ -82,6 +91,40 @@ object DataModule {
     @Provides
     @Singleton
     fun provideEmbeddingDao(db: ClothingDatabase): EmbeddingDao = db.embeddingDao()
+
+    /**
+     * Provides the [EmbeddingScheduler] singleton.
+     *
+     * Schedules [EmbeddingWorker] as unique periodic work (1-hour interval) constrained to
+     * charging + idle so it never competes with foreground activity.
+     * [WorkManager] is provided by `WardrobeModule`; Hilt resolves the binding automatically.
+     */
+    @Provides
+    @Singleton
+    fun provideEmbeddingScheduler(workManager: WorkManager): EmbeddingScheduler =
+        object : EmbeddingScheduler {
+            private val constraints = Constraints.Builder()
+                .setRequiresCharging(true)
+                .setRequiresDeviceIdle(true)
+                .setRequiredNetworkType(NetworkType.NOT_REQUIRED)
+                .build()
+
+            private val request = PeriodicWorkRequestBuilder<EmbeddingWorker>(1L, TimeUnit.HOURS)
+                .setConstraints(constraints)
+                .build()
+
+            override fun schedule() {
+                workManager.enqueueUniquePeriodicWork(
+                    EmbeddingWork.NAME,
+                    ExistingPeriodicWorkPolicy.KEEP,
+                    request,
+                )
+            }
+
+            override fun cancel() {
+                workManager.cancelUniqueWork(EmbeddingWork.NAME)
+            }
+        }
 
     /** Provides the [RecommendationRepository] singleton. */
     @Provides

--- a/app-android/core/data/src/main/kotlin/com/closet/core/data/di/DataModule.kt
+++ b/app-android/core/data/src/main/kotlin/com/closet/core/data/di/DataModule.kt
@@ -78,6 +78,11 @@ object DataModule {
     @Singleton
     fun provideRecommendationDao(db: ClothingDatabase): RecommendationDao = db.recommendationDao()
 
+    /** Provides the [EmbeddingDao] singleton from the shared database instance. */
+    @Provides
+    @Singleton
+    fun provideEmbeddingDao(db: ClothingDatabase): EmbeddingDao = db.embeddingDao()
+
     /** Provides the [RecommendationRepository] singleton. */
     @Provides
     @Singleton

--- a/app-android/core/data/src/main/kotlin/com/closet/core/data/migrations/Migration4To5.kt
+++ b/app-android/core/data/src/main/kotlin/com/closet/core/data/migrations/Migration4To5.kt
@@ -1,0 +1,43 @@
+package com.closet.core.data.migrations
+
+import androidx.room.migration.Migration
+import androidx.sqlite.db.SupportSQLiteDatabase
+
+/**
+ * Migration 4 → 5: Vector storage for RAG pipeline (Phase 2A).
+ *
+ * Changes:
+ * - Creates `item_embeddings` table to store pre-computed float32 embedding vectors
+ *   alongside the Room database. Each row holds a BLOB of `dimensions × 4` bytes
+ *   (384 dims for all-MiniLM-L6-v2 = 1 536 bytes), the model version string used to
+ *   detect stale embeddings, and the timestamp of last embedding.
+ * - Cascade-deletes on `clothing_items` removal to prevent orphan vectors.
+ *
+ * Storage estimate: 300 items × 1 536 B ≈ 460 KB — fits comfortably in memory for
+ * Phase 2A cosine-similarity search. Phase 2B (sqlite-vss) can replace this when
+ * the wardrobe exceeds ~2,000 items.
+ */
+val MIGRATION_4_5 = object : Migration(4, 5) {
+    override fun migrate(db: SupportSQLiteDatabase) {
+        // ── Partial index — always drop first (AGENTS.md) ──────────────────────
+        db.execSQL("DROP INDEX IF EXISTS one_ootd_per_day")
+
+        // ── item_embeddings ─────────────────────────────────────────────────────
+        db.execSQL("""
+            CREATE TABLE IF NOT EXISTS `item_embeddings` (
+                `item_id` INTEGER NOT NULL,
+                `embedding_blob` BLOB NOT NULL,
+                `model_version` TEXT NOT NULL,
+                `embedded_at` TEXT NOT NULL,
+                PRIMARY KEY(`item_id`),
+                FOREIGN KEY(`item_id`) REFERENCES `clothing_items`(`id`)
+                    ON UPDATE NO ACTION ON DELETE CASCADE
+            )
+        """.trimIndent())
+
+        db.execSQL(
+            "CREATE UNIQUE INDEX IF NOT EXISTS `index_item_embeddings_item_id` " +
+            "ON `item_embeddings` (`item_id`)"
+        )
+    }
+}

--- a/app-android/core/data/src/main/kotlin/com/closet/core/data/migrations/Migration5To6.kt
+++ b/app-android/core/data/src/main/kotlin/com/closet/core/data/migrations/Migration5To6.kt
@@ -1,0 +1,28 @@
+package com.closet.core.data.migrations
+
+import androidx.room.migration.Migration
+import androidx.sqlite.db.SupportSQLiteDatabase
+
+/**
+ * Migration 5 → 6: Input-snapshot column for embedding staleness detection (Phase 3).
+ *
+ * Changes:
+ * - item_embeddings: add `input_snapshot TEXT` — the exact text string
+ *   (`semantic_description + " " + image_caption`) that was fed to the ONNX model.
+ *   Stored so [EmbeddingWorker] can detect stale embeddings via a SQL comparison
+ *   without requiring a hash function in SQLite.
+ *
+ * Existing rows receive `input_snapshot = NULL`.  [EmbeddingDao.getItemIdsNeedingEmbedding]
+ * treats NULL as stale, so all existing embeddings are transparently re-computed on the
+ * next worker run after this migration.
+ */
+val MIGRATION_5_6 = object : Migration(5, 6) {
+    override fun migrate(db: SupportSQLiteDatabase) {
+        // ── Partial index — always drop first (AGENTS.md) ──────────────────────
+        db.execSQL("DROP INDEX IF EXISTS one_ootd_per_day")
+
+        // ── item_embeddings.input_snapshot ──────────────────────────────────────
+        // No DEFAULT — NULL indicates "was never stored" and is treated as stale.
+        db.execSQL("ALTER TABLE item_embeddings ADD COLUMN input_snapshot TEXT")
+    }
+}

--- a/app-android/core/data/src/main/kotlin/com/closet/core/data/model/ItemEmbeddingEntity.kt
+++ b/app-android/core/data/src/main/kotlin/com/closet/core/data/model/ItemEmbeddingEntity.kt
@@ -11,8 +11,8 @@ import java.time.Instant
  * Stores a pre-computed embedding vector for a clothing item.
  *
  * Vectors are stored as raw float32 little-endian bytes (384 dimensions for
- * `all-MiniLM-L6-v2`). The [modelVersion] field allows the embedding worker to
- * detect and re-embed items when the ONNX model is updated.
+ * `snowflake-arctic-embed-xs`). [modelVersion] triggers re-embedding when the ONNX
+ * model changes; [inputSnapshot] triggers re-embedding when the item's text changes.
  *
  * Cascade-deletes when the parent [ClothingItemEntity] is removed so orphan
  * vectors never accumulate.
@@ -61,6 +61,17 @@ data class ItemEmbeddingEntity(
      */
     @ColumnInfo(name = "model_version")
     val modelVersion: String,
+
+    /**
+     * The exact text string fed to the model (`semanticDescription + " " + imageCaption`).
+     * Stored so [EmbeddingDao.getItemIdsNeedingEmbedding] can detect stale embeddings via
+     * a SQL comparison without needing a separate hash function in the database.
+     *
+     * Null only on rows migrated from v5 before this column was added; the worker treats
+     * null as stale and re-embeds.
+     */
+    @ColumnInfo(name = "input_snapshot")
+    val inputSnapshot: String?,
 
     /** Timestamp of when this embedding was last computed. */
     @ColumnInfo(name = "embedded_at")

--- a/app-android/core/data/src/main/kotlin/com/closet/core/data/model/ItemEmbeddingEntity.kt
+++ b/app-android/core/data/src/main/kotlin/com/closet/core/data/model/ItemEmbeddingEntity.kt
@@ -1,0 +1,68 @@
+package com.closet.core.data.model
+
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.ForeignKey
+import androidx.room.Index
+import androidx.room.PrimaryKey
+import java.time.Instant
+
+/**
+ * Stores a pre-computed embedding vector for a clothing item.
+ *
+ * Vectors are stored as raw float32 little-endian bytes (384 dimensions for
+ * `all-MiniLM-L6-v2`). The [modelVersion] field allows the embedding worker to
+ * detect and re-embed items when the ONNX model is updated.
+ *
+ * Cascade-deletes when the parent [ClothingItemEntity] is removed so orphan
+ * vectors never accumulate.
+ *
+ * Populated by `EmbeddingWorker` (Phase 3). This entity is the Phase 2A storage
+ * layer — a plain Room BLOB column that is sufficient until ~2,000 items, at which
+ * point Phase 2B (sqlite-vss) can take over.
+ */
+@Entity(
+    tableName = "item_embeddings",
+    foreignKeys = [
+        ForeignKey(
+            entity = ClothingItemEntity::class,
+            parentColumns = ["id"],
+            childColumns = ["item_id"],
+            onDelete = ForeignKey.CASCADE,
+        )
+    ],
+    indices = [Index("item_id", unique = true)],
+)
+data class ItemEmbeddingEntity(
+    /** Foreign key to [ClothingItemEntity.id] — also serves as the primary key. */
+    @PrimaryKey
+    @ColumnInfo(name = "item_id")
+    val itemId: Long,
+
+    /**
+     * Serialised float32 vector in little-endian byte order.
+     * Size: `dimensions × 4` bytes (e.g. 384 × 4 = 1 536 bytes for MiniLM-L6-v2).
+     *
+     * Encode with:
+     * ```kotlin
+     * ByteBuffer.allocate(floats.size * 4)
+     *     .order(ByteOrder.LITTLE_ENDIAN)
+     *     .apply { asFloatBuffer().put(floats) }
+     *     .array()
+     * ```
+     */
+    @ColumnInfo(name = "embedding_blob")
+    val embeddingBlob: ByteArray,
+
+    /**
+     * Identifies which model produced this vector (e.g. `"minilm-l6-v2-q8-v1"`).
+     * The embedding worker compares this against its current [EmbeddingWork.MODEL_VERSION]
+     * to detect stale embeddings that need to be re-computed.
+     */
+    @ColumnInfo(name = "model_version")
+    val modelVersion: String,
+
+    /** Timestamp of when this embedding was last computed. */
+    @ColumnInfo(name = "embedded_at")
+    val embeddedAt: Instant,
+)

--- a/app-android/core/data/src/main/kotlin/com/closet/core/data/repository/ClothingRepository.kt
+++ b/app-android/core/data/src/main/kotlin/com/closet/core/data/repository/ClothingRepository.kt
@@ -278,7 +278,7 @@ class ClothingRepository @Inject constructor(
             val detail = clothingDao.getClothingItemDetailOnce(id) ?: return
             val description = ItemVectorizer.describe(detail)
             clothingDao.updateSemanticDescription(id, description, Instant.now())
-            Timber.d("vectorizeItem: wrote description for item $id (${description.length} chars): $description")
+            Timber.d("vectorizeItem: wrote description for item $id (${description.length} chars)")
         } catch (e: Exception) {
             if (e is CancellationException) throw e
             Timber.d(e, "vectorizeItem: failed for item $id — ignored")

--- a/app-android/core/data/src/main/kotlin/com/closet/core/data/repository/ClothingRepository.kt
+++ b/app-android/core/data/src/main/kotlin/com/closet/core/data/repository/ClothingRepository.kt
@@ -258,6 +258,12 @@ class ClothingRepository @Inject constructor(
     }
 
     /**
+     * Public entry point for background workers (e.g. [com.closet.features.wardrobe.BatchSegmentationWorker])
+     * that need to refresh the semantic description after updating an item's image.
+     */
+    suspend fun revectorizeItem(id: Long) = vectorizeItem(id)
+
+    /**
      * Fetches the full [ClothingItemDetail] for [id] and writes its prose description
      * to [com.closet.core.data.dao.ClothingDao.updateSemanticDescription].
      * Failures are logged and swallowed — vectorization is best-effort and must never

--- a/app-android/core/data/src/main/kotlin/com/closet/core/data/repository/ClothingRepository.kt
+++ b/app-android/core/data/src/main/kotlin/com/closet/core/data/repository/ClothingRepository.kt
@@ -268,6 +268,7 @@ class ClothingRepository @Inject constructor(
             val detail = clothingDao.getClothingItemDetailOnce(id) ?: return
             val description = ItemVectorizer.describe(detail)
             clothingDao.updateSemanticDescription(id, description, Instant.now())
+            Timber.d("vectorizeItem: wrote description for item $id (${description.length} chars): $description")
         } catch (e: Exception) {
             if (e is CancellationException) throw e
             Timber.d(e, "vectorizeItem: failed for item $id — ignored")

--- a/app-android/core/data/src/main/kotlin/com/closet/core/data/repository/ClothingRepository.kt
+++ b/app-android/core/data/src/main/kotlin/com/closet/core/data/repository/ClothingRepository.kt
@@ -260,6 +260,10 @@ class ClothingRepository @Inject constructor(
     /**
      * Public entry point for background workers (e.g. [com.closet.features.wardrobe.BatchSegmentationWorker])
      * that need to refresh the semantic description after updating an item's image.
+     *
+     * Returns [Unit] intentionally: [vectorizeItem] already catches and logs all non-cancellation
+     * exceptions, so there is no observable error state to surface. Callers should treat this as
+     * fire-and-forget (failures are visible in Logcat under the [ClothingRepository] tag).
      */
     suspend fun revectorizeItem(id: Long) = vectorizeItem(id)
 

--- a/app-android/core/data/src/main/kotlin/com/closet/core/data/util/WordPieceTokenizer.kt
+++ b/app-android/core/data/src/main/kotlin/com/closet/core/data/util/WordPieceTokenizer.kt
@@ -1,0 +1,208 @@
+package com.closet.core.data.util
+
+import java.io.InputStream
+import java.text.Normalizer
+
+/**
+ * Output of [WordPieceTokenizer.encode]: three parallel arrays of the same length
+ * ([maxLength]) ready to feed directly into the ONNX model.
+ *
+ * @property inputIds     token IDs — `[CLS] tokens… [SEP] [PAD]…`
+ * @property attentionMask 1 for real tokens (including CLS/SEP), 0 for padding
+ * @property tokenTypeIds all-zero for single-sequence inputs (segment A only)
+ */
+data class TokenizerOutput(
+    val inputIds: LongArray,
+    val attentionMask: LongArray,
+    val tokenTypeIds: LongArray,
+)
+
+/**
+ * Minimal BERT-style WordPiece tokenizer for `all-MiniLM-L6-v2` (uncased).
+ *
+ * Reads the vocabulary from a `vocab.txt` stream (one token per line; line index = token ID)
+ * and produces fixed-length [TokenizerOutput] arrays suitable for the ONNX model.
+ *
+ * Pipeline:
+ * 1. **Basic tokenization** — lowercase → unicode NFD + strip combining marks → whitespace split
+ *    → punctuation split.
+ * 2. **WordPiece** — greedy longest-prefix match; continuation pieces are prefixed with `##`.
+ * 3. **Encoding** — prepend `[CLS]`, append `[SEP]`, truncate at `maxLength - 2` content
+ *    tokens, zero-pad to `maxLength`.
+ *
+ * @param vocabStream a stream for `vocab.txt`; consumed and closed during construction.
+ */
+class WordPieceTokenizer(vocabStream: InputStream) {
+
+    private val vocab: Map<String, Int>
+    private val clsId: Int
+    private val sepId: Int
+    private val padId: Int
+    private val unkId: Int
+
+    companion object {
+        private const val CLS_TOKEN = "[CLS]"
+        private const val SEP_TOKEN = "[SEP]"
+        private const val PAD_TOKEN = "[PAD]"
+        private const val UNK_TOKEN = "[UNK]"
+        private const val CONTINUATION_PREFIX = "##"
+
+        /** Words longer than this many characters are replaced wholesale with [UNK_TOKEN]. */
+        private const val MAX_CHARS_PER_WORD = 100
+    }
+
+    init {
+        vocab = HashMap<String, Int>().also { map ->
+            vocabStream.bufferedReader().useLines { lines ->
+                lines.forEachIndexed { index, token -> map[token.trimEnd()] = index }
+            }
+        }
+        clsId = vocab[CLS_TOKEN] ?: 101
+        sepId = vocab[SEP_TOKEN] ?: 102
+        padId = vocab[PAD_TOKEN] ?: 0
+        unkId = vocab[UNK_TOKEN] ?: 100
+    }
+
+    /**
+     * Tokenizes [text] and encodes it as fixed-length arrays of length [maxLength].
+     *
+     * Content tokens are truncated to `maxLength - 2` to leave room for CLS and SEP.
+     */
+    fun encode(text: String, maxLength: Int = 128): TokenizerOutput {
+        val contentTokenIds = tokenize(text).map { vocab[it] ?: unkId }
+
+        // Truncate to leave room for CLS and SEP
+        val maxContent = maxLength - 2
+        val truncated = if (contentTokenIds.size > maxContent) contentTokenIds.take(maxContent)
+                        else contentTokenIds
+
+        val realLength = truncated.size + 2  // +CLS +SEP
+
+        val inputIds     = LongArray(maxLength) { padId.toLong() }
+        val attentionMask = LongArray(maxLength) { 0L }
+        val tokenTypeIds = LongArray(maxLength) { 0L }
+
+        inputIds[0] = clsId.toLong()
+        attentionMask[0] = 1L
+
+        for ((i, id) in truncated.withIndex()) {
+            inputIds[i + 1] = id.toLong()
+            attentionMask[i + 1] = 1L
+        }
+
+        inputIds[realLength - 1] = sepId.toLong()
+        attentionMask[realLength - 1] = 1L
+
+        return TokenizerOutput(inputIds, attentionMask, tokenTypeIds)
+    }
+
+    // ─── Internal tokenization ────────────────────────────────────────────────
+
+    private fun tokenize(text: String): List<String> {
+        val tokens = mutableListOf<String>()
+        for (word in basicTokenize(text)) {
+            tokens.addAll(wordPieceTokenize(word))
+        }
+        return tokens
+    }
+
+    /**
+     * Lowercases, strips accents (NFD + remove Mn-category code points), then splits on
+     * whitespace and punctuation boundaries.
+     */
+    private fun basicTokenize(text: String): List<String> {
+        // 1. Clean control characters and normalise whitespace
+        val cleaned = buildString(text.length) {
+            for (ch in text) {
+                val cp = ch.code
+                if (cp == 0 || cp == 0xFFFD || ch.isISOControl()) continue
+                append(if (ch.isWhitespace()) ' ' else ch)
+            }
+        }.trim().lowercase()
+
+        // 2. Unicode NFD + strip combining (accent) marks
+        val normalized = Normalizer.normalize(cleaned, Normalizer.Form.NFD)
+            .filter { it.category != CharCategory.NON_SPACING_MARK }
+
+        // 3. Split on whitespace, then further split each piece on punctuation boundaries
+        return normalized.split(Regex("\\s+"))
+            .filter { it.isNotEmpty() }
+            .flatMap { splitOnPunctuation(it) }
+            .filter { it.isNotEmpty() }
+    }
+
+    /**
+     * Inserts split points around punctuation characters.
+     * Returns a list of non-empty strings; punctuation characters become their own tokens.
+     */
+    private fun splitOnPunctuation(word: String): List<String> {
+        val result = mutableListOf<String>()
+        val buf = StringBuilder()
+        for (ch in word) {
+            if (isPunctuation(ch)) {
+                if (buf.isNotEmpty()) { result.add(buf.toString()); buf.clear() }
+                result.add(ch.toString())
+            } else {
+                buf.append(ch)
+            }
+        }
+        if (buf.isNotEmpty()) result.add(buf.toString())
+        return result
+    }
+
+    /**
+     * Returns `true` for ASCII punctuation ranges and Unicode punctuation categories.
+     * Matches the original BERT tokenizer's `_is_punctuation` function.
+     */
+    private fun isPunctuation(ch: Char): Boolean {
+        val cp = ch.code
+        // ASCII punctuation ranges
+        if (cp in 33..47 || cp in 58..64 || cp in 91..96 || cp in 123..126) return true
+        return when (ch.category) {
+            CharCategory.CONNECTOR_PUNCTUATION,
+            CharCategory.DASH_PUNCTUATION,
+            CharCategory.START_PUNCTUATION,
+            CharCategory.END_PUNCTUATION,
+            CharCategory.INITIAL_QUOTE_PUNCTUATION,
+            CharCategory.FINAL_QUOTE_PUNCTUATION,
+            CharCategory.OTHER_PUNCTUATION -> true
+            else -> false
+        }
+    }
+
+    /**
+     * Greedy longest-prefix WordPiece algorithm.
+     *
+     * Returns `["[UNK]"]` if:
+     * - [word] exceeds [MAX_CHARS_PER_WORD] characters, or
+     * - any sub-word cannot be found in the vocabulary.
+     */
+    private fun wordPieceTokenize(word: String): List<String> {
+        if (word.length > MAX_CHARS_PER_WORD) return listOf(UNK_TOKEN)
+
+        val subTokens = mutableListOf<String>()
+        var start = 0
+
+        while (start < word.length) {
+            var end = word.length
+            var found: String? = null
+
+            // Greedily find the longest sub-string from `start` that is in vocab
+            while (start < end) {
+                val substr = word.substring(start, end)
+                val candidate = if (start == 0) substr else "$CONTINUATION_PREFIX$substr"
+                if (vocab.containsKey(candidate)) {
+                    found = candidate
+                    break
+                }
+                end--
+            }
+
+            if (found == null) return listOf(UNK_TOKEN)
+            subTokens.add(found)
+            start = end
+        }
+
+        return subTokens
+    }
+}

--- a/app-android/core/data/src/main/kotlin/com/closet/core/data/util/WordPieceTokenizer.kt
+++ b/app-android/core/data/src/main/kotlin/com/closet/core/data/util/WordPieceTokenizer.kt
@@ -69,6 +69,9 @@ class WordPieceTokenizer(vocabStream: InputStream) {
      * Content tokens are truncated to `maxLength - 2` to leave room for CLS and SEP.
      */
     fun encode(text: String, maxLength: Int = 128): TokenizerOutput {
+        require(maxLength >= 2) {
+            "maxLength must be at least 2 to accommodate [CLS] and [SEP] tokens, got $maxLength"
+        }
         val contentTokenIds = tokenize(text).map { vocab[it] ?: unkId }
 
         // Truncate to leave room for CLS and SEP
@@ -115,7 +118,11 @@ class WordPieceTokenizer(vocabStream: InputStream) {
         val cleaned = buildString(text.length) {
             for (ch in text) {
                 val cp = ch.code
-                if (cp == 0 || cp == 0xFFFD || ch.isISOControl()) continue
+                // Always drop the null character and Unicode replacement character.
+                if (cp == 0 || cp == 0xFFFD) continue
+                // Drop non-whitespace control characters (e.g. BEL, ESC) but preserve
+                // whitespace controls (\n, \t, etc.) so token boundaries are maintained.
+                if (ch.isISOControl() && !ch.isWhitespace()) continue
                 append(if (ch.isWhitespace()) ' ' else ch)
             }
         }.trim().lowercase()

--- a/app-android/core/data/src/main/kotlin/com/closet/core/data/worker/EmbeddingWork.kt
+++ b/app-android/core/data/src/main/kotlin/com/closet/core/data/worker/EmbeddingWork.kt
@@ -1,0 +1,43 @@
+package com.closet.core.data.worker
+
+/**
+ * Constants shared between [EmbeddingWorker] and any observer (e.g. a future Settings screen)
+ * so neither module needs to depend on the other.
+ */
+object EmbeddingWork {
+    /** Unique work name for [androidx.work.WorkManager.enqueueUniquePeriodicWork]. */
+    const val NAME = "embedding_worker"
+
+    /**
+     * Identifies the model that produced an embedding.
+     * Changing this value causes [EmbeddingWorker] to re-embed all items on the next run.
+     */
+    const val MODEL_VERSION = "arctic-embed-xs-q8-v1"
+
+    /** Progress / output key: number of items successfully embedded in this run. */
+    const val KEY_DONE = "done"
+
+    /** Progress key: total items queued for this run. */
+    const val KEY_TOTAL = "total"
+
+    /** Progress / output key: number of items that failed during this run. */
+    const val KEY_FAILED = "failed"
+}
+
+/**
+ * Abstraction that lets future callers (e.g. `SettingsViewModel`) trigger or cancel
+ * background embedding without a direct dependency on `EmbeddingWorker`.
+ *
+ * Bound to [EmbeddingSchedulerImpl] by [com.closet.core.data.di.DataModule].
+ */
+interface EmbeddingScheduler {
+    /**
+     * Enqueues the periodic embedding worker if not already scheduled.
+     * Safe to call on every app start — uses [androidx.work.ExistingPeriodicWorkPolicy.KEEP]
+     * so duplicate enqueues are no-ops.
+     */
+    fun schedule()
+
+    /** Cancels any pending or running embedding work. */
+    fun cancel()
+}

--- a/app-android/core/data/src/main/kotlin/com/closet/core/data/worker/EmbeddingWorker.kt
+++ b/app-android/core/data/src/main/kotlin/com/closet/core/data/worker/EmbeddingWorker.kt
@@ -93,7 +93,7 @@ class EmbeddingWorker @AssistedInject constructor(
         val total   = itemIds.size
         if (total == 0) {
             Timber.d("EmbeddingWorker: nothing to embed")
-            return@withContext Result.success(workDataOf(KEY_DONE to 0, KEY_FAILED to 0))
+            return@withContext Result.success(workDataOf(KEY_DONE to 0, KEY_TOTAL to 0, KEY_FAILED to 0))
         }
 
         val items = embeddingDao.getTextsForEmbedding(itemIds)
@@ -104,35 +104,37 @@ class EmbeddingWorker @AssistedInject constructor(
 
         val env = OrtEnvironment.getEnvironment()
         try {
-            env.createSession(modelBytes, OrtSession.SessionOptions()).use { session ->
-                for (item in items) {
-                    try {
-                        val text = buildString {
-                            append(item.semanticDescription)
-                            item.imageCaption?.let { append(' ').append(it) }
+            OrtSession.SessionOptions().use { options ->
+                env.createSession(modelBytes, options).use { session ->
+                    for (item in items) {
+                        try {
+                            val text = buildString {
+                                append(item.semanticDescription)
+                                item.imageCaption?.let { append(' ').append(it) }
+                            }
+
+                            val tokens = tokenizer.encode(text, MAX_SEQ_LEN)
+                            val vector = embed(env, session, tokens)
+
+                            embeddingDao.upsert(
+                                ItemEmbeddingEntity(
+                                    itemId        = item.id,
+                                    embeddingBlob = floatsToBlob(vector),
+                                    modelVersion  = MODEL_VERSION,
+                                    inputSnapshot = text,
+                                    embeddedAt    = Instant.now(),
+                                )
+                            )
+                            done++
+                        } catch (e: CancellationException) {
+                            throw e
+                        } catch (e: Exception) {
+                            Timber.e(e, "EmbeddingWorker: failed to embed item ${item.id}")
+                            failed++
                         }
 
-                        val tokens = tokenizer.encode(text, MAX_SEQ_LEN)
-                        val vector = embed(env, session, tokens)
-
-                        embeddingDao.upsert(
-                            ItemEmbeddingEntity(
-                                itemId        = item.id,
-                                embeddingBlob = floatsToBlob(vector),
-                                modelVersion  = MODEL_VERSION,
-                                inputSnapshot = text,
-                                embeddedAt    = Instant.now(),
-                            )
-                        )
-                        done++
-                    } catch (e: CancellationException) {
-                        throw e
-                    } catch (e: Exception) {
-                        Timber.e(e, "EmbeddingWorker: failed to embed item ${item.id}")
-                        failed++
+                        setProgress(workDataOf(KEY_DONE to done, KEY_TOTAL to total, KEY_FAILED to failed))
                     }
-
-                    setProgress(workDataOf(KEY_DONE to done, KEY_TOTAL to total, KEY_FAILED to failed))
                 }
             }
         } catch (e: CancellationException) {
@@ -143,7 +145,7 @@ class EmbeddingWorker @AssistedInject constructor(
         }
 
         Timber.d("EmbeddingWorker: done=$done failed=$failed total=$total")
-        return@withContext Result.success(workDataOf(KEY_DONE to done, KEY_FAILED to failed))
+        return@withContext Result.success(workDataOf(KEY_DONE to done, KEY_TOTAL to total, KEY_FAILED to failed))
     }
 
     // ─── Inference helpers ────────────────────────────────────────────────────

--- a/app-android/core/data/src/main/kotlin/com/closet/core/data/worker/EmbeddingWorker.kt
+++ b/app-android/core/data/src/main/kotlin/com/closet/core/data/worker/EmbeddingWorker.kt
@@ -162,24 +162,21 @@ class EmbeddingWorker @AssistedInject constructor(
         val seqLen = tokens.inputIds.size.toLong()
         val shape  = longArrayOf(1L, seqLen)
 
-        val inputIdsTensor  = OnnxTensor.createTensor(env, LongBuffer.wrap(tokens.inputIds),      shape)
-        val maskTensor      = OnnxTensor.createTensor(env, LongBuffer.wrap(tokens.attentionMask),  shape)
-        val typesTensor     = OnnxTensor.createTensor(env, LongBuffer.wrap(tokens.tokenTypeIds),   shape)
-        try {
-            val inputs = mapOf(
-                "input_ids"      to inputIdsTensor,
-                "attention_mask" to maskTensor,
-                "token_type_ids" to typesTensor,
-            )
-            session.run(inputs).use { result ->
-                @Suppress("UNCHECKED_CAST")
-                val hidden = (result[0].value as Array<Array<FloatArray>>)[0] // [seqLen][384]
-                return l2Normalize(meanPool(hidden, tokens.attentionMask))
+        OnnxTensor.createTensor(env, LongBuffer.wrap(tokens.inputIds), shape).use { inputIdsTensor ->
+            OnnxTensor.createTensor(env, LongBuffer.wrap(tokens.attentionMask), shape).use { maskTensor ->
+                OnnxTensor.createTensor(env, LongBuffer.wrap(tokens.tokenTypeIds), shape).use { typesTensor ->
+                    val inputs = mapOf(
+                        "input_ids"      to inputIdsTensor,
+                        "attention_mask" to maskTensor,
+                        "token_type_ids" to typesTensor,
+                    )
+                    session.run(inputs).use { result ->
+                        @Suppress("UNCHECKED_CAST")
+                        val hidden = (result[0].value as Array<Array<FloatArray>>)[0] // [seqLen][384]
+                        return l2Normalize(meanPool(hidden, tokens.attentionMask))
+                    }
+                }
             }
-        } finally {
-            inputIdsTensor.close()
-            maskTensor.close()
-            typesTensor.close()
         }
     }
 

--- a/app-android/core/data/src/main/kotlin/com/closet/core/data/worker/EmbeddingWorker.kt
+++ b/app-android/core/data/src/main/kotlin/com/closet/core/data/worker/EmbeddingWorker.kt
@@ -65,7 +65,7 @@ class EmbeddingWorker @AssistedInject constructor(
         private const val MODEL_ASSET = "models/arctic-embed-xs-q8.onnx"
         private const val VOCAB_ASSET  = "models/vocab.txt"
 
-        /** Embedding dimension of `all-MiniLM-L6-v2`. */
+        /** Embedding dimension of `snowflake-arctic-embed-xs`. */
         private const val HIDDEN_SIZE = 384
 
         /** Sequence length fed to the model — longer texts are truncated. */
@@ -117,9 +117,10 @@ class EmbeddingWorker @AssistedInject constructor(
 
                         embeddingDao.upsert(
                             ItemEmbeddingEntity(
-                                itemId       = item.id,
+                                itemId        = item.id,
                                 embeddingBlob = floatsToBlob(vector),
                                 modelVersion  = MODEL_VERSION,
+                                inputSnapshot = text,
                                 embeddedAt    = Instant.now(),
                             )
                         )
@@ -129,7 +130,6 @@ class EmbeddingWorker @AssistedInject constructor(
                     } catch (e: Exception) {
                         Timber.e(e, "EmbeddingWorker: failed to embed item ${item.id}")
                         failed++
-                        done++
                     }
 
                     setProgress(workDataOf(KEY_DONE to done, KEY_TOTAL to total, KEY_FAILED to failed))
@@ -162,20 +162,24 @@ class EmbeddingWorker @AssistedInject constructor(
         val seqLen = tokens.inputIds.size.toLong()
         val shape  = longArrayOf(1L, seqLen)
 
-        val inputIdsTensor  = OnnxTensor.createTensor(env, LongBuffer.wrap(tokens.inputIds),     shape)
-        val maskTensor      = OnnxTensor.createTensor(env, LongBuffer.wrap(tokens.attentionMask), shape)
-        val typesTensor     = OnnxTensor.createTensor(env, LongBuffer.wrap(tokens.tokenTypeIds),  shape)
-
-        val inputs = mapOf(
-            "input_ids"      to inputIdsTensor,
-            "attention_mask" to maskTensor,
-            "token_type_ids" to typesTensor,
-        )
-
-        session.run(inputs).use { result ->
-            @Suppress("UNCHECKED_CAST")
-            val hidden = (result[0].value as Array<Array<FloatArray>>)[0] // [seqLen][384]
-            return l2Normalize(meanPool(hidden, tokens.attentionMask))
+        val inputIdsTensor  = OnnxTensor.createTensor(env, LongBuffer.wrap(tokens.inputIds),      shape)
+        val maskTensor      = OnnxTensor.createTensor(env, LongBuffer.wrap(tokens.attentionMask),  shape)
+        val typesTensor     = OnnxTensor.createTensor(env, LongBuffer.wrap(tokens.tokenTypeIds),   shape)
+        try {
+            val inputs = mapOf(
+                "input_ids"      to inputIdsTensor,
+                "attention_mask" to maskTensor,
+                "token_type_ids" to typesTensor,
+            )
+            session.run(inputs).use { result ->
+                @Suppress("UNCHECKED_CAST")
+                val hidden = (result[0].value as Array<Array<FloatArray>>)[0] // [seqLen][384]
+                return l2Normalize(meanPool(hidden, tokens.attentionMask))
+            }
+        } finally {
+            inputIdsTensor.close()
+            maskTensor.close()
+            typesTensor.close()
         }
     }
 

--- a/app-android/core/data/src/main/kotlin/com/closet/core/data/worker/EmbeddingWorker.kt
+++ b/app-android/core/data/src/main/kotlin/com/closet/core/data/worker/EmbeddingWorker.kt
@@ -1,0 +1,222 @@
+package com.closet.core.data.worker
+
+import ai.onnxruntime.OnnxTensor
+import ai.onnxruntime.OrtEnvironment
+import ai.onnxruntime.OrtException
+import ai.onnxruntime.OrtSession
+import android.content.Context
+import androidx.hilt.work.HiltWorker
+import androidx.work.CoroutineWorker
+import androidx.work.WorkerParameters
+import androidx.work.workDataOf
+import com.closet.core.data.dao.EmbeddingDao
+import com.closet.core.data.model.ItemEmbeddingEntity
+import com.closet.core.data.util.TokenizerOutput
+import com.closet.core.data.util.WordPieceTokenizer
+import com.closet.core.data.worker.EmbeddingWork.KEY_DONE
+import com.closet.core.data.worker.EmbeddingWork.KEY_FAILED
+import com.closet.core.data.worker.EmbeddingWork.KEY_TOTAL
+import com.closet.core.data.worker.EmbeddingWork.MODEL_VERSION
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedInject
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import timber.log.Timber
+import java.io.IOException
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+import java.nio.LongBuffer
+import java.time.Instant
+import kotlin.math.sqrt
+
+/**
+ * Background worker that embeds every clothing item whose `semantic_description` is populated
+ * but has no up-to-date vector in `item_embeddings`.
+ *
+ * Runs only when the device is charging and idle (WorkManager constraints) so it never
+ * competes with foreground work. Scheduled as unique periodic work (1-hour interval) by
+ * [EmbeddingScheduler]; re-runs automatically as new items are saved.
+ *
+ * Per-item pipeline:
+ * 1. Concatenate `semanticDescription + " " + imageCaption` (caption optional).
+ * 2. Tokenise with [WordPieceTokenizer] (BERT WordPiece, `vocab.txt` from assets).
+ * 3. Run `snowflake-arctic-embed-xs` INT8 ONNX session → `last_hidden_state` [1, seq, 384].
+ * 4. Mean-pool over non-padding tokens → L2-normalise → 384-float unit vector.
+ * 5. Serialise as little-endian float32 BLOB → upsert into `item_embeddings`.
+ *
+ * **Asset requirements** (must be present before the worker produces results):
+ * - `assets/models/arctic-embed-xs-q8.onnx`  (~23 MB, INT8 quantized)
+ * - `assets/models/vocab.txt`                (~250 KB, BERT uncased vocabulary)
+ *
+ * If either asset is missing the worker returns [Result.failure] with an `"error"` key
+ * so WorkManager stops retrying until the next periodic interval.
+ */
+@HiltWorker
+class EmbeddingWorker @AssistedInject constructor(
+    @Assisted private val context: Context,
+    @Assisted params: WorkerParameters,
+    private val embeddingDao: EmbeddingDao,
+) : CoroutineWorker(context, params) {
+
+    companion object {
+        val WORK_NAME = EmbeddingWork.NAME
+
+        private const val MODEL_ASSET = "models/arctic-embed-xs-q8.onnx"
+        private const val VOCAB_ASSET  = "models/vocab.txt"
+
+        /** Embedding dimension of `all-MiniLM-L6-v2`. */
+        private const val HIDDEN_SIZE = 384
+
+        /** Sequence length fed to the model — longer texts are truncated. */
+        private const val MAX_SEQ_LEN = 128
+    }
+
+    override suspend fun doWork(): Result = withContext(Dispatchers.IO) {
+        // ── 1. Load assets ───────────────────────────────────────────────────
+        val modelBytes = try {
+            context.assets.open(MODEL_ASSET).use { it.readBytes() }
+        } catch (e: IOException) {
+            Timber.e(e, "EmbeddingWorker: model asset not found at $MODEL_ASSET — add the ONNX file to assets/models/")
+            return@withContext Result.failure(workDataOf("error" to "model_not_found"))
+        }
+
+        val tokenizer = try {
+            WordPieceTokenizer(context.assets.open(VOCAB_ASSET))
+        } catch (e: IOException) {
+            Timber.e(e, "EmbeddingWorker: vocab asset not found at $VOCAB_ASSET — add vocab.txt to assets/models/")
+            return@withContext Result.failure(workDataOf("error" to "vocab_not_found"))
+        }
+
+        // ── 2. Determine work queue ──────────────────────────────────────────
+        val itemIds = embeddingDao.getItemIdsNeedingEmbedding(MODEL_VERSION)
+        val total   = itemIds.size
+        if (total == 0) {
+            Timber.d("EmbeddingWorker: nothing to embed")
+            return@withContext Result.success(workDataOf(KEY_DONE to 0, KEY_FAILED to 0))
+        }
+
+        val items = embeddingDao.getTextsForEmbedding(itemIds)
+
+        // ── 3. Open ONNX session and embed ───────────────────────────────────
+        var done   = 0
+        var failed = 0
+
+        val env = OrtEnvironment.getEnvironment()
+        try {
+            env.createSession(modelBytes, OrtSession.SessionOptions()).use { session ->
+                for (item in items) {
+                    try {
+                        val text = buildString {
+                            append(item.semanticDescription)
+                            item.imageCaption?.let { append(' ').append(it) }
+                        }
+
+                        val tokens = tokenizer.encode(text, MAX_SEQ_LEN)
+                        val vector = embed(env, session, tokens)
+
+                        embeddingDao.upsert(
+                            ItemEmbeddingEntity(
+                                itemId       = item.id,
+                                embeddingBlob = floatsToBlob(vector),
+                                modelVersion  = MODEL_VERSION,
+                                embeddedAt    = Instant.now(),
+                            )
+                        )
+                        done++
+                    } catch (e: CancellationException) {
+                        throw e
+                    } catch (e: Exception) {
+                        Timber.e(e, "EmbeddingWorker: failed to embed item ${item.id}")
+                        failed++
+                        done++
+                    }
+
+                    setProgress(workDataOf(KEY_DONE to done, KEY_TOTAL to total, KEY_FAILED to failed))
+                }
+            }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: OrtException) {
+            Timber.e(e, "EmbeddingWorker: ONNX session error")
+            return@withContext Result.failure(workDataOf("error" to "onnx_session_failed"))
+        }
+
+        Timber.d("EmbeddingWorker: done=$done failed=$failed total=$total")
+        return@withContext Result.success(workDataOf(KEY_DONE to done, KEY_FAILED to failed))
+    }
+
+    // ─── Inference helpers ────────────────────────────────────────────────────
+
+    /**
+     * Runs one ONNX inference pass and returns an L2-normalised 384-float embedding.
+     *
+     * Inputs: `input_ids`, `attention_mask`, `token_type_ids` — all Long[1][seqLen].
+     * Output: `last_hidden_state` Float[1][seqLen][384] → mean-pool → L2-normalise.
+     */
+    private fun embed(
+        env: OrtEnvironment,
+        session: OrtSession,
+        tokens: TokenizerOutput,
+    ): FloatArray {
+        val seqLen = tokens.inputIds.size.toLong()
+        val shape  = longArrayOf(1L, seqLen)
+
+        val inputIdsTensor  = OnnxTensor.createTensor(env, LongBuffer.wrap(tokens.inputIds),     shape)
+        val maskTensor      = OnnxTensor.createTensor(env, LongBuffer.wrap(tokens.attentionMask), shape)
+        val typesTensor     = OnnxTensor.createTensor(env, LongBuffer.wrap(tokens.tokenTypeIds),  shape)
+
+        val inputs = mapOf(
+            "input_ids"      to inputIdsTensor,
+            "attention_mask" to maskTensor,
+            "token_type_ids" to typesTensor,
+        )
+
+        session.run(inputs).use { result ->
+            @Suppress("UNCHECKED_CAST")
+            val hidden = (result[0].value as Array<Array<FloatArray>>)[0] // [seqLen][384]
+            return l2Normalize(meanPool(hidden, tokens.attentionMask))
+        }
+    }
+
+    /**
+     * Mean-pools token embeddings, weighting only real (non-padding) positions
+     * (attention mask == 1).
+     */
+    private fun meanPool(hidden: Array<FloatArray>, attentionMask: LongArray): FloatArray {
+        val sum   = FloatArray(HIDDEN_SIZE)
+        var count = 0
+        for (i in hidden.indices) {
+            if (attentionMask[i] == 1L) {
+                val tok = hidden[i]
+                for (j in 0 until HIDDEN_SIZE) sum[j] += tok[j]
+                count++
+            }
+        }
+        if (count > 0) for (j in sum.indices) sum[j] /= count
+        return sum
+    }
+
+    /** Divides [vector] by its L2 norm, producing a unit vector for cosine similarity. */
+    private fun l2Normalize(vector: FloatArray): FloatArray {
+        var norm = 0f
+        for (v in vector) norm += v * v
+        norm = sqrt(norm)
+        return if (norm > 1e-12f) FloatArray(vector.size) { vector[it] / norm } else vector
+    }
+
+    /**
+     * Serialises [floats] as a little-endian float32 byte array for BLOB storage.
+     *
+     * Decode with:
+     * ```kotlin
+     * ByteBuffer.wrap(blob).order(ByteOrder.LITTLE_ENDIAN).asFloatBuffer()
+     *     .let { FloatArray(it.remaining()).also { arr -> it.get(arr) } }
+     * ```
+     */
+    private fun floatsToBlob(floats: FloatArray): ByteArray =
+        ByteBuffer.allocate(floats.size * 4)
+            .order(ByteOrder.LITTLE_ENDIAN)
+            .apply { asFloatBuffer().put(floats) }
+            .array()
+}

--- a/app-android/features/wardrobe/build.gradle.kts
+++ b/app-android/features/wardrobe/build.gradle.kts
@@ -24,6 +24,7 @@ android {
 
     buildFeatures {
         compose = true
+        buildConfig = true
     }
 
     compileOptions {

--- a/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/BatchSegmentationWorker.kt
+++ b/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/BatchSegmentationWorker.kt
@@ -11,12 +11,16 @@ import android.os.Build
 import androidx.annotation.RequiresApi
 import androidx.core.app.NotificationCompat
 import androidx.hilt.work.HiltWorker
+import androidx.palette.graphics.Palette
 import androidx.work.CoroutineWorker
 import androidx.work.ForegroundInfo
 import androidx.work.WorkerParameters
 import androidx.work.workDataOf
 import com.closet.core.data.dao.ClothingDao
+import com.closet.core.data.dao.LookupDao
+import com.closet.core.data.repository.ClothingRepository
 import com.closet.core.data.repository.StorageRepository
+import com.closet.core.data.util.ColorMatcher
 import com.closet.core.data.worker.BatchSegmentationWork
 import com.closet.features.wardrobe.repository.SegmentationRepository
 import dagger.assisted.Assisted
@@ -47,8 +51,10 @@ class BatchSegmentationWorker @AssistedInject constructor(
     @Assisted private val context: Context,
     @Assisted params: WorkerParameters,
     private val clothingDao: ClothingDao,
+    private val lookupDao: LookupDao,
     private val storageRepository: StorageRepository,
     private val segmentationRepository: SegmentationRepository,
+    private val clothingRepository: ClothingRepository,
 ) : CoroutineWorker(context, params) {
 
     companion object {
@@ -117,6 +123,36 @@ class BatchSegmentationWorker @AssistedInject constructor(
                             .onFailure { Timber.d(it, "BatchSeg: failed to delete orphaned PNG $path") }
                     }
                     throw e
+                }
+
+                // Best-effort: re-extract colours from the masked bitmap and refresh the
+                // semantic description. The Palette API skips transparent pixels so only
+                // subject colours are sampled — not the removed background.
+                // Runs inline (worker is already on IO); failure never marks the item as failed.
+                try {
+                    val palette = Palette.from(masked).generate()
+                    val extracted = listOfNotNull(
+                        palette.dominantSwatch?.rgb,
+                        palette.vibrantSwatch?.rgb,
+                        palette.mutedSwatch?.rgb,
+                    ).distinct()
+                    if (extracted.isNotEmpty()) {
+                        val availableColors = lookupDao.getAllColors()
+                        if (availableColors.isNotEmpty()) {
+                            val matched = extracted
+                                .map { ColorMatcher.findNearestColor(it, availableColors) }
+                                .distinctBy { it.id }
+                            clothingRepository.updateItemColors(item.id, matched.map { it.id })
+                            Timber.d("BatchSeg: item ${item.id} colours → ${matched.joinToString { it.name }}")
+                            clothingRepository.revectorizeItem(item.id)
+                        }
+                    } else {
+                        Timber.d("BatchSeg: item ${item.id} — no swatches extracted from masked bitmap")
+                    }
+                } catch (e: CancellationException) {
+                    throw e
+                } catch (e: Exception) {
+                    Timber.w(e, "BatchSeg: colour re-extraction failed for item ${item.id} — ignored")
                 }
 
                 // Delete the original file best-effort — a failure here is not fatal

--- a/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/ClothingDetailScreen.kt
+++ b/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/ClothingDetailScreen.kt
@@ -26,6 +26,7 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import coil.compose.AsyncImage
+import com.closet.features.wardrobe.BuildConfig
 import com.closet.core.data.dao.ItemWearLog
 import com.closet.core.data.model.*
 import com.closet.core.ui.R as CoreR
@@ -335,6 +336,13 @@ fun ClothingDetailScreen(
                         )
 
                         Spacer(modifier = Modifier.height(16.dp))
+
+                        if (BuildConfig.DEBUG) {
+                            SemanticDebugCard(
+                                semanticDescription = detail.item.semanticDescription,
+                                imageCaption = detail.item.imageCaption,
+                            )
+                        }
                     }
                 }
             }

--- a/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/ClothingFormViewModel.kt
+++ b/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/ClothingFormViewModel.kt
@@ -598,9 +598,14 @@ class ClothingFormViewModel @Inject constructor(
                         val availableColors = allColors.value
                         val matched = extracted.map { ColorMatcher.findNearestColor(it, availableColors) }.distinct()
                         if (matched.isNotEmpty()) {
+                            Timber.d("extractColors: ${file.name} → ${matched.joinToString { it.name }}")
                             _form.update { it.copy(selectedColors = matched) }
                         }
+                    } else {
+                        Timber.d("extractColors: ${file.name} → no swatches extracted")
                     }
+                } else {
+                    Timber.d("extractColors: ${file.name} → bitmap decode returned null")
                 }
             } catch (e: Exception) {
                 Timber.d(e, "color extraction failed")

--- a/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/ClothingFormViewModel.kt
+++ b/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/ClothingFormViewModel.kt
@@ -485,6 +485,7 @@ class ClothingFormViewModel @Inject constructor(
                     ?: throw IllegalStateException("Could not decode image file: $path")
                 val masked = segmentationRepository.removeBackground(bitmap)
                 val savedPath = storageRepository.saveBitmap(masked, "${UUID.randomUUID()}.png")
+                val segmentedFile = storageRepository.getFile(savedPath)
                 _form.update { it.copy(
                     imagePath = savedPath,
                     hasSegmentedImage = true,
@@ -492,9 +493,12 @@ class ClothingFormViewModel @Inject constructor(
                     imageCaption = null,                      // old caption was for the un-segmented image
                     originalSegmentationImageCaption = null,  // stash consumed; caption lifecycle restarts
                 ) }
+                // Re-extract colours from the segmented PNG. The Palette API filters out
+                // transparent pixels, so only subject colours are sampled — not the background.
+                extractColorsFromFile(segmentedFile)
                 // Re-caption the segmented image on Main (Image Description API requirement).
                 if (imageCaptionRepository.isSupported) {
-                    launchCaptionJob(savedPath, storageRepository.getFile(savedPath))
+                    launchCaptionJob(savedPath, segmentedFile)
                 }
             } catch (e: CancellationException) {
                 throw e

--- a/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/SemanticDebugCard.kt
+++ b/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/SemanticDebugCard.kt
@@ -107,12 +107,14 @@ private fun SemanticDebugSheetContent(
             label = "Semantic description",
             value = semanticDescription,
             onCopy = { clipboardManager.setText(AnnotatedString(semanticDescription ?: "")) },
+            copyContentDescription = "Copy semantic description",
         )
         Spacer(Modifier.height(12.dp))
         DebugTextField(
             label = "Image caption",
             value = imageCaption,
             onCopy = { clipboardManager.setText(AnnotatedString(imageCaption ?: "")) },
+            copyContentDescription = "Copy image caption",
         )
         Spacer(Modifier.height(16.dp))
     }
@@ -123,6 +125,7 @@ private fun DebugTextField(
     label: String,
     value: String?,
     onCopy: () -> Unit,
+    copyContentDescription: String,
 ) {
     OutlinedTextField(
         value = value ?: "Not yet generated",
@@ -136,7 +139,7 @@ private fun DebugTextField(
         trailingIcon = {
             if (value != null) {
                 IconButton(onClick = onCopy) {
-                    Icon(Icons.Default.ContentCopy, contentDescription = "Copy")
+                    Icon(Icons.Default.ContentCopy, contentDescription = copyContentDescription)
                 }
             }
         },

--- a/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/SemanticDebugCard.kt
+++ b/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/SemanticDebugCard.kt
@@ -1,0 +1,146 @@
+package com.closet.features.wardrobe
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
+import androidx.compose.material.icons.filled.ContentCopy
+import androidx.compose.material3.Badge
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.LocalTextStyle
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.OutlinedCard
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalClipboardManager
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.unit.dp
+
+/**
+ * Debug-only card that surfaces `semantic_description` and `image_caption` for a clothing item.
+ *
+ * Tapping opens a [ModalBottomSheet] where both fields are shown as read-only text with
+ * a Copy button. Intended for data-quality inspection during Phase 1 iteration.
+ *
+ * **Only rendered when [BuildConfig.DEBUG] is true — never shown in release builds.**
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+internal fun SemanticDebugCard(
+    semanticDescription: String?,
+    imageCaption: String?,
+) {
+    var showSheet by remember { mutableStateOf(false) }
+
+    OutlinedCard(
+        onClick = { showSheet = true },
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = 8.dp),
+    ) {
+        Row(
+            modifier = Modifier.padding(12.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Badge { Text("DEV") }
+            Spacer(Modifier.width(8.dp))
+            Text(
+                text = "Semantic data",
+                style = MaterialTheme.typography.labelMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Spacer(Modifier.weight(1f))
+            Icon(
+                imageVector = Icons.AutoMirrored.Filled.KeyboardArrowRight,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+    }
+
+    if (showSheet) {
+        ModalBottomSheet(onDismissRequest = { showSheet = false }) {
+            SemanticDebugSheetContent(
+                semanticDescription = semanticDescription,
+                imageCaption = imageCaption,
+            )
+        }
+    }
+}
+
+@Composable
+private fun SemanticDebugSheetContent(
+    semanticDescription: String?,
+    imageCaption: String?,
+) {
+    val clipboardManager = LocalClipboardManager.current
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp)
+            .padding(bottom = 32.dp)
+            .verticalScroll(rememberScrollState()),
+    ) {
+        Text(
+            text = "Semantic data inspector",
+            style = MaterialTheme.typography.titleMedium,
+            modifier = Modifier.padding(vertical = 12.dp),
+        )
+        DebugTextField(
+            label = "Semantic description",
+            value = semanticDescription,
+            onCopy = { clipboardManager.setText(AnnotatedString(semanticDescription ?: "")) },
+        )
+        Spacer(Modifier.height(12.dp))
+        DebugTextField(
+            label = "Image caption",
+            value = imageCaption,
+            onCopy = { clipboardManager.setText(AnnotatedString(imageCaption ?: "")) },
+        )
+        Spacer(Modifier.height(16.dp))
+    }
+}
+
+@Composable
+private fun DebugTextField(
+    label: String,
+    value: String?,
+    onCopy: () -> Unit,
+) {
+    OutlinedTextField(
+        value = value ?: "Not yet generated",
+        onValueChange = {},
+        readOnly = true,
+        label = { Text(label) },
+        textStyle = LocalTextStyle.current.copy(
+            color = if (value == null) MaterialTheme.colorScheme.onSurfaceVariant
+                    else MaterialTheme.colorScheme.onSurface,
+        ),
+        trailingIcon = {
+            if (value != null) {
+                IconButton(onClick = onCopy) {
+                    Icon(Icons.Default.ContentCopy, contentDescription = "Copy")
+                }
+            }
+        },
+        modifier = Modifier.fillMaxWidth(),
+        minLines = 3,
+    )
+}

--- a/app-android/gradle/libs.versions.toml
+++ b/app-android/gradle/libs.versions.toml
@@ -34,6 +34,7 @@ mlkitSubjectSegmentation = "16.0.0-beta1" # beta accepted; no stable release exi
 kotlinxCoroutinesPlayServices = "1.10.2"
 work = "2.10.0"
 hiltWork = "1.2.0"
+onnxRuntime = "1.21.0"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "androidxCore" }
@@ -84,6 +85,7 @@ kotlinx-coroutines-play-services = { group = "org.jetbrains.kotlinx", name = "ko
 androidx-work-runtime-ktx = { group = "androidx.work", name = "work-runtime-ktx", version.ref = "work" }
 androidx-hilt-work = { group = "androidx.hilt", name = "hilt-work", version.ref = "hiltWork" }
 androidx-hilt-compiler = { group = "androidx.hilt", name = "hilt-compiler", version.ref = "hiltWork" }
+onnx-runtime-android = { group = "com.microsoft.onnxruntime", name = "onnxruntime-android", version.ref = "onnxRuntime" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }

--- a/app-android/rag-roadmap.md
+++ b/app-android/rag-roadmap.md
@@ -334,11 +334,14 @@ onnx-runtime-android = { group = "com.microsoft.onnxruntime", name = "onnxruntim
 
 No flavor split needed — ONNX Runtime is Apache-2 with no GMS dependency.
 
-### Model: `all-MiniLM-L6-v2` (quantized INT8)
+### Model: `snowflake-arctic-embed-xs` (quantized INT8)
 
-- Produces 384-dimensional sentence embeddings; well-suited to short prose descriptions
-- INT8 quantized `.onnx` file: ~22 MB (ships in `core/data/src/main/assets/models/`)
-- Tokenizer vocab file (≈ 250 KB) alongside the model
+- Produces 384-dimensional sentence embeddings; Apache 2.0 license, no GMS dependency
+- Stronger retrieval quality than `all-MiniLM-L6-v2` at the same dimension / size point —
+  meaningfully better Phase 4+ chat relevance with zero schema or pipeline changes
+- INT8 quantized `.onnx` file: ~23 MB (ships in `core/data/src/main/assets/models/arctic-embed-xs-q8.onnx`)
+- Tokenizer vocab file (≈ 250 KB) at `core/data/src/main/assets/models/vocab.txt`
+- BERT WordPiece tokenizer (same as MiniLM) — `input_ids`, `attention_mask`, `token_type_ids`
 - Mean-pooling of token embeddings → L2-normalise → 384-float vector
 
 ### `EmbeddingWorker`

--- a/app-android/rag-roadmap.md
+++ b/app-android/rag-roadmap.md
@@ -490,3 +490,183 @@ The chat history is in-memory only for the session (no persistence needed in v1)
 > Run migration tests (`./gradlew connectedAndroidTest`) before any PR that touches
 > the schema. The existing `MigrationTest.kt` pattern in `core/data/src/androidTest`
 > must be extended to cover Migration 3→4.
+
+---
+
+## Debug — Semantic Description Inspector (dev builds only)
+
+A lightweight diagnostic card on the Item Detail screen that surfaces
+`semantic_description` and `image_caption` directly, so you can inspect data
+quality as Phase 1 iterates without shipping any user-facing RAG UI.
+
+**Scope:** `BuildConfig.DEBUG` only. No Phase 2–4 dependencies. No new DB queries —
+reads from the `ClothingItemDetail` already loaded by `ItemDetailViewModel`.
+
+---
+
+### Behaviour
+
+- A subtly styled "Dev" card appears at the bottom of `ItemDetailScreen`, below all
+  production content. It is invisible in release builds (guarded by
+  `if (BuildConfig.DEBUG)`).
+- Tapping the card opens a `ModalBottomSheet` displaying:
+  - **Semantic description** — the structured prose from `ItemVectorizer`
+    (`ClothingItemDetail.semanticDescription`), or a muted placeholder
+    `"Not yet generated"` when null.
+  - **Image caption** — the AI photo caption (`ClothingItemDetail.imageCaption`),
+    or `"Not yet generated"` when null.
+- A "Copy" icon button next to each field copies the raw text to the clipboard
+  (`ClipboardManager`) so you can paste it into notes or compare revisions.
+- The sheet has no edit controls — it is read-only.
+
+---
+
+### Implementation sketch
+
+**`ItemDetailScreen.kt`**
+
+```kotlin
+// At the bottom of the screen content, inside a Column:
+if (BuildConfig.DEBUG) {
+    SemanticDebugCard(
+        semanticDescription = uiState.item?.semanticDescription,
+        imageCaption        = uiState.item?.imageCaption,
+    )
+}
+```
+
+**`SemanticDebugCard` composable** (can live in
+`features/wardrobe/src/main/kotlin/.../ui/component/SemanticDebugCard.kt` or
+inline in the screen file if you prefer to keep it local):
+
+```kotlin
+@Composable
+fun SemanticDebugCard(
+    semanticDescription: String?,
+    imageCaption: String?,
+) {
+    var showSheet by remember { mutableStateOf(false) }
+
+    // Trigger card — tappable row with a debug badge
+    OutlinedCard(
+        onClick = { showSheet = true },
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 8.dp),
+        border = BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant),
+    ) {
+        Row(
+            modifier = Modifier.padding(12.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Badge { Text("DEV") }
+            Spacer(Modifier.width(8.dp))
+            Text(
+                "Semantic data",
+                style = MaterialTheme.typography.labelMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Spacer(Modifier.weight(1f))
+            Icon(
+                Icons.Default.ChevronRight,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+    }
+
+    // Bottom sheet
+    if (showSheet) {
+        ModalBottomSheet(onDismissRequest = { showSheet = false }) {
+            SemanticDebugSheetContent(
+                semanticDescription = semanticDescription,
+                imageCaption        = imageCaption,
+                onDismiss           = { showSheet = false },
+            )
+        }
+    }
+}
+
+@Composable
+private fun SemanticDebugSheetContent(
+    semanticDescription: String?,
+    imageCaption: String?,
+    onDismiss: () -> Unit,
+) {
+    val clipboardManager = LocalClipboardManager.current
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp)
+            .padding(bottom = 32.dp)
+            .verticalScroll(rememberScrollState()),
+    ) {
+        Text(
+            "Semantic data inspector",
+            style = MaterialTheme.typography.titleMedium,
+            modifier = Modifier.padding(vertical = 12.dp),
+        )
+        DebugTextField(
+            label = "Semantic description",
+            value = semanticDescription,
+            onCopy = { clipboardManager.setText(AnnotatedString(semanticDescription ?: "")) },
+        )
+        Spacer(Modifier.height(12.dp))
+        DebugTextField(
+            label = "Image caption",
+            value = imageCaption,
+            onCopy = { clipboardManager.setText(AnnotatedString(imageCaption ?: "")) },
+        )
+    }
+}
+
+@Composable
+private fun DebugTextField(label: String, value: String?, onCopy: () -> Unit) {
+    val display = value ?: "Not yet generated"
+    val muted   = value == null
+    OutlinedTextField(
+        value = display,
+        onValueChange = {},
+        readOnly = true,
+        label = { Text(label) },
+        textStyle = LocalTextStyle.current.copy(
+            color = if (muted) MaterialTheme.colorScheme.onSurfaceVariant
+                    else MaterialTheme.colorScheme.onSurface,
+        ),
+        trailingIcon = {
+            if (value != null) {
+                IconButton(onClick = onCopy) {
+                    Icon(Icons.Default.ContentCopy, contentDescription = "Copy")
+                }
+            }
+        },
+        modifier = Modifier.fillMaxWidth(),
+        minLines = 3,
+    )
+}
+```
+
+---
+
+### What to expose
+
+| Field | Source | Notes |
+|-------|--------|-------|
+| `semanticDescription` | `ClothingItemDetail.semanticDescription` | Populated by `ItemVectorizer` on every save |
+| `imageCaption` | `ClothingItemDetail.imageCaption` | Populated at-capture or via Batch Enrichment |
+
+Both fields are already loaded by `ItemDetailViewModel` as part of the normal
+`ClothingItemDetail` fetch — no extra DAO query needed.
+
+---
+
+### Files to touch
+
+| File | Change |
+|------|--------|
+| `features/wardrobe/src/main/kotlin/.../ui/ItemDetailScreen.kt` | Add `if (BuildConfig.DEBUG)` guard + `SemanticDebugCard` call |
+| `features/wardrobe/src/main/kotlin/.../ui/component/SemanticDebugCard.kt` | New file — composable + sheet content (or inline in screen) |
+
+> This section can be implemented at any point during Phase 1 iteration.
+> Delete (or keep behind the debug flag permanently) once Phase 4 ships a real
+> data-quality workflow.

--- a/app-android/rag-roadmap.md
+++ b/app-android/rag-roadmap.md
@@ -372,7 +372,7 @@ Constants (same `BatchSegmentationWork` pattern):
 ```kotlin
 object EmbeddingWork {
     const val NAME = "embedding_worker"
-    const val MODEL_VERSION = "minilm-l6-v2-q8-v1"
+    const val MODEL_VERSION = "arctic-embed-xs-q8-v1"
     const val KEY_DONE = "done"
     const val KEY_TOTAL = "total"
     const val KEY_FAILED = "failed"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  - Dev-only "Semantic Description Inspector" card on item details (debug builds).
  - Background periodic embedding job scheduled at app startup (idempotent, debug builds).
  - On-device embedding pipeline: tokenizer, ONNX runtime inference, worker/scheduler, and local embedding storage.
  - Automatic color re-extraction after segmentation with optional re-vectorization.

* **Chores**
  - Database schema and migrations updated to store embeddings and input snapshots.
  - BuildConfig enabled and ONNX/WorkManager dependencies added.
  - App version bumped and CHANGELOG added.

* **Bug Fixes**
  - Color re-extraction failures are non-fatal and logged.

* **Documentation**
  - Roadmap updated with embedding model and tokenizer details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->