### PR TITLE
Add wardrobe item editing and multi-attribute selection

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,9 +31,16 @@ There are no tests yet.
 ### Routing
 expo-router with file-based routing. All screens live in `hangr/app/`:
 - `(tabs)/index.tsx` — Closet screen (main screen, grid/list)
+- `(tabs)/outfits.tsx` — Outfits tab
+- `(tabs)/journal.tsx` — Outfit log journal
+- `(tabs)/stats.tsx` — Stats tab
+- `(tabs)/settings.tsx` — Settings tab
 - `item/add.tsx` — Add Item
 - `item/[id].tsx` — Item Detail
 - `item/[id]/edit.tsx` — Edit Item
+- `log/new.tsx` — Log a new outfit wear
+- `log/[id].tsx` — Log entry detail
+- `outfit/[id]/` — Outfit detail and editing
 - `_layout.tsx` — Root layout: initializes DB, wraps with `AccentProvider` + `ThemeProvider`
 
 ### Database

--- a/app-android/CLAUDE.md
+++ b/app-android/CLAUDE.md
@@ -37,8 +37,8 @@ Unit and instrumented tests exist for the stats feature. Migration tests live in
 app/                   — Application entry point, NavGraph, MainActivity
 core/data/             — Database, DAOs, Repositories, entities, DI module
 core/ui/               — Material 3 theme, shared Composable components
-features/wardrobe/     — Closet screen, item detail, add/edit form
-features/outfits/      — Outfit builder, OOTD (in progress / placeholder)
+features/wardrobe/     — Closet screen, item detail, add/edit form, bulk wash, brand management
+features/outfits/      — Outfits screen, outfit builder, OOTD journal, wardrobe picker, day detail sheet
 features/stats/        — Stats screen, StatsViewModel, breakdown sections
 features/recommendations/ — Outfit recommendations, AI providers (NanoProvider, AnthropicProvider, OpenAiProvider)
 features/settings/     — Settings screen, AI toggle, model picker, key management
@@ -69,7 +69,7 @@ Hilt throughout. `@HiltAndroidApp` on `ClosetApp`, `@AndroidEntryPoint` on `Main
 
 ### Database (Room)
 
-- **File:** `closet.db`, current version **1** (chain reset 2026-03-22 — pre-release, no shipped installs).
+- **File:** `closet.db`, current version **6**.
 - **Initialization order:** `PRAGMA foreign_keys = ON` → create tables → `DatabaseSeeder` seeds lookup data on `onCreate`.
 - **Migrations** live in `ClothingDatabase.kt`. Never edit an applied migration — add a new one. Room schema JSON is exported to `core/data/schemas/`.
 - **Junction tables** (`clothing_item_colors`, `_materials`, `_seasons`, `_occasions`, `_patterns`) use delete-then-insert helpers in `ClothingRepository`. Never append.
@@ -118,6 +118,7 @@ Two distinct MLKit namespaces — do not confuse them:
 | File | Purpose |
 |------|---------|
 | `app/src/.../navigation/ClosetNavGraph.kt` | Root `NavHost` — all routes registered here |
+| `app/src/.../shortcuts/ShortcutActions.kt` | App shortcut constants (IDs, actions, extras) — shared hub for `shortcuts.xml`, `MainActivity`, `ClosetNavGraph`, and `ClosetViewModel` |
 | `core/data/src/.../ClothingDatabase.kt` | Room DB, migrations, `DatabaseSeeder` invocation |
 | `core/data/src/.../dao/ClothingDao.kt` | Clothing queries with `wear_count` join |
 | `core/data/src/.../repository/ClothingRepository.kt` | CRUD, junction helpers, `DataResult` wrapping |

--- a/app-android/app/src/main/kotlin/com/closet/navigation/ClosetNavGraph.kt
+++ b/app-android/app/src/main/kotlin/com/closet/navigation/ClosetNavGraph.kt
@@ -220,7 +220,10 @@ fun ClosetNavGraph(
                 onItemClick = { itemId -> navController.navigate(ClothingDetailDestination(itemId)) }
             )
 
-            settingsScreen(onNavigateUp = { navController.popBackStack() })
+            settingsScreen(
+                onNavigateUp = { navController.popBackStack() },
+                onNavigateToBulkWash = { navController.navigate(BulkWashDestination) },
+            )
         }
     }
 }

--- a/app-android/app/src/main/kotlin/com/closet/navigation/ClosetNavGraph.kt
+++ b/app-android/app/src/main/kotlin/com/closet/navigation/ClosetNavGraph.kt
@@ -209,11 +209,9 @@ fun ClosetNavGraph(
 
             recommendationScreen(
                 onNavigateUp = { navController.popBackStack() },
-                // TODO: wire "Log it" — OutfitBuilderDestination supports editing existing outfits
-                //  (via outfitId) but not pre-populating a new outfit with specific item IDs.
-                //  To implement this, add a `preselectedItemIds: List<Long>` param to
-                //  OutfitBuilderDestination and update OutfitBuilderViewModel accordingly.
-                onNavigateToLog = null,
+                onNavigateToLog = { itemIds ->
+                    navController.navigate(OutfitBuilderDestination(preselectedItemIds = itemIds))
+                },
                 onNavigateToSettings = { navController.navigateToSettings() },
             )
             journalScreen()

--- a/app-android/core/data/src/main/kotlin/com/closet/core/data/dao/ClothingDao.kt
+++ b/app-android/core/data/src/main/kotlin/com/closet/core/data/dao/ClothingDao.kt
@@ -6,13 +6,17 @@ import kotlinx.coroutines.flow.Flow
 
 /**
  * Correlated subquery that counts distinct outfit log entries for a clothing item.
+ * Joins via [outfit_log_items] (the historical snapshot table) rather than [outfit_items]
+ * (live outfit membership) so that:
+ *  - ad-hoc single-item wear logs (outfit_id = null) are included, and
+ *  - items removed from an outfit after logging still count as worn.
  * Requires the `ci` alias to be in scope (clothing_items). Alias `wear_count` is included.
  */
 private const val WEAR_COUNT_SUBQUERY = """(
         SELECT COUNT(DISTINCT ol.id)
         FROM outfit_logs ol
-        JOIN outfit_items oi ON ol.outfit_id = oi.outfit_id
-        WHERE oi.clothing_item_id = ci.id
+        JOIN outfit_log_items oli ON oli.outfit_log_id = ol.id
+        WHERE oli.clothing_item_id = ci.id
     ) AS wear_count"""
 
 /**

--- a/app-android/core/data/src/main/kotlin/com/closet/core/data/dao/ClothingDao.kt
+++ b/app-android/core/data/src/main/kotlin/com/closet/core/data/dao/ClothingDao.kt
@@ -136,6 +136,12 @@ interface ClothingDao {
     @Query("UPDATE clothing_items SET is_favorite = :isFavorite, updated_at = :updatedAt WHERE id = :id")
     suspend fun updateFavoriteStatus(id: Long, isFavorite: Int, updatedAt: String)
 
+    /**
+     * Updates the lifecycle status and modification timestamp for a specific clothing item.
+     */
+    @Query("UPDATE clothing_items SET status = :status, updated_at = :updatedAt WHERE id = :id")
+    suspend fun updateItemStatus(id: Long, status: String, updatedAt: String)
+
     // --- Junction Table Helpers (Atomically replace associations) ---
 
     /**

--- a/app-android/core/data/src/main/kotlin/com/closet/core/data/dao/LogDao.kt
+++ b/app-android/core/data/src/main/kotlin/com/closet/core/data/dao/LogDao.kt
@@ -151,6 +151,14 @@ interface LogDao {
     suspend fun insertSnapshotRows(logId: Long, outfitId: Long)
 
     /**
+     * Inserts a list of ad-hoc snapshot rows directly from clothing item IDs.
+     * Used when logging a wear with no associated outfit ([OutfitLogEntity.outfitId] = null).
+     * [OutfitLogItemEntity.outfitName] is left null — the UI falls back to its "untitled" string.
+     */
+    @Insert(onConflict = OnConflictStrategy.IGNORE)
+    suspend fun insertSnapshotItems(items: List<OutfitLogItemEntity>)
+
+    /**
      * Atomically inserts an outfit log and immediately snapshots its item membership.
      * If [log.outfitId] is null (free-form log) no snapshot rows are written.
      * @return The row ID of the newly inserted log.
@@ -160,6 +168,21 @@ interface LogDao {
         val logId = insertLog(log)
         if (log.outfitId != null) {
             insertSnapshotRows(logId, log.outfitId)
+        }
+        return logId
+    }
+
+    /**
+     * Atomically inserts an ad-hoc wear log (no outfit) and snapshots the given [itemIds]
+     * into [outfit_log_items]. Use this for single-item or multi-item wear logging that
+     * doesn't involve a saved outfit ([OutfitLogEntity.outfitId] must be null).
+     * @return The row ID of the newly inserted log.
+     */
+    @Transaction
+    suspend fun insertAdHocLogAndSnapshot(log: OutfitLogEntity, itemIds: List<Long>): Long {
+        val logId = insertLog(log)
+        if (itemIds.isNotEmpty()) {
+            insertSnapshotItems(itemIds.map { OutfitLogItemEntity(logId, it, outfitName = null) })
         }
         return logId
     }

--- a/app-android/core/data/src/main/kotlin/com/closet/core/data/dao/LogDao.kt
+++ b/app-android/core/data/src/main/kotlin/com/closet/core/data/dao/LogDao.kt
@@ -43,6 +43,13 @@ interface LogDao {
     suspend fun getLogIdByOutfitAndDate(outfitId: Long, date: String): Long?
 
     /**
+     * Returns the row ID of the existing ad-hoc (outfit_id = null) log for [date], or null.
+     * Used to enforce one ad-hoc log per calendar day (idempotency for [wearItemsToday]).
+     */
+    @Query("SELECT id FROM outfit_logs WHERE outfit_id IS NULL AND date = :date LIMIT 1")
+    suspend fun getAdHocLogIdForDate(date: String): Long?
+
+    /**
      * Inserts a new outfit log entry.
      * @param log The [OutfitLogEntity] to insert.
      * @return The row ID of the newly inserted log.
@@ -181,6 +188,22 @@ interface LogDao {
     @Transaction
     suspend fun insertAdHocLogAndSnapshot(log: OutfitLogEntity, itemIds: List<Long>): Long {
         val logId = insertLog(log)
+        if (itemIds.isNotEmpty()) {
+            insertSnapshotItems(itemIds.map { OutfitLogItemEntity(logId, it, outfitName = null) })
+        }
+        return logId
+    }
+
+    /**
+     * Idempotent: returns the existing ad-hoc log ID for [date] if one already exists, or
+     * inserts a new one. Then adds [itemIds] to [outfit_log_items] for the (existing or new)
+     * log using INSERT OR IGNORE, so repeated calls for the same item on the same day are safe.
+     * @return The existing or newly created log row ID.
+     */
+    @Transaction
+    suspend fun getOrCreateAdHocLogAndSnapshot(date: String, itemIds: List<Long>): Long {
+        val logId = getAdHocLogIdForDate(date)
+            ?: insertLog(OutfitLogEntity(outfitId = null, date = date))
         if (itemIds.isNotEmpty()) {
             insertSnapshotItems(itemIds.map { OutfitLogItemEntity(logId, it, outfitName = null) })
         }

--- a/app-android/core/data/src/main/kotlin/com/closet/core/data/dao/StatsDao.kt
+++ b/app-android/core/data/src/main/kotlin/com/closet/core/data/dao/StatsDao.kt
@@ -84,14 +84,14 @@ interface StatsDao {
             COUNT(*) AS totalItems,
             COUNT(CASE WHEN EXISTS (
                 SELECT 1 FROM outfit_logs ol
-                JOIN outfit_items oi ON ol.outfit_id = oi.outfit_id
-                WHERE oi.clothing_item_id = ci.id
+                JOIN outfit_log_items oli ON oli.outfit_log_id = ol.id
+                WHERE oli.clothing_item_id = ci.id
                   AND (:fromDate IS NULL OR ol.date >= :fromDate)
             ) THEN 1 END) AS wornItems,
             COUNT(CASE WHEN NOT EXISTS (
                 SELECT 1 FROM outfit_logs ol
-                JOIN outfit_items oi ON ol.outfit_id = oi.outfit_id
-                WHERE oi.clothing_item_id = ci.id
+                JOIN outfit_log_items oli ON oli.outfit_log_id = ol.id
+                WHERE oli.clothing_item_id = ci.id
                   AND (:fromDate IS NULL OR ol.date >= :fromDate)
             ) THEN 1 END) AS neverWornItems,
             SUM(purchase_price) AS totalValue
@@ -113,8 +113,8 @@ interface StatsDao {
             ci.image_path AS imagePath,
             COUNT(DISTINCT ol.id) AS wearCount
         FROM clothing_items ci
-        JOIN outfit_items oi ON oi.clothing_item_id = ci.id
-        JOIN outfit_logs ol  ON ol.outfit_id = oi.outfit_id
+        JOIN outfit_log_items oli ON oli.clothing_item_id = ci.id
+        JOIN outfit_logs ol ON ol.id = oli.outfit_log_id
         WHERE ci.status = 'Active'
           AND (:fromDate IS NULL OR ol.date >= :fromDate)
         GROUP BY ci.id
@@ -138,8 +138,8 @@ interface StatsDao {
             COUNT(DISTINCT ol.id) AS wearCount,
             ci.purchase_price / COUNT(DISTINCT ol.id) AS costPerWear
         FROM clothing_items ci
-        JOIN outfit_items oi ON oi.clothing_item_id = ci.id
-        JOIN outfit_logs ol  ON ol.outfit_id = oi.outfit_id
+        JOIN outfit_log_items oli ON oli.clothing_item_id = ci.id
+        JOIN outfit_logs ol ON ol.id = oli.outfit_log_id
         WHERE ci.status = 'Active'
           AND ci.purchase_price IS NOT NULL
           AND (:fromDate IS NULL OR ol.date >= :fromDate)
@@ -174,8 +174,8 @@ interface StatsDao {
         SELECT COALESCE(c.name, 'Uncategorized') AS label, COUNT(*) AS count
         FROM clothing_items ci
         LEFT JOIN categories c ON c.id = ci.category_id
-        JOIN outfit_items oi ON oi.clothing_item_id = ci.id
-        JOIN outfit_logs ol  ON ol.outfit_id = oi.outfit_id
+        JOIN outfit_log_items oli ON oli.clothing_item_id = ci.id
+        JOIN outfit_logs ol ON ol.id = oli.outfit_log_id
         WHERE ci.status = 'Active'
           AND (:fromDate IS NULL OR ol.date >= :fromDate)
         GROUP BY label
@@ -193,9 +193,8 @@ interface StatsDao {
         FROM clothing_items ci
         WHERE ci.status = 'Active'
           AND NOT EXISTS (
-              SELECT 1 FROM outfit_logs ol
-              JOIN outfit_items oi ON ol.outfit_id = oi.outfit_id
-              WHERE oi.clothing_item_id = ci.id
+              SELECT 1 FROM outfit_log_items oli
+              WHERE oli.clothing_item_id = ci.id
           )
         ORDER BY ci.name ASC
     """)

--- a/app-android/core/data/src/main/kotlin/com/closet/core/data/dao/StatsDao.kt
+++ b/app-android/core/data/src/main/kotlin/com/closet/core/data/dao/StatsDao.kt
@@ -150,14 +150,16 @@ interface StatsDao {
     fun getCostPerWear(fromDate: String?): Flow<List<CostPerWearItem>>
 
     /**
-     * Counts the total number of distinct outfit log entries.
+     * Counts the total number of distinct outfit log entries (excludes ad-hoc single-item logs
+     * that have no associated outfit — those have [outfit_id] = null).
      * @param fromDate Optional start date (YYYY-MM-DD) to restrict the count.
      * @return A [Flow] emitting the total count of logged outfits.
      */
     @Query("""
         SELECT COUNT(DISTINCT id)
         FROM outfit_logs
-        WHERE :fromDate IS NULL OR date >= :fromDate
+        WHERE outfit_id IS NOT NULL
+          AND (:fromDate IS NULL OR date >= :fromDate)
     """)
     fun getTotalOutfitsLogged(fromDate: String?): Flow<Int>
 

--- a/app-android/core/data/src/main/kotlin/com/closet/core/data/repository/ClothingRepository.kt
+++ b/app-android/core/data/src/main/kotlin/com/closet/core/data/repository/ClothingRepository.kt
@@ -92,12 +92,15 @@ class ClothingRepository @Inject constructor(
 
     /**
      * One-shot fetch of a fully-loaded [ClothingItemDetail] including all junction data.
-     *
-     * Returns `null` rather than wrapping in [DataResult] because callers that need a one-shot
-     * read (e.g. pre-populating a form) handle the missing-item case inline; the [DataResult]
-     * overhead would add noise without benefit here.
+     * Returns [DataResult.Success] with a null value when the item does not exist.
      */
-    suspend fun getItemDetailOnce(id: Long): ClothingItemDetail? = clothingDao.getClothingItemDetailOnce(id)
+    suspend fun getItemDetailOnce(id: Long): DataResult<ClothingItemDetail?> = try {
+        DataResult.Success(clothingDao.getClothingItemDetailOnce(id))
+    } catch (e: Exception) {
+        if (e is CancellationException) throw e
+        Timber.e(e, "Error fetching item detail once for ID: $id")
+        DataResult.Error(AppError.DatabaseError.QueryError(e))
+    }
 
     /**
      * Retrieves the colors associated with a clothing item.

--- a/app-android/core/data/src/main/kotlin/com/closet/core/data/repository/ClothingRepository.kt
+++ b/app-android/core/data/src/main/kotlin/com/closet/core/data/repository/ClothingRepository.kt
@@ -91,6 +91,11 @@ class ClothingRepository @Inject constructor(
     }
 
     /**
+     * One-shot fetch of a fully-loaded [ClothingItemDetail] including all junction data.
+     */
+    suspend fun getItemDetailOnce(id: Long): ClothingItemDetail? = clothingDao.getClothingItemDetailOnce(id)
+
+    /**
      * Retrieves the colors associated with a clothing item.
      */
     fun getItemColors(itemId: Long): Flow<List<ColorEntity>> = clothingDao.getItemColors(itemId)
@@ -123,6 +128,60 @@ class ClothingRepository @Inject constructor(
         val result = insertItem(item, colors.map { it.id })
         if (result is DataResult.Success) repositoryScope.launch { vectorizeItem(result.data) }
         return result
+    }
+
+    /**
+     * Inserts a new clothing item with all junction table associations in a single transaction.
+     * Best-effort: runs ItemVectorizer after a successful insert.
+     */
+    suspend fun insertItemWithAttributes(
+        item: ClothingItemEntity,
+        colors: List<ColorEntity>,
+        seasonIds: List<Long>,
+        occasionIds: List<Long>,
+        materialIds: List<Long>,
+        patternIds: List<Long>,
+    ): DataResult<Long> {
+        val result = wrapInTransaction {
+            val id = clothingDao.insertClothingItem(item)
+            clothingDao.updateItemColors(id, colors.map { it.id })
+            clothingDao.updateItemSeasons(id, seasonIds)
+            clothingDao.updateItemOccasions(id, occasionIds)
+            clothingDao.updateItemMaterials(id, materialIds)
+            clothingDao.updateItemPatterns(id, patternIds)
+            id
+        }
+        if (result is DataResult.Success) repositoryScope.launch { vectorizeItem(result.data) }
+        return result
+    }
+
+    /**
+     * Updates an existing clothing item with all junction table associations in a single transaction.
+     * Best-effort: re-runs ItemVectorizer after a successful update.
+     */
+    suspend fun updateItemWithAttributes(
+        item: ClothingItemEntity,
+        colors: List<ColorEntity>,
+        seasonIds: List<Long>,
+        occasionIds: List<Long>,
+        materialIds: List<Long>,
+        patternIds: List<Long>,
+    ): DataResult<Int> {
+        val result = wrapInTransaction {
+            val rowsAffected = clothingDao.updateClothingItem(item)
+            if (rowsAffected == 0) return@wrapInTransaction 0
+            clothingDao.updateItemColors(item.id, colors.map { it.id })
+            clothingDao.updateItemSeasons(item.id, seasonIds)
+            clothingDao.updateItemOccasions(item.id, occasionIds)
+            clothingDao.updateItemMaterials(item.id, materialIds)
+            clothingDao.updateItemPatterns(item.id, patternIds)
+            rowsAffected
+        }
+        return if (result is DataResult.Success && result.data == 0) {
+            DataResult.Error(AppError.DatabaseError.NotFound())
+        } else {
+            result
+        }.also { if (it is DataResult.Success) vectorizeItem(item.id) }
     }
 
     /**

--- a/app-android/core/data/src/main/kotlin/com/closet/core/data/repository/ClothingRepository.kt
+++ b/app-android/core/data/src/main/kotlin/com/closet/core/data/repository/ClothingRepository.kt
@@ -194,6 +194,22 @@ class ClothingRepository @Inject constructor(
     }
 
     /**
+     * Updates the lifecycle status for a specific clothing item.
+     * @param id The ID of the item.
+     * @param status The new [ClothingStatus].
+     * @return A [DataResult] indicating success or failure.
+     */
+    suspend fun updateStatus(id: Long, status: ClothingStatus): DataResult<Unit> = try {
+        val updatedAt = converters.dateToTimestamp(Instant.now()) ?: ""
+        clothingDao.updateItemStatus(id, status.label, updatedAt)
+        DataResult.Success(Unit)
+    } catch (e: Exception) {
+        if (e is CancellationException) throw e
+        Timber.e(e, "Error updating status for item: $id")
+        DataResult.Error(AppError.DatabaseError.QueryError(e))
+    }
+
+    /**
      * Toggles the favorite status for a specific clothing item.
      * @param id The ID of the item.
      * @param isFavorite Whether the item should be marked as favorite.

--- a/app-android/core/data/src/main/kotlin/com/closet/core/data/repository/ClothingRepository.kt
+++ b/app-android/core/data/src/main/kotlin/com/closet/core/data/repository/ClothingRepository.kt
@@ -92,6 +92,10 @@ class ClothingRepository @Inject constructor(
 
     /**
      * One-shot fetch of a fully-loaded [ClothingItemDetail] including all junction data.
+     *
+     * Returns `null` rather than wrapping in [DataResult] because callers that need a one-shot
+     * read (e.g. pre-populating a form) handle the missing-item case inline; the [DataResult]
+     * overhead would add noise without benefit here.
      */
     suspend fun getItemDetailOnce(id: Long): ClothingItemDetail? = clothingDao.getClothingItemDetailOnce(id)
 
@@ -181,7 +185,7 @@ class ClothingRepository @Inject constructor(
             DataResult.Error(AppError.DatabaseError.NotFound())
         } else {
             result
-        }.also { if (it is DataResult.Success) vectorizeItem(item.id) }
+        }.also { if (it is DataResult.Success) repositoryScope.launch { vectorizeItem(item.id) } }
     }
 
     /**
@@ -218,7 +222,7 @@ class ClothingRepository @Inject constructor(
         colors: List<ColorEntity>
     ): DataResult<Int> {
         val result = updateItem(item, colors.map { it.id })
-        if (result is DataResult.Success) vectorizeItem(item.id)
+        if (result is DataResult.Success) repositoryScope.launch { vectorizeItem(item.id) }
         return result
     }
 

--- a/app-android/core/data/src/main/kotlin/com/closet/core/data/repository/LogRepository.kt
+++ b/app-android/core/data/src/main/kotlin/com/closet/core/data/repository/LogRepository.kt
@@ -95,10 +95,32 @@ class LogRepository @Inject constructor(
     }
 
     /**
+     * Logs one or more individual items as worn today without associating them with a saved outfit.
+     *
+     * Creates an [OutfitLogEntity] with a null [OutfitLogEntity.outfitId] and snapshots [itemIds]
+     * into [outfit_log_items]. Each item's wear count is automatically reflected in the next
+     * emission from clothing queries because wear_count is computed at query time.
+     *
+     * @param itemIds The IDs of the clothing items that were worn.
+     * @return The new log row ID in [DataResult.Success], or [DataResult.Error].
+     */
+    suspend fun wearItemsToday(itemIds: List<Long>): DataResult<Long> = try {
+        val logId = logDao.insertAdHocLogAndSnapshot(
+            log = OutfitLogEntity(outfitId = null, date = LocalDate.now().toString()),
+            itemIds = itemIds,
+        )
+        DataResult.Success(logId)
+    } catch (e: Exception) {
+        if (e is CancellationException) throw e
+        Timber.e(e, "Error logging ad-hoc wear for items $itemIds")
+        DataResult.Error(AppError.DatabaseError.QueryError(e))
+    }
+
+    /**
      * Updates an existing log's metadata (e.g., notes, weather, temperature).
      * @param log The [OutfitLogEntity] with updated values.
      */
-    suspend fun updateLog(log: OutfitLogEntity) = 
+    suspend fun updateLog(log: OutfitLogEntity) =
         logDao.updateLog(log)
 
     /**

--- a/app-android/core/data/src/main/kotlin/com/closet/core/data/repository/LogRepository.kt
+++ b/app-android/core/data/src/main/kotlin/com/closet/core/data/repository/LogRepository.kt
@@ -105,8 +105,8 @@ class LogRepository @Inject constructor(
      * @return The new log row ID in [DataResult.Success], or [DataResult.Error].
      */
     suspend fun wearItemsToday(itemIds: List<Long>): DataResult<Long> = try {
-        val logId = logDao.insertAdHocLogAndSnapshot(
-            log = OutfitLogEntity(outfitId = null, date = LocalDate.now().toString()),
+        val logId = logDao.getOrCreateAdHocLogAndSnapshot(
+            date = LocalDate.now().toString(),
             itemIds = itemIds,
         )
         DataResult.Success(logId)

--- a/app-android/docs/roadmaps/gaps-roadmap.md
+++ b/app-android/docs/roadmaps/gaps-roadmap.md
@@ -100,13 +100,13 @@ recommendation result cards. The blocker is that `OutfitBuilderDestination` has 
 
 ---
 
-## Phase 4 — Bulk Wash discoverability 🟡
+## Phase 4 — Bulk Wash discoverability ✅
 
 `BulkWashScreen` is registered in the nav graph and reachable via the "Laundry Day" launcher
 shortcut, but there is no in-app navigation path to it. Users who don't use the shortcut
 will never find this feature.
 
-- [ ] **§4.1 — Add a Bulk Wash entry point in Settings**
+- [x] **§4.1 — Add a Bulk Wash entry point in Settings**
   File: `features/settings/src/main/kotlin/.../SettingsScreen.kt`
   - Add a `SettingsItem` row (e.g. "Laundry Day — bulk mark wash status") in the Wardrobe
     section of the settings list.

--- a/app-android/docs/roadmaps/gaps-roadmap.md
+++ b/app-android/docs/roadmaps/gaps-roadmap.md
@@ -1,0 +1,243 @@
+# UI/UX Gaps — Roadmap
+
+Tracks gaps between what the data layer supports and what the UI actually exposes.
+Derived from the March 2026 full-codebase audit.
+
+**Severity key:**
+- 🔴 **MAJOR** — feature exists in the backend but is broken or effectively unreachable in the UI
+- 🟡 **MINOR** — data is stored but not surfaced; polish and completeness issues
+
+---
+
+## Phase 1 — Item status management 🔴
+
+`clothing_items.status` has four values (`Active | Sold | Donated | Lost`) but the status badge
+on the detail screen is display-only. `ClothingFormViewModel.save()` hardcodes `Active` on new
+items. Users cannot retire, sell, or archive anything.
+
+- [ ] **§1.1 — Status picker in the clothing form**
+  File: `features/wardrobe/src/main/kotlin/.../ClothingFormScreen.kt` + `ClothingFormViewModel.kt`
+  - Add `status: ClothingStatus` to `ClothingFormState` (default `Active`).
+  - Load existing item's status in the edit path (`ClothingFormViewModel.loadItem()`).
+  - Write status in `save()` instead of hardcoding `Active`.
+  - UI: `ExposedDropdownMenuBox` (or a `SingleChoiceSegmentedButtonRow`) for the 4 values.
+    Place near the bottom of the form alongside wash status.
+
+- [ ] **§1.2 — Status picker on the detail screen**
+  File: `features/wardrobe/src/main/kotlin/.../ClothingDetailScreen.kt` + `ClothingDetailViewModel.kt`
+  - Replace the read-only status `Badge` with a tappable chip.
+  - Tapping opens a `ModalBottomSheet` or `AlertDialog` with the 4 status choices.
+  - Add `fun updateStatus(status: ClothingStatus)` to the ViewModel — calls
+    `ClothingRepository.updateStatus(itemId, status)`.
+  - Add `updateStatus(id, status)` to `ClothingRepository` (single-column update, same pattern
+    as `updateWashStatus`).
+
+---
+
+## Phase 2 — Seasons, occasions, materials, patterns in the add/edit form 🔴
+
+Multi-select attributes (colors, seasons, occasions, materials, patterns) can only be set from
+the detail screen after an item is saved. Items created fresh have zero seasons and occasions,
+which means they are **invisible to the recommendation engine's hard filter**. This is the
+highest-priority fix.
+
+- [ ] **§2.1 — Add `seasons`, `occasions`, `materials`, `patterns` to `ClothingFormState`**
+  File: `features/wardrobe/src/main/kotlin/.../ClothingFormViewModel.kt`
+  - Extend `ClothingFormState` with:
+    ```kotlin
+    val selectedSeasonIds: Set<Long> = emptySet(),
+    val selectedOccasionIds: Set<Long> = emptySet(),
+    val selectedMaterialIds: Set<Long> = emptySet(),
+    val selectedPatternIds: Set<Long> = emptySet(),
+    ```
+  - Populate from the existing item in the edit path (join IDs from junction tables).
+  - Write all four junction tables in `save()` using the existing `set*` helpers in
+    `ClothingRepository` (already used for colors).
+
+- [ ] **§2.2 — Expose lookup lists for the pickers**
+  `LookupDao` already has `getAllSeasons()`, `getAllOccasions()`, `getAllMaterials()`,
+  `getAllPatterns()`. Load them in `ClothingFormViewModel.init {}` alongside the existing
+  category/brand lists and expose as `StateFlow`.
+
+- [ ] **§2.3 — Add pickers to `ClothingFormScreen`**
+  Reuse the `MultiSelectChipRow` pattern already used for colors. Add four rows:
+  - Seasons (icons from `SeasonEntity.icon`)
+  - Occasions (icons from `OccasionEntity.icon`)
+  - Materials (text-only chips)
+  - Patterns (text-only chips)
+  Place them after the colors row in the form scroll column.
+
+---
+
+## Phase 3 — "Log it" from recommendations 🔴
+
+`onNavigateToLog = null` in `ClosetNavGraph.kt` line ~213 disables the "Log it" button on
+recommendation result cards. The blocker is that `OutfitBuilderDestination` has no
+`preselectedItemIds` param.
+
+- [ ] **§3.1 — Add `preselectedItemIds` to `OutfitBuilderDestination`**
+  File: `features/wardrobe/src/main/kotlin/.../WardrobeNavigation.kt`
+  ```kotlin
+  @Serializable
+  data class OutfitBuilderDestination(
+      val outfitId: Long? = null,
+      val preselectedItemIds: List<Long> = emptyList(),
+  )
+  ```
+
+- [ ] **§3.2 — Consume `preselectedItemIds` in `OutfitBuilderViewModel`**
+  File: `features/outfits/src/main/kotlin/.../OutfitBuilderViewModel.kt`
+  - In `init {}`, if `destination.preselectedItemIds` is non-empty, set
+    `_selectedItems` from those IDs (load `ClothingItemWithMeta` via repository).
+
+- [ ] **§3.3 — Wire `onNavigateToLog` in `ClosetNavGraph.kt`**
+  Replace `onNavigateToLog = null` with:
+  ```kotlin
+  onNavigateToLog = { itemIds ->
+      navController.navigate(OutfitBuilderDestination(preselectedItemIds = itemIds))
+  }
+  ```
+
+---
+
+## Phase 4 — Bulk Wash discoverability 🟡
+
+`BulkWashScreen` is registered in the nav graph and reachable via the "Laundry Day" launcher
+shortcut, but there is no in-app navigation path to it. Users who don't use the shortcut
+will never find this feature.
+
+- [ ] **§4.1 — Add a Bulk Wash entry point in Settings**
+  File: `features/settings/src/main/kotlin/.../SettingsScreen.kt`
+  - Add a `SettingsItem` row (e.g. "Laundry Day — bulk mark wash status") in the Wardrobe
+    section of the settings list.
+  - Pass `onNavigateToBulkWash: () -> Unit` lambda from `ClosetNavGraph` through the
+    settings screen to the row.
+
+---
+
+## Phase 5 — Closet screen sorting 🟡
+
+Items are always ordered `created_at DESC` (hardcoded in `ClothingDao`). No UI exists to
+change the sort order.
+
+- [ ] **§5.1 — Add a `SortOrder` enum**
+  File: `features/wardrobe/src/main/kotlin/.../ClosetViewModel.kt`
+  ```kotlin
+  enum class SortOrder { NEWEST, OLDEST, NAME_AZ, NAME_ZA, MOST_WORN, LEAST_WORN }
+  ```
+
+- [ ] **§5.2 — Sort in-memory in `ClosetViewModel`**
+  The existing `filteredAndSorted` flow already does in-memory filtering. Apply a
+  `sortedWith(comparator)` step after filtering based on `_sortOrder: StateFlow<SortOrder>`.
+  `MOST_WORN` / `LEAST_WORN` use the `wearCount` field already present on
+  `ClothingItemWithMeta`.
+
+- [ ] **§5.3 — Add a sort button to `ClosetScreen`**
+  Place a sort `IconButton` (SortAscending/SortDescending icon) in the top app bar or
+  alongside the filter chip row. Tapping opens a `ModalBottomSheet` or `DropdownMenu`
+  with the sort options.
+
+---
+
+## Phase 6 — Status filter on the Closet screen 🟡
+
+Depends on Phase 1 (status must be settable before filtering by it is useful). The closet
+currently shows all items regardless of status; once users can mark items as Sold/Donated/Lost
+they'll need a way to hide them.
+
+- [ ] **§6.1 — Default to Active-only in `ClothingDao.getAllClothingItemDetails()`**
+  Add a `WHERE ci.status = 'Active'` clause to the main listing query, or add a
+  `statusFilter: String? = "Active"` parameter to the DAO method.
+
+- [ ] **§6.2 — Add a status filter chip to `ClosetScreen`**
+  A "Show archived" toggle chip (or a "Status" chip in `FilterPanel`) that sets
+  `statusFilter = null` in the DAO query to surface all statuses.
+
+---
+
+## Phase 7 — Show purchase date and location on the detail screen 🟡
+
+`purchase_date` and `purchase_location` are stored in the DB and writable via the form,
+but they are not displayed anywhere in the detail screen.
+
+- [ ] **§7.1 — Add purchase metadata rows to `ClothingDetailScreen`**
+  File: `features/wardrobe/src/main/kotlin/.../ClothingDetailComponents.kt`
+  - Below the existing price / cost-per-wear `DetailStatRow` entries, add:
+    - "Purchased" — formatted `purchase_date` (e.g. "March 2024"), null-guarded
+    - "From" — `purchase_location` text, null-guarded
+  - `ClothingDetailViewModel` already loads the full `ClothingItemDetail` entity; both
+    fields are already in scope.
+
+---
+
+## Phase 8 — Single-item wear logging (no outfit required) 🔴
+
+The entire wear tracking system requires an outfit. Logging a single item as worn means
+creating a one-item outfit, which is friction-heavy. This is the most architecturally
+significant gap.
+
+> **Note:** This phase introduces a new log type. Approach options:
+> - **Option A (lightweight):** Allow `outfit_logs.outfit_id` to be nullable, treat a null
+>   outfit_id as an ad-hoc log. Snapshot items via `outfit_log_items` as usual.
+> - **Option B (new table):** Add a separate `item_wear_logs` table (simpler schema,
+>   cleaner queries, no null FK).
+> Option A is recommended — it reuses all existing stat queries with minimal schema change.
+
+- [ ] **§8.1 — Make `outfit_logs.outfit_id` nullable (migration)**
+  File: `core/data/src/main/kotlin/.../ClothingDatabase.kt`
+  - Write `Migration(N, N+1)` that drops and recreates `outfit_logs` without `NOT NULL` on
+    `outfit_id`.
+  - Update `OutfitLogEntity.outfitId` to `val outfitId: Long?`.
+  - Follow the migration checklist in `migrations/AGENTS.md` (drop `one_ootd_per_day` index
+    at top of migration, recreate in `onOpen`).
+
+- [ ] **§8.2 — Add `LogRepository.wearItemsToday(itemIds: List<Long>)`**
+  Creates an `OutfitLogEntity` with `outfitId = null`, inserts snapshot rows into
+  `outfit_log_items` for each item ID. Reuses `LogRepository.insertLogAndSnapshot()`.
+
+- [ ] **§8.3 — "Log wear" action on `ClothingDetailScreen`**
+  Add a "Log wear" button (or secondary FAB) to the detail screen. Tapping calls
+  `ClothingDetailViewModel.logWearToday()` which calls `wearItemsToday(listOf(itemId))`.
+  Show a snackbar confirmation on success.
+
+- [ ] **§8.4 — Ensure null-outfit logs are excluded from outfit-specific queries**
+  Audit `OutfitDao` and `StatsDao` queries that join `outfit_logs → outfits` — add
+  `WHERE outfit_id IS NOT NULL` guards where appropriate so null-outfit logs don't surface
+  as broken outfit entries.
+
+---
+
+## Build order
+
+```
+Phase 2 (attribute form pickers)        ← highest impact, unblocks recommendations
+Phase 1 (item status)
+  → Phase 6 (status filter)             ← blocked on Phase 1 being useful
+Phase 3 (Log it from recs)              ← small lift, big UX payoff
+Phase 4 (Bulk Wash discoverability)     ← one row in Settings
+Phase 5 (Closet sorting)               ← self-contained
+Phase 7 (purchase metadata on detail)  ← purely additive
+Phase 8 (single-item wear logging)     ← most complex, requires migration
+```
+
+---
+
+## Files summary
+
+| Status | File | Change |
+|--------|------|--------|
+| [ ] | `features/wardrobe/.../ClothingFormViewModel.kt` | Phase 1.1: status in form state; Phase 2.1-2.2: junction attributes |
+| [ ] | `features/wardrobe/.../ClothingFormScreen.kt` | Phase 1.1: status picker; Phase 2.3: season/occasion/material/pattern pickers |
+| [ ] | `features/wardrobe/.../ClothingDetailScreen.kt` | Phase 1.2: tappable status; Phase 7.1: purchase date/location rows |
+| [ ] | `features/wardrobe/.../ClothingDetailViewModel.kt` | Phase 1.2: `updateStatus()` |
+| [ ] | `core/data/.../repository/ClothingRepository.kt` | Phase 1.2: `updateStatus()` single-column update |
+| [ ] | `features/wardrobe/.../WardrobeNavigation.kt` | Phase 3.1: `preselectedItemIds` on `OutfitBuilderDestination` |
+| [ ] | `features/outfits/.../OutfitBuilderViewModel.kt` | Phase 3.2: consume `preselectedItemIds` |
+| [ ] | `app/.../navigation/ClosetNavGraph.kt` | Phase 3.3: wire `onNavigateToLog` |
+| [ ] | `features/settings/.../SettingsScreen.kt` | Phase 4.1: Bulk Wash entry point |
+| [ ] | `features/wardrobe/.../ClosetViewModel.kt` | Phase 5.1-5.2: `SortOrder` enum + in-memory sort |
+| [ ] | `features/wardrobe/.../ClosetScreen.kt` | Phase 5.3: sort button UI |
+| [ ] | `core/data/.../dao/ClothingDao.kt` | Phase 6.1: status filter param |
+| [ ] | `core/data/.../ClothingDatabase.kt` | Phase 8.1: migration for nullable `outfit_id` |
+| [ ] | `core/data/.../entity/OutfitLogEntity.kt` | Phase 8.1: `outfitId: Long?` |
+| [ ] | `core/data/.../repository/LogRepository.kt` | Phase 8.2: `wearItemsToday()` |

--- a/app-android/docs/roadmaps/gaps-roadmap.md
+++ b/app-android/docs/roadmaps/gaps-roadmap.md
@@ -115,24 +115,24 @@ will never find this feature.
 
 ---
 
-## Phase 5 — Closet screen sorting 🟡
+## Phase 5 — Closet screen sorting ✅
 
 Items are always ordered `created_at DESC` (hardcoded in `ClothingDao`). No UI exists to
 change the sort order.
 
-- [ ] **§5.1 — Add a `SortOrder` enum**
+- [x] **§5.1 — Add a `SortOrder` enum**
   File: `features/wardrobe/src/main/kotlin/.../ClosetViewModel.kt`
   ```kotlin
   enum class SortOrder { NEWEST, OLDEST, NAME_AZ, NAME_ZA, MOST_WORN, LEAST_WORN }
   ```
 
-- [ ] **§5.2 — Sort in-memory in `ClosetViewModel`**
+- [x] **§5.2 — Sort in-memory in `ClosetViewModel`**
   The existing `filteredAndSorted` flow already does in-memory filtering. Apply a
   `sortedWith(comparator)` step after filtering based on `_sortOrder: StateFlow<SortOrder>`.
   `MOST_WORN` / `LEAST_WORN` use the `wearCount` field already present on
   `ClothingItemWithMeta`.
 
-- [ ] **§5.3 — Add a sort button to `ClosetScreen`**
+- [x] **§5.3 — Add a sort button to `ClosetScreen`**
   Place a sort `IconButton` (SortAscending/SortDescending icon) in the top app bar or
   alongside the filter chip row. Tapping opens a `ModalBottomSheet` or `DropdownMenu`
   with the sort options.

--- a/app-android/docs/roadmaps/gaps-roadmap.md
+++ b/app-android/docs/roadmaps/gaps-roadmap.md
@@ -76,7 +76,7 @@ recommendation result cards. The blocker is that `OutfitBuilderDestination` has 
 `preselectedItemIds` param.
 
 - [x] **§3.1 — Add `preselectedItemIds` to `OutfitBuilderDestination`**
-  File: `features/wardrobe/src/main/kotlin/.../WardrobeNavigation.kt`
+  File: `features/outfits/src/main/kotlin/.../OutfitsNavigation.kt`
   ```kotlin
   @Serializable
   data class OutfitBuilderDestination(
@@ -209,7 +209,7 @@ significant gap.
 
 ## Build order
 
-```
+```text
 Phase 2 (attribute form pickers)        ← highest impact, unblocks recommendations
 Phase 1 (item status)
   → Phase 6 (status filter)             ← blocked on Phase 1 being useful
@@ -231,13 +231,13 @@ Phase 8 (single-item wear logging)     ← most complex, requires migration
 | [ ] | `features/wardrobe/.../ClothingDetailScreen.kt` | Phase 1.2: tappable status; Phase 7.1: purchase date/location rows |
 | [ ] | `features/wardrobe/.../ClothingDetailViewModel.kt` | Phase 1.2: `updateStatus()` |
 | [ ] | `core/data/.../repository/ClothingRepository.kt` | Phase 1.2: `updateStatus()` single-column update |
-| [ ] | `features/wardrobe/.../WardrobeNavigation.kt` | Phase 3.1: `preselectedItemIds` on `OutfitBuilderDestination` |
+| [ ] | `features/outfits/.../OutfitsNavigation.kt` | Phase 3.1: `preselectedItemIds` on `OutfitBuilderDestination` |
 | [ ] | `features/outfits/.../OutfitBuilderViewModel.kt` | Phase 3.2: consume `preselectedItemIds` |
 | [ ] | `app/.../navigation/ClosetNavGraph.kt` | Phase 3.3: wire `onNavigateToLog` |
 | [ ] | `features/settings/.../SettingsScreen.kt` | Phase 4.1: Bulk Wash entry point |
 | [ ] | `features/wardrobe/.../ClosetViewModel.kt` | Phase 5.1-5.2: `SortOrder` enum + in-memory sort |
 | [ ] | `features/wardrobe/.../ClosetScreen.kt` | Phase 5.3: sort button UI |
-| [ ] | `core/data/.../dao/ClothingDao.kt` | Phase 6.1: status filter param |
+| [ ] | `features/wardrobe/.../ClosetViewModel.kt` | Phase 6.1: Active-only filter (in-memory) |
 | [ ] | `core/data/.../ClothingDatabase.kt` | Phase 8.1: migration for nullable `outfit_id` |
 | [ ] | `core/data/.../entity/OutfitLogEntity.kt` | Phase 8.1: `outfitId: Long?` |
 | [ ] | `core/data/.../repository/LogRepository.kt` | Phase 8.2: `wearItemsToday()` |

--- a/app-android/docs/roadmaps/gaps-roadmap.md
+++ b/app-android/docs/roadmaps/gaps-roadmap.md
@@ -34,14 +34,14 @@ items. Users cannot retire, sell, or archive anything.
 
 ---
 
-## Phase 2 — Seasons, occasions, materials, patterns in the add/edit form 🔴
+## Phase 2 — Seasons, occasions, materials, patterns in the add/edit form ✅
 
 Multi-select attributes (colors, seasons, occasions, materials, patterns) can only be set from
 the detail screen after an item is saved. Items created fresh have zero seasons and occasions,
 which means they are **invisible to the recommendation engine's hard filter**. This is the
 highest-priority fix.
 
-- [ ] **§2.1 — Add `seasons`, `occasions`, `materials`, `patterns` to `ClothingFormState`**
+- [x] **§2.1 — Add `seasons`, `occasions`, `materials`, `patterns` to `ClothingFormState`**
   File: `features/wardrobe/src/main/kotlin/.../ClothingFormViewModel.kt`
   - Extend `ClothingFormState` with:
     ```kotlin
@@ -54,12 +54,12 @@ highest-priority fix.
   - Write all four junction tables in `save()` using the existing `set*` helpers in
     `ClothingRepository` (already used for colors).
 
-- [ ] **§2.2 — Expose lookup lists for the pickers**
+- [x] **§2.2 — Expose lookup lists for the pickers**
   `LookupDao` already has `getAllSeasons()`, `getAllOccasions()`, `getAllMaterials()`,
   `getAllPatterns()`. Load them in `ClothingFormViewModel.init {}` alongside the existing
   category/brand lists and expose as `StateFlow`.
 
-- [ ] **§2.3 — Add pickers to `ClothingFormScreen`**
+- [x] **§2.3 — Add pickers to `ClothingFormScreen`**
   Reuse the `MultiSelectChipRow` pattern already used for colors. Add four rows:
   - Seasons (icons from `SeasonEntity.icon`)
   - Occasions (icons from `OccasionEntity.icon`)

--- a/app-android/docs/roadmaps/gaps-roadmap.md
+++ b/app-android/docs/roadmaps/gaps-roadmap.md
@@ -139,19 +139,19 @@ change the sort order.
 
 ---
 
-## Phase 6 — Status filter on the Closet screen 🟡
+## Phase 6 — Status filter on the Closet screen ✅
 
 Depends on Phase 1 (status must be settable before filtering by it is useful). The closet
 currently shows all items regardless of status; once users can mark items as Sold/Donated/Lost
 they'll need a way to hide them.
 
-- [ ] **§6.1 — Default to Active-only in `ClothingDao.getAllClothingItemDetails()`**
-  Add a `WHERE ci.status = 'Active'` clause to the main listing query, or add a
-  `statusFilter: String? = "Active"` parameter to the DAO method.
+- [x] **§6.1 — Default to Active-only in `ClosetViewModel`**
+  Added in-memory filter in the `combine` block: `.filter { fs.showArchived || it.item.status == ClothingStatus.Active }`.
+  Consistent with the existing in-memory filtering pattern; no DAO change needed.
 
-- [ ] **§6.2 — Add a status filter chip to `ClosetScreen`**
-  A "Show archived" toggle chip (or a "Status" chip in `FilterPanel`) that sets
-  `statusFilter = null` in the DAO query to surface all statuses.
+- [x] **§6.2 — Add a status filter chip to `ClosetScreen`**
+  "Show archived" `FilterChip` appended to `CategoryFilterRow`. Backed by `_showArchived: MutableStateFlow<Boolean>(false)`
+  in `ClosetViewModel`; does not count toward the filter badge.
 
 ---
 

--- a/app-android/docs/roadmaps/gaps-roadmap.md
+++ b/app-android/docs/roadmaps/gaps-roadmap.md
@@ -69,13 +69,13 @@ highest-priority fix.
 
 ---
 
-## Phase 3 — "Log it" from recommendations 🔴
+## Phase 3 — "Log it" from recommendations ✅
 
 `onNavigateToLog = null` in `ClosetNavGraph.kt` line ~213 disables the "Log it" button on
 recommendation result cards. The blocker is that `OutfitBuilderDestination` has no
 `preselectedItemIds` param.
 
-- [ ] **§3.1 — Add `preselectedItemIds` to `OutfitBuilderDestination`**
+- [x] **§3.1 — Add `preselectedItemIds` to `OutfitBuilderDestination`**
   File: `features/wardrobe/src/main/kotlin/.../WardrobeNavigation.kt`
   ```kotlin
   @Serializable
@@ -85,12 +85,12 @@ recommendation result cards. The blocker is that `OutfitBuilderDestination` has 
   )
   ```
 
-- [ ] **§3.2 — Consume `preselectedItemIds` in `OutfitBuilderViewModel`**
+- [x] **§3.2 — Consume `preselectedItemIds` in `OutfitBuilderViewModel`**
   File: `features/outfits/src/main/kotlin/.../OutfitBuilderViewModel.kt`
   - In `init {}`, if `destination.preselectedItemIds` is non-empty, set
     `_selectedItems` from those IDs (load `ClothingItemWithMeta` via repository).
 
-- [ ] **§3.3 — Wire `onNavigateToLog` in `ClosetNavGraph.kt`**
+- [x] **§3.3 — Wire `onNavigateToLog` in `ClosetNavGraph.kt`**
   Replace `onNavigateToLog = null` with:
   ```kotlin
   onNavigateToLog = { itemIds ->

--- a/app-android/docs/roadmaps/gaps-roadmap.md
+++ b/app-android/docs/roadmaps/gaps-roadmap.md
@@ -155,12 +155,12 @@ they'll need a way to hide them.
 
 ---
 
-## Phase 7 — Show purchase date and location on the detail screen 🟡
+## Phase 7 — Show purchase date and location on the detail screen ✅
 
 `purchase_date` and `purchase_location` are stored in the DB and writable via the form,
 but they are not displayed anywhere in the detail screen.
 
-- [ ] **§7.1 — Add purchase metadata rows to `ClothingDetailScreen`**
+- [x] **§7.1 — Add purchase metadata rows to `ClothingDetailScreen`**
   File: `features/wardrobe/src/main/kotlin/.../ClothingDetailComponents.kt`
   - Below the existing price / cost-per-wear `DetailStatRow` entries, add:
     - "Purchased" — formatted `purchase_date` (e.g. "March 2024"), null-guarded

--- a/app-android/docs/roadmaps/gaps-roadmap.md
+++ b/app-android/docs/roadmaps/gaps-roadmap.md
@@ -170,40 +170,38 @@ but they are not displayed anywhere in the detail screen.
 
 ---
 
-## Phase 8 — Single-item wear logging (no outfit required) 🔴
+## Phase 8 — Single-item wear logging (no outfit required) ✅
 
 The entire wear tracking system requires an outfit. Logging a single item as worn means
 creating a one-item outfit, which is friction-heavy. This is the most architecturally
 significant gap.
 
-> **Note:** This phase introduces a new log type. Approach options:
-> - **Option A (lightweight):** Allow `outfit_logs.outfit_id` to be nullable, treat a null
->   outfit_id as an ad-hoc log. Snapshot items via `outfit_log_items` as usual.
-> - **Option B (new table):** Add a separate `item_wear_logs` table (simpler schema,
->   cleaner queries, no null FK).
-> Option A is recommended — it reuses all existing stat queries with minimal schema change.
+> **Note:** Option A (lightweight) was used — `outfit_logs.outfit_id` is already nullable
+> in the DB schema (`INTEGER` without `NOT NULL`, `onDelete = ForeignKey.SET_NULL`).
+> No migration was needed. Ad-hoc logs use the same `outfit_log_items` snapshot table.
 
-- [ ] **§8.1 — Make `outfit_logs.outfit_id` nullable (migration)**
-  File: `core/data/src/main/kotlin/.../ClothingDatabase.kt`
-  - Write `Migration(N, N+1)` that drops and recreates `outfit_logs` without `NOT NULL` on
-    `outfit_id`.
-  - Update `OutfitLogEntity.outfitId` to `val outfitId: Long?`.
-  - Follow the migration checklist in `migrations/AGENTS.md` (drop `one_ootd_per_day` index
-    at top of migration, recreate in `onOpen`).
+- [x] **§8.1 — `outfit_logs.outfit_id` already nullable — no migration needed**
+  `OutfitLogEntity.outfitId: Long? = null` and the DB column is `INTEGER` (no `NOT NULL`)
+  as of v6. `LogDao.insertLogAndSnapshot` already skips snapshot rows when `outfitId` is
+  null. No schema change required.
 
-- [ ] **§8.2 — Add `LogRepository.wearItemsToday(itemIds: List<Long>)`**
-  Creates an `OutfitLogEntity` with `outfitId = null`, inserts snapshot rows into
-  `outfit_log_items` for each item ID. Reuses `LogRepository.insertLogAndSnapshot()`.
+- [x] **§8.2 — Add `LogRepository.wearItemsToday(itemIds: List<Long>)`**
+  File: `core/data/src/main/kotlin/.../dao/LogDao.kt` + `.../repository/LogRepository.kt`
+  - Added `LogDao.insertSnapshotItems(items: List<OutfitLogItemEntity>)` (`@Insert IGNORE`).
+  - Added `LogDao.insertAdHocLogAndSnapshot(log, itemIds)` (`@Transaction`).
+  - Added `LogRepository.wearItemsToday(itemIds)` — creates null-outfit log + snapshot.
 
-- [ ] **§8.3 — "Log wear" action on `ClothingDetailScreen`**
-  Add a "Log wear" button (or secondary FAB) to the detail screen. Tapping calls
-  `ClothingDetailViewModel.logWearToday()` which calls `wearItemsToday(listOf(itemId))`.
-  Show a snackbar confirmation on success.
+- [x] **§8.3 — "Log wear" action on `ClothingDetailScreen`**
+  File: `features/wardrobe/src/main/kotlin/.../ClothingDetailScreen.kt` + `ClothingDetailViewModel.kt`
+  - Added `ClothingDetailViewModel.logWearToday()` + `logWearSuccess: SharedFlow<Unit>`.
+  - Added full-width `FilledTonalButton` ("Log wear") below `DetailStatRow`.
+  - `LaunchedEffect` collects `logWearSuccess` and shows "Wear logged" snackbar.
 
-- [ ] **§8.4 — Ensure null-outfit logs are excluded from outfit-specific queries**
-  Audit `OutfitDao` and `StatsDao` queries that join `outfit_logs → outfits` — add
-  `WHERE outfit_id IS NOT NULL` guards where appropriate so null-outfit logs don't surface
-  as broken outfit entries.
+- [x] **§8.4 — Ensure null-outfit logs are excluded from outfit-specific queries**
+  File: `core/data/src/main/kotlin/.../dao/StatsDao.kt`
+  - `getTotalOutfitsLogged`: added `AND outfit_id IS NOT NULL` guard.
+  - All other StatsDao/OutfitDao queries join through `outfit_items` (inner join on
+    `outfit_id`), so null-outfit logs are naturally excluded — no further guards needed.
 
 ---
 
@@ -238,6 +236,8 @@ Phase 8 (single-item wear logging)     ← most complex, requires migration
 | [ ] | `features/wardrobe/.../ClosetViewModel.kt` | Phase 5.1-5.2: `SortOrder` enum + in-memory sort |
 | [ ] | `features/wardrobe/.../ClosetScreen.kt` | Phase 5.3: sort button UI |
 | [ ] | `features/wardrobe/.../ClosetViewModel.kt` | Phase 6.1: Active-only filter (in-memory) |
-| [ ] | `core/data/.../ClothingDatabase.kt` | Phase 8.1: migration for nullable `outfit_id` |
-| [ ] | `core/data/.../entity/OutfitLogEntity.kt` | Phase 8.1: `outfitId: Long?` |
+| [ ] | `core/data/.../dao/LogDao.kt` | Phase 8.2: `insertSnapshotItems()` + `insertAdHocLogAndSnapshot()` |
 | [ ] | `core/data/.../repository/LogRepository.kt` | Phase 8.2: `wearItemsToday()` |
+| [ ] | `features/wardrobe/.../ClothingDetailViewModel.kt` | Phase 8.3: `logWearToday()` + `logWearSuccess` flow |
+| [ ] | `features/wardrobe/.../ClothingDetailScreen.kt` | Phase 8.3: Log Wear button + success snackbar |
+| [ ] | `core/data/.../dao/StatsDao.kt` | Phase 8.4: `outfit_id IS NOT NULL` guard in `getTotalOutfitsLogged` |

--- a/app-android/docs/roadmaps/gaps-roadmap.md
+++ b/app-android/docs/roadmaps/gaps-roadmap.md
@@ -9,13 +9,13 @@ Derived from the March 2026 full-codebase audit.
 
 ---
 
-## Phase 1 — Item status management 🔴
+## Phase 1 — Item status management ✅
 
 `clothing_items.status` has four values (`Active | Sold | Donated | Lost`) but the status badge
 on the detail screen is display-only. `ClothingFormViewModel.save()` hardcodes `Active` on new
 items. Users cannot retire, sell, or archive anything.
 
-- [ ] **§1.1 — Status picker in the clothing form**
+- [x] **§1.1 — Status picker in the clothing form**
   File: `features/wardrobe/src/main/kotlin/.../ClothingFormScreen.kt` + `ClothingFormViewModel.kt`
   - Add `status: ClothingStatus` to `ClothingFormState` (default `Active`).
   - Load existing item's status in the edit path (`ClothingFormViewModel.loadItem()`).
@@ -23,7 +23,7 @@ items. Users cannot retire, sell, or archive anything.
   - UI: `ExposedDropdownMenuBox` (or a `SingleChoiceSegmentedButtonRow`) for the 4 values.
     Place near the bottom of the form alongside wash status.
 
-- [ ] **§1.2 — Status picker on the detail screen**
+- [x] **§1.2 — Status picker on the detail screen**
   File: `features/wardrobe/src/main/kotlin/.../ClothingDetailScreen.kt` + `ClothingDetailViewModel.kt`
   - Replace the read-only status `Badge` with a tappable chip.
   - Tapping opens a `ModalBottomSheet` or `AlertDialog` with the 4 status choices.

--- a/app-android/features/outfits/src/main/kotlin/com/closet/features/outfits/OutfitBuilderViewModel.kt
+++ b/app-android/features/outfits/src/main/kotlin/com/closet/features/outfits/OutfitBuilderViewModel.kt
@@ -3,6 +3,7 @@ package com.closet.features.outfits
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import androidx.navigation.toRoute
 import com.closet.core.data.model.ClothingItemDetail
 import com.closet.core.data.repository.ClothingRepository
 import com.closet.core.data.repository.OutfitItem
@@ -129,6 +130,11 @@ class OutfitBuilderViewModel @Inject constructor(
                         .sortedBy { it.zIndex }
                         .map { it.clothingItem.id }
                 }
+            }
+        } else {
+            val preselectedIds = savedStateHandle.toRoute<OutfitBuilderDestination>().preselectedItemIds
+            if (preselectedIds.isNotEmpty()) {
+                _memberIds.value = preselectedIds
             }
         }
     }

--- a/app-android/features/outfits/src/main/kotlin/com/closet/features/outfits/OutfitsNavigation.kt
+++ b/app-android/features/outfits/src/main/kotlin/com/closet/features/outfits/OutfitsNavigation.kt
@@ -15,9 +15,14 @@ object OutfitsRoute
  * Route for the Outfit Builder screen.
  *
  * [outfitId] = -1 means "create new"; any positive value opens edit mode for that outfit.
+ * [preselectedItemIds] seeds the member list on new-outfit creation (e.g. from "Log it" on
+ * a recommendation). Ignored in edit mode.
  */
 @Serializable
-data class OutfitBuilderDestination(val outfitId: Long = -1L)
+data class OutfitBuilderDestination(
+    val outfitId: Long = -1L,
+    val preselectedItemIds: List<Long> = emptyList(),
+)
 
 /** Route for the Wardrobe Picker screen used to select items while building an outfit. */
 @Serializable

--- a/app-android/features/settings/src/main/kotlin/com/closet/features/settings/SettingsNavigation.kt
+++ b/app-android/features/settings/src/main/kotlin/com/closet/features/settings/SettingsNavigation.kt
@@ -21,10 +21,17 @@ fun NavController.navigateToSettings(navOptions: NavOptions? = null) {
 /**
  * Registers the [SettingsRoute] composable destination in the [NavGraphBuilder].
  *
- * @param onNavigateUp Called when the user taps the back arrow.
+ * @param onNavigateUp         Called when the user taps the back arrow.
+ * @param onNavigateToBulkWash Called when the user taps the Laundry Day row.
  */
-fun NavGraphBuilder.settingsScreen(onNavigateUp: () -> Unit) {
+fun NavGraphBuilder.settingsScreen(
+    onNavigateUp: () -> Unit,
+    onNavigateToBulkWash: () -> Unit = {},
+) {
     composable<SettingsRoute> {
-        SettingsScreen(onNavigateUp = onNavigateUp)
+        SettingsScreen(
+            onNavigateUp = onNavigateUp,
+            onNavigateToBulkWash = onNavigateToBulkWash,
+        )
     }
 }

--- a/app-android/features/settings/src/main/kotlin/com/closet/features/settings/SettingsScreen.kt
+++ b/app-android/features/settings/src/main/kotlin/com/closet/features/settings/SettingsScreen.kt
@@ -31,6 +31,7 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
 import androidx.compose.material.icons.filled.CheckCircle
 import androidx.compose.material.icons.filled.Visibility
 import androidx.compose.material.icons.filled.VisibilityOff
@@ -110,6 +111,7 @@ import com.closet.core.ui.theme.ClosetTheme
 @Composable
 fun SettingsScreen(
     onNavigateUp: () -> Unit,
+    onNavigateToBulkWash: () -> Unit = {},
     viewModel: SettingsViewModel = hiltViewModel(),
 ) {
     val accent by viewModel.accent.collectAsStateWithLifecycle()
@@ -305,6 +307,7 @@ fun SettingsScreen(
         onStartBatchEnrichment = viewModel::startBatchEnrichment,
         snackbarHostState = snackbarHostState,
         onNavigateUp = onNavigateUp,
+        onNavigateToBulkWash = onNavigateToBulkWash,
     )
 }
 
@@ -365,6 +368,7 @@ internal fun SettingsContent(
     onStartBatchEnrichment: () -> Unit,
     snackbarHostState: SnackbarHostState,
     onNavigateUp: () -> Unit,
+    onNavigateToBulkWash: () -> Unit = {},
     modifier: Modifier = Modifier,
 ) {
     Scaffold(
@@ -498,27 +502,28 @@ internal fun SettingsContent(
             }
 
             // ── Wardrobe ──────────────────────────────────────────────────────
-            if (segmentationSupported || captionSupported) {
+            item {
+                SettingsSectionHeader(stringResource(R.string.settings_section_wardrobe))
+            }
+            item {
+                LaundryDayItem(onClick = onNavigateToBulkWash)
+            }
+            if (segmentationSupported) {
                 item {
-                    SettingsSectionHeader(stringResource(R.string.settings_section_wardrobe))
+                    BatchSegmentationItem(
+                        eligibleCount = segmentationEligibleCount,
+                        workInfo = batchSegWorkInfo,
+                        onStart = onStartBatchSegmentation,
+                    )
                 }
-                if (segmentationSupported) {
-                    item {
-                        BatchSegmentationItem(
-                            eligibleCount = segmentationEligibleCount,
-                            workInfo = batchSegWorkInfo,
-                            onStart = onStartBatchSegmentation,
-                        )
-                    }
-                }
-                if (captionSupported) {
-                    item {
-                        BatchCaptionItem(
-                            eligibleCount = captionEligibleCount,
-                            progress = batchCaptionProgress,
-                            onStart = onStartBatchEnrichment,
-                        )
-                    }
+            }
+            if (captionSupported) {
+                item {
+                    BatchCaptionItem(
+                        eligibleCount = captionEligibleCount,
+                        progress = batchCaptionProgress,
+                        onStart = onStartBatchEnrichment,
+                    )
                 }
             }
         }
@@ -1182,6 +1187,21 @@ private val OPENAI_URL_PRESETS = listOf(
 )
 
 // ── Wardrobe items ────────────────────────────────────────────────────────────
+
+@Composable
+private fun LaundryDayItem(onClick: () -> Unit) {
+    ListItem(
+        headlineContent = { Text(stringResource(R.string.settings_wardrobe_laundry_day)) },
+        supportingContent = { Text(stringResource(R.string.settings_wardrobe_laundry_day_summary)) },
+        trailingContent = {
+            Icon(
+                imageVector = Icons.AutoMirrored.Filled.KeyboardArrowRight,
+                contentDescription = null,
+            )
+        },
+        modifier = Modifier.clickable(onClick = onClick),
+    )
+}
 
 @Composable
 private fun BatchSegmentationItem(

--- a/app-android/features/settings/src/main/res/values/strings.xml
+++ b/app-android/features/settings/src/main/res/values/strings.xml
@@ -83,6 +83,8 @@
 
     <!-- Wardrobe section -->
     <string name="settings_section_wardrobe">Wardrobe</string>
+    <string name="settings_wardrobe_laundry_day">Laundry Day</string>
+    <string name="settings_wardrobe_laundry_day_summary">Bulk mark items as clean or dirty</string>
     <string name="settings_wardrobe_remove_backgrounds">Remove backgrounds</string>
     <string name="settings_wardrobe_removing_backgrounds">Removing backgrounds…</string>
     <string name="settings_wardrobe_removing_backgrounds_progress">%1$d of %2$d items</string>

--- a/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/ClosetScreen.kt
+++ b/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/ClosetScreen.kt
@@ -299,6 +299,13 @@ private fun CategoryFilterRow(
                 label = { Text(stringResource(R.string.wardrobe_all_items)) }
             )
         }
+        item(key = "show_archived") {
+            FilterChip(
+                selected = showArchived,
+                onClick = onToggleShowArchived,
+                label = { Text(stringResource(R.string.wardrobe_filter_show_archived)) }
+            )
+        }
         items(categories, key = { it.id }) { category ->
             Row(verticalAlignment = androidx.compose.ui.Alignment.CenterVertically) {
                 FilterChip(
@@ -318,13 +325,6 @@ private fun CategoryFilterRow(
                     )
                 }
             }
-        }
-        item(key = "show_archived") {
-            FilterChip(
-                selected = showArchived,
-                onClick = onToggleShowArchived,
-                label = { Text(stringResource(R.string.wardrobe_filter_show_archived)) }
-            )
         }
     }
 }

--- a/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/ClosetScreen.kt
+++ b/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/ClosetScreen.kt
@@ -65,6 +65,7 @@ fun ClosetScreen(
         selectedOccasionIds = uiState.selectedOccasionIds,
         selectedSizeSystemIds = uiState.selectedSizeSystemIds,
         activeFilterCount = uiState.activeFilterCount,
+        hiddenArchivedCount = uiState.hiddenArchivedCount,
         onCategorySelect = viewModel::selectCategory,
         onToggleFavorites = viewModel::toggleFavoritesOnly,
         onToggleShowArchived = viewModel::toggleShowArchived,
@@ -105,6 +106,7 @@ internal fun ClosetContent(
     selectedOccasionIds: Set<Long>,
     selectedSizeSystemIds: Set<Long>,
     activeFilterCount: Int,
+    hiddenArchivedCount: Int = 0,
     onCategorySelect: (Long?) -> Unit,
     onToggleFavorites: () -> Unit,
     onToggleShowArchived: () -> Unit,
@@ -245,7 +247,11 @@ internal fun ClosetContent(
                     onClearFilters = onClearAllFilters,
                     modifier = Modifier.weight(1f)
                 )
-                else -> EmptyClosetMessage(modifier = Modifier.weight(1f))
+                else -> EmptyClosetMessage(
+                    hiddenArchivedCount = hiddenArchivedCount,
+                    onShowArchived = onToggleShowArchived,
+                    modifier = Modifier.weight(1f)
+                )
             }
         }
     }
@@ -364,14 +370,28 @@ private fun ClosetGrid(
 
 /**
  * Message displayed when the wardrobe contains no items.
+ *
+ * If [hiddenArchivedCount] > 0, a "Show archived" button is shown so the user can reveal
+ * items that were hidden by the Active-only default filter.
  */
 @Composable
-private fun EmptyClosetMessage(modifier: Modifier = Modifier) {
+private fun EmptyClosetMessage(
+    hiddenArchivedCount: Int = 0,
+    onShowArchived: () -> Unit = {},
+    modifier: Modifier = Modifier,
+) {
     Box(
         modifier = modifier.fillMaxSize(),
         contentAlignment = androidx.compose.ui.Alignment.Center
     ) {
-        Text(stringResource(R.string.wardrobe_empty_closet))
+        Column(horizontalAlignment = androidx.compose.ui.Alignment.CenterHorizontally) {
+            Text(stringResource(R.string.wardrobe_empty_closet))
+            if (hiddenArchivedCount > 0) {
+                TextButton(onClick = onShowArchived) {
+                    Text(stringResource(R.string.wardrobe_filter_show_archived))
+                }
+            }
+        }
     }
 }
 

--- a/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/ClosetScreen.kt
+++ b/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/ClosetScreen.kt
@@ -8,13 +8,16 @@ import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.Favorite
 import androidx.compose.material.icons.outlined.FavoriteBorder
 import androidx.compose.material.icons.outlined.FilterList
 import androidx.compose.material.icons.outlined.PushPin
 import androidx.compose.material.icons.outlined.Settings
+import androidx.compose.material.icons.outlined.Sort
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
+import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
@@ -52,6 +55,7 @@ fun ClosetScreen(
         selectedCategoryId = uiState.selectedCategoryId,
         favoritesOnly = uiState.favoritesOnly,
         showArchived = uiState.showArchived,
+        sortOrder = uiState.sortOrder,
         colors = uiState.colors,
         seasons = uiState.seasons,
         occasions = uiState.occasions,
@@ -64,6 +68,7 @@ fun ClosetScreen(
         onCategorySelect = viewModel::selectCategory,
         onToggleFavorites = viewModel::toggleFavoritesOnly,
         onToggleShowArchived = viewModel::toggleShowArchived,
+        onSortOrderSelected = viewModel::setSortOrder,
         onToggleColor = viewModel::toggleColorFilter,
         onToggleSeason = viewModel::toggleSeasonFilter,
         onToggleOccasion = viewModel::toggleOccasionFilter,
@@ -90,6 +95,7 @@ internal fun ClosetContent(
     selectedCategoryId: Long?,
     favoritesOnly: Boolean,
     showArchived: Boolean,
+    sortOrder: SortOrder,
     colors: List<ColorEntity>,
     seasons: List<SeasonEntity>,
     occasions: List<OccasionEntity>,
@@ -102,6 +108,7 @@ internal fun ClosetContent(
     onCategorySelect: (Long?) -> Unit,
     onToggleFavorites: () -> Unit,
     onToggleShowArchived: () -> Unit,
+    onSortOrderSelected: (SortOrder) -> Unit,
     onToggleColor: (Long) -> Unit,
     onToggleSeason: (Long) -> Unit,
     onToggleOccasion: (Long) -> Unit,
@@ -116,6 +123,7 @@ internal fun ClosetContent(
     modifier: Modifier = Modifier
 ) {
     var showFilterPanel by remember { mutableStateOf(false) }
+    var showSortMenu by remember { mutableStateOf(false) }
 
     if (showFilterPanel) {
         FilterPanel(
@@ -154,6 +162,41 @@ internal fun ClosetContent(
                                 imageVector = Icons.Outlined.FilterList,
                                 contentDescription = stringResource(R.string.wardrobe_cd_open_filters)
                             )
+                        }
+                    }
+                    Box {
+                        IconButton(onClick = { showSortMenu = true }) {
+                            Icon(
+                                imageVector = Icons.Outlined.Sort,
+                                contentDescription = stringResource(R.string.wardrobe_cd_sort)
+                            )
+                        }
+                        DropdownMenu(
+                            expanded = showSortMenu,
+                            onDismissRequest = { showSortMenu = false },
+                            offset = DpOffset(x = 0.dp, y = 0.dp),
+                        ) {
+                            SortOrder.entries.forEach { order ->
+                                DropdownMenuItem(
+                                    text = {
+                                        Text(stringResource(when (order) {
+                                            SortOrder.NEWEST     -> R.string.wardrobe_sort_newest
+                                            SortOrder.OLDEST     -> R.string.wardrobe_sort_oldest
+                                            SortOrder.NAME_AZ    -> R.string.wardrobe_sort_name_az
+                                            SortOrder.NAME_ZA    -> R.string.wardrobe_sort_name_za
+                                            SortOrder.MOST_WORN  -> R.string.wardrobe_sort_most_worn
+                                            SortOrder.LEAST_WORN -> R.string.wardrobe_sort_least_worn
+                                        }))
+                                    },
+                                    onClick = {
+                                        onSortOrderSelected(order)
+                                        showSortMenu = false
+                                    },
+                                    trailingIcon = if (order == sortOrder) {
+                                        { Icon(Icons.Default.Check, contentDescription = null) }
+                                    } else null,
+                                )
+                            }
                         }
                     }
                     IconButton(onClick = onSettingsClick) {
@@ -396,6 +439,7 @@ private fun ClosetScreenPreview() {
                 selectedCategoryId = null,
                 favoritesOnly = false,
                 showArchived = false,
+                sortOrder = SortOrder.NEWEST,
                 colors = emptyList(),
                 seasons = emptyList(),
                 occasions = emptyList(),
@@ -408,6 +452,7 @@ private fun ClosetScreenPreview() {
                 onCategorySelect = {},
                 onToggleFavorites = {},
                 onToggleShowArchived = {},
+                onSortOrderSelected = {},
                 onToggleColor = {},
                 onToggleSeason = {},
                 onToggleOccasion = {},
@@ -433,6 +478,7 @@ private fun ClosetScreenEmptyPreview() {
                 selectedCategoryId = null,
                 favoritesOnly = false,
                 showArchived = false,
+                sortOrder = SortOrder.NEWEST,
                 colors = emptyList(),
                 seasons = emptyList(),
                 occasions = emptyList(),
@@ -445,6 +491,7 @@ private fun ClosetScreenEmptyPreview() {
                 onCategorySelect = {},
                 onToggleFavorites = {},
                 onToggleShowArchived = {},
+                onSortOrderSelected = {},
                 onToggleColor = {},
                 onToggleSeason = {},
                 onToggleOccasion = {},

--- a/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/ClosetScreen.kt
+++ b/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/ClosetScreen.kt
@@ -51,6 +51,7 @@ fun ClosetScreen(
         categories = uiState.categories,
         selectedCategoryId = uiState.selectedCategoryId,
         favoritesOnly = uiState.favoritesOnly,
+        showArchived = uiState.showArchived,
         colors = uiState.colors,
         seasons = uiState.seasons,
         occasions = uiState.occasions,
@@ -62,6 +63,7 @@ fun ClosetScreen(
         activeFilterCount = uiState.activeFilterCount,
         onCategorySelect = viewModel::selectCategory,
         onToggleFavorites = viewModel::toggleFavoritesOnly,
+        onToggleShowArchived = viewModel::toggleShowArchived,
         onToggleColor = viewModel::toggleColorFilter,
         onToggleSeason = viewModel::toggleSeasonFilter,
         onToggleOccasion = viewModel::toggleOccasionFilter,
@@ -87,6 +89,7 @@ internal fun ClosetContent(
     categories: List<CategoryEntity>,
     selectedCategoryId: Long?,
     favoritesOnly: Boolean,
+    showArchived: Boolean,
     colors: List<ColorEntity>,
     seasons: List<SeasonEntity>,
     occasions: List<OccasionEntity>,
@@ -98,6 +101,7 @@ internal fun ClosetContent(
     activeFilterCount: Int,
     onCategorySelect: (Long?) -> Unit,
     onToggleFavorites: () -> Unit,
+    onToggleShowArchived: () -> Unit,
     onToggleColor: (Long) -> Unit,
     onToggleSeason: (Long) -> Unit,
     onToggleOccasion: (Long) -> Unit,
@@ -179,8 +183,10 @@ internal fun ClosetContent(
                 categories = categories,
                 selectedCategoryId = selectedCategoryId,
                 favoritesOnly = favoritesOnly,
+                showArchived = showArchived,
                 onCategorySelect = onCategorySelect,
                 onToggleFavorites = onToggleFavorites,
+                onToggleShowArchived = onToggleShowArchived,
                 onPinCategory = onPinCategory,
             )
             
@@ -213,8 +219,10 @@ private fun CategoryFilterRow(
     categories: List<CategoryEntity>,
     selectedCategoryId: Long?,
     favoritesOnly: Boolean,
+    showArchived: Boolean,
     onCategorySelect: (Long?) -> Unit,
     onToggleFavorites: () -> Unit,
+    onToggleShowArchived: () -> Unit,
     onPinCategory: (Long, String) -> Unit,
     modifier: Modifier = Modifier
 ) {
@@ -263,6 +271,13 @@ private fun CategoryFilterRow(
                     )
                 }
             }
+        }
+        item(key = "show_archived") {
+            FilterChip(
+                selected = showArchived,
+                onClick = onToggleShowArchived,
+                label = { Text(stringResource(R.string.wardrobe_filter_show_archived)) }
+            )
         }
     }
 }
@@ -380,6 +395,7 @@ private fun ClosetScreenPreview() {
                 ),
                 selectedCategoryId = null,
                 favoritesOnly = false,
+                showArchived = false,
                 colors = emptyList(),
                 seasons = emptyList(),
                 occasions = emptyList(),
@@ -391,6 +407,7 @@ private fun ClosetScreenPreview() {
                 activeFilterCount = 0,
                 onCategorySelect = {},
                 onToggleFavorites = {},
+                onToggleShowArchived = {},
                 onToggleColor = {},
                 onToggleSeason = {},
                 onToggleOccasion = {},
@@ -415,6 +432,7 @@ private fun ClosetScreenEmptyPreview() {
                 categories = emptyList(),
                 selectedCategoryId = null,
                 favoritesOnly = false,
+                showArchived = false,
                 colors = emptyList(),
                 seasons = emptyList(),
                 occasions = emptyList(),
@@ -426,6 +444,7 @@ private fun ClosetScreenEmptyPreview() {
                 activeFilterCount = 0,
                 onCategorySelect = {},
                 onToggleFavorites = {},
+                onToggleShowArchived = {},
                 onToggleColor = {},
                 onToggleSeason = {},
                 onToggleOccasion = {},

--- a/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/ClosetScreen.kt
+++ b/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/ClosetScreen.kt
@@ -17,7 +17,6 @@ import androidx.compose.material.icons.outlined.Settings
 import androidx.compose.material.icons.outlined.Sort
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
-import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
@@ -176,7 +175,6 @@ internal fun ClosetContent(
                         DropdownMenu(
                             expanded = showSortMenu,
                             onDismissRequest = { showSortMenu = false },
-                            offset = DpOffset(x = 0.dp, y = 0.dp),
                         ) {
                             SortOrder.entries.forEach { order ->
                                 DropdownMenuItem(

--- a/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/ClosetViewModel.kt
+++ b/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/ClosetViewModel.kt
@@ -11,6 +11,7 @@ import androidx.lifecycle.viewModelScope
 import androidx.navigation.toRoute
 import com.closet.core.data.model.CategoryEntity
 import com.closet.core.data.model.ClothingItemDetail
+import com.closet.core.data.model.ClothingStatus
 import com.closet.core.data.model.ColorEntity
 import com.closet.core.data.model.OccasionEntity
 import com.closet.core.data.model.SeasonEntity
@@ -51,6 +52,7 @@ data class ClosetUiState(
     val selectedOccasionIds: Set<Long> = emptySet(),
     val selectedSizeSystemIds: Set<Long> = emptySet(),
     val favoritesOnly: Boolean = false,
+    val showArchived: Boolean = false,
     val activeFilterCount: Int = 0,
 )
 
@@ -64,6 +66,7 @@ private data class FilterSelections(
     val occIds: Set<Long>,
     val sizeSystemIds: Set<Long>,
     val favOnly: Boolean,
+    val showArchived: Boolean,
 ) {
     /** Number of active filter dimensions (max 5). Drives the filter badge. */
     val activeCount: Int get() = listOf(
@@ -104,15 +107,25 @@ class ClosetViewModel @Inject constructor(
     private val _selectedOccasionIds   = MutableStateFlow<Set<Long>>(emptySet())
     private val _selectedSizeSystemIds = MutableStateFlow<Set<Long>>(emptySet())
     private val _favoritesOnly         = MutableStateFlow(false)
+    private val _showArchived          = MutableStateFlow(false)
 
     private val filterSelections = combine(
         _selectedColorIds,
         _selectedSeasonIds,
         _selectedOccasionIds,
         _selectedSizeSystemIds,
-        _favoritesOnly
-    ) { colorIds, seasonIds, occIds, sizeSystemIds, favOnly ->
-        FilterSelections(colorIds, seasonIds, occIds, sizeSystemIds, favOnly)
+        _favoritesOnly,
+        _showArchived,
+    ) { args: Array<Any?> ->
+        @Suppress("UNCHECKED_CAST")
+        FilterSelections(
+            colorIds = args[0] as Set<Long>,
+            seasonIds = args[1] as Set<Long>,
+            occIds = args[2] as Set<Long>,
+            sizeSystemIds = args[3] as Set<Long>,
+            favOnly = args[4] as Boolean,
+            showArchived = args[5] as Boolean,
+        )
     }
 
     /** Aggregated UI state for the Closet screen. */
@@ -137,6 +150,7 @@ class ClosetViewModel @Inject constructor(
         filterSelections
     ) { allItems, categoryId, categories, lookups, fs ->
         val filtered = allItems
+            .filter { fs.showArchived || it.item.status == ClothingStatus.Active }
             .filter { categoryId == null || it.item.categoryId == categoryId }
             .filter { fs.colorIds.isEmpty() || it.colors.any { c -> c.id in fs.colorIds } }
             .filter { fs.seasonIds.isEmpty() || it.seasons.any { s -> s.id in fs.seasonIds } }
@@ -161,6 +175,7 @@ class ClosetViewModel @Inject constructor(
             selectedOccasionIds = fs.occIds,
             selectedSizeSystemIds = fs.sizeSystemIds,
             favoritesOnly = fs.favOnly,
+            showArchived = fs.showArchived,
             activeFilterCount = fs.activeCount,
         )
     }.stateIn(
@@ -209,7 +224,12 @@ class ClosetViewModel @Inject constructor(
         _favoritesOnly.value = !_favoritesOnly.value
     }
 
-    /** Clears all active filters, including category. */
+    /** Toggles visibility of archived (non-Active) items. */
+    fun toggleShowArchived() {
+        _showArchived.value = !_showArchived.value
+    }
+
+    /** Clears all active filters, including category and show-archived. */
     fun clearAllFilters() {
         _selectedCategoryId.value = null
         _selectedColorIds.value = emptySet()
@@ -217,6 +237,7 @@ class ClosetViewModel @Inject constructor(
         _selectedOccasionIds.value = emptySet()
         _selectedSizeSystemIds.value = emptySet()
         _favoritesOnly.value = false
+        _showArchived.value = false
     }
 
     /**

--- a/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/ClosetViewModel.kt
+++ b/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/ClosetViewModel.kt
@@ -39,6 +39,12 @@ import javax.inject.Inject
  * colors, seasons, occasions, favorites, sizes). Use this to drive the badge on the
  * filter icon button.
  */
+/**
+ * Controls the order of items displayed in the Closet grid.
+ * Sorting is applied in-memory after all active filters.
+ */
+enum class SortOrder { NEWEST, OLDEST, NAME_AZ, NAME_ZA, MOST_WORN, LEAST_WORN }
+
 data class ClosetUiState(
     val items: List<ClothingItemDetail> = emptyList(),
     val categories: List<CategoryEntity> = emptyList(),
@@ -53,6 +59,7 @@ data class ClosetUiState(
     val selectedSizeSystemIds: Set<Long> = emptySet(),
     val favoritesOnly: Boolean = false,
     val showArchived: Boolean = false,
+    val sortOrder: SortOrder = SortOrder.NEWEST,
     val activeFilterCount: Int = 0,
 )
 
@@ -67,6 +74,7 @@ private data class FilterSelections(
     val sizeSystemIds: Set<Long>,
     val favOnly: Boolean,
     val showArchived: Boolean,
+    val sortOrder: SortOrder,
 ) {
     /** Number of active filter dimensions (max 5). Drives the filter badge. */
     val activeCount: Int get() = listOf(
@@ -108,6 +116,7 @@ class ClosetViewModel @Inject constructor(
     private val _selectedSizeSystemIds = MutableStateFlow<Set<Long>>(emptySet())
     private val _favoritesOnly         = MutableStateFlow(false)
     private val _showArchived          = MutableStateFlow(false)
+    private val _sortOrder             = MutableStateFlow(SortOrder.NEWEST)
 
     private val filterSelections = combine(
         _selectedColorIds,
@@ -116,6 +125,7 @@ class ClosetViewModel @Inject constructor(
         _selectedSizeSystemIds,
         _favoritesOnly,
         _showArchived,
+        _sortOrder,
     ) { args: Array<Any?> ->
         @Suppress("UNCHECKED_CAST")
         FilterSelections(
@@ -125,6 +135,7 @@ class ClosetViewModel @Inject constructor(
             sizeSystemIds = args[3] as Set<Long>,
             favOnly = args[4] as Boolean,
             showArchived = args[5] as Boolean,
+            sortOrder = args[6] as SortOrder,
         )
     }
 
@@ -157,6 +168,7 @@ class ClosetViewModel @Inject constructor(
             .filter { fs.occIds.isEmpty() || it.occasions.any { o -> o.id in fs.occIds } }
             .filter { fs.sizeSystemIds.isEmpty() || it.sizeValue?.sizeSystemId in fs.sizeSystemIds }
             .filter { !fs.favOnly || it.item.isFavorite == 1 }
+            .sortedWith(fs.sortOrder.comparator())
 
         // Only show size systems that are actually used by items in the closet
         val usedSizeSystemIds = allItems.mapNotNull { it.sizeValue?.sizeSystemId }.toSet()
@@ -176,6 +188,7 @@ class ClosetViewModel @Inject constructor(
             selectedSizeSystemIds = fs.sizeSystemIds,
             favoritesOnly = fs.favOnly,
             showArchived = fs.showArchived,
+            sortOrder = fs.sortOrder,
             activeFilterCount = fs.activeCount,
         )
     }.stateIn(
@@ -227,6 +240,11 @@ class ClosetViewModel @Inject constructor(
     /** Toggles visibility of archived (non-Active) items. */
     fun toggleShowArchived() {
         _showArchived.value = !_showArchived.value
+    }
+
+    /** Sets the active sort order for the item grid. */
+    fun setSortOrder(order: SortOrder) {
+        _sortOrder.value = order
     }
 
     /** Clears all active filters, including category and show-archived. */
@@ -293,3 +311,12 @@ class ClosetViewModel @Inject constructor(
 }
 
 private fun Set<Long>.toggle(id: Long): Set<Long> = if (id in this) this - id else this + id
+
+private fun SortOrder.comparator(): Comparator<ClothingItemDetail> = when (this) {
+    SortOrder.NEWEST    -> compareByDescending { it.item.createdAt }
+    SortOrder.OLDEST    -> compareBy { it.item.createdAt }
+    SortOrder.NAME_AZ   -> compareBy { it.item.name.lowercase() }
+    SortOrder.NAME_ZA   -> compareByDescending { it.item.name.lowercase() }
+    SortOrder.MOST_WORN -> compareByDescending { it.wearCount }
+    SortOrder.LEAST_WORN -> compareBy { it.wearCount }
+}

--- a/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/ClosetViewModel.kt
+++ b/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/ClosetViewModel.kt
@@ -176,7 +176,9 @@ class ClosetViewModel @Inject constructor(
         val visibleSizeSystems = lookups.sizeSystems.filter { it.id in usedSizeSystemIds }
 
         val hiddenArchivedCount = if (!fs.showArchived) {
-            allItems.count { it.item.status != ClothingStatus.Active }
+            allItems
+                .filter { categoryId == null || it.item.categoryId == categoryId }
+                .count { it.item.status != ClothingStatus.Active }
         } else 0
 
         ClosetUiState(

--- a/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/ClosetViewModel.kt
+++ b/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/ClosetViewModel.kt
@@ -61,6 +61,7 @@ data class ClosetUiState(
     val showArchived: Boolean = false,
     val sortOrder: SortOrder = SortOrder.NEWEST,
     val activeFilterCount: Int = 0,
+    val hiddenArchivedCount: Int = 0,
 )
 
 /**
@@ -174,6 +175,10 @@ class ClosetViewModel @Inject constructor(
         val usedSizeSystemIds = allItems.mapNotNull { it.sizeValue?.sizeSystemId }.toSet()
         val visibleSizeSystems = lookups.sizeSystems.filter { it.id in usedSizeSystemIds }
 
+        val hiddenArchivedCount = if (!fs.showArchived) {
+            allItems.count { it.item.status != ClothingStatus.Active }
+        } else 0
+
         ClosetUiState(
             items = filtered,
             categories = categories,
@@ -190,6 +195,7 @@ class ClosetViewModel @Inject constructor(
             showArchived = fs.showArchived,
             sortOrder = fs.sortOrder,
             activeFilterCount = fs.activeCount,
+            hiddenArchivedCount = hiddenArchivedCount,
         )
     }.stateIn(
         scope = viewModelScope,

--- a/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/ClothingDetailScreen.kt
+++ b/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/ClothingDetailScreen.kt
@@ -61,6 +61,13 @@ fun ClothingDetailScreen(
     val snackbarHostState = remember { SnackbarHostState() }
     UserMessageSnackbarEffect(viewModel.actionError, snackbarHostState)
 
+    val logWearSuccessMessage = stringResource(R.string.wardrobe_log_wear_success)
+    LaunchedEffect(viewModel.logWearSuccess) {
+        viewModel.logWearSuccess.collect {
+            snackbarHostState.showSnackbar(logWearSuccessMessage)
+        }
+    }
+
     var activePicker by remember { mutableStateOf<AttributePicker?>(null) }
     var showDeleteDialog by remember { mutableStateOf(false) }
     var showStatusDialog by remember { mutableStateOf(false) }
@@ -267,6 +274,20 @@ fun ClothingDetailScreen(
                             purchasePrice = detail.item.purchasePrice,
                             onToggleWash = { viewModel.toggleWashStatus() },
                         )
+
+                        Spacer(modifier = Modifier.height(12.dp))
+                        FilledTonalButton(
+                            onClick = { viewModel.logWearToday() },
+                            modifier = Modifier.fillMaxWidth(),
+                        ) {
+                            Icon(
+                                imageVector = Icons.Default.CheckCircle,
+                                contentDescription = null,
+                                modifier = Modifier.size(18.dp),
+                            )
+                            Spacer(modifier = Modifier.width(8.dp))
+                            Text(stringResource(R.string.wardrobe_log_wear))
+                        }
 
                         // Purchase metadata — only rendered when at least one field is set
                         if (detail.item.purchaseDate != null || !detail.item.purchaseLocation.isNullOrBlank()) {

--- a/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/ClothingDetailScreen.kt
+++ b/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/ClothingDetailScreen.kt
@@ -269,7 +269,7 @@ fun ClothingDetailScreen(
                         )
 
                         // Purchase metadata — only rendered when at least one field is set
-                        if (detail.item.purchaseDate != null || detail.item.purchaseLocation != null) {
+                        if (detail.item.purchaseDate != null || !detail.item.purchaseLocation.isNullOrBlank()) {
                             Spacer(modifier = Modifier.height(16.dp))
                             PurchaseMetaRow(
                                 purchaseDate = detail.item.purchaseDate,

--- a/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/ClothingDetailScreen.kt
+++ b/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/ClothingDetailScreen.kt
@@ -268,6 +268,15 @@ fun ClothingDetailScreen(
                             onToggleWash = { viewModel.toggleWashStatus() },
                         )
 
+                        // Purchase metadata — only rendered when at least one field is set
+                        if (detail.item.purchaseDate != null || detail.item.purchaseLocation != null) {
+                            Spacer(modifier = Modifier.height(16.dp))
+                            PurchaseMetaRow(
+                                purchaseDate = detail.item.purchaseDate,
+                                purchaseLocation = detail.item.purchaseLocation,
+                            )
+                        }
+
                         Spacer(modifier = Modifier.height(24.dp))
 
                         // Attributes
@@ -509,6 +518,51 @@ private fun StatPillCard(
         OutlinedCard(onClick = onClick, modifier = modifier) { content() }
     } else {
         OutlinedCard(modifier = modifier) { content() }
+    }
+}
+
+/**
+ * Displays the purchase date (formatted as "Month YYYY") and/or purchase location
+ * as a simple two-row label/value section. Each row is only rendered if the value is non-null.
+ */
+@Composable
+private fun PurchaseMetaRow(
+    purchaseDate: String?,
+    purchaseLocation: String?,
+    modifier: Modifier = Modifier,
+) {
+    val monthYearFormatter = DateTimeFormatter.ofPattern("MMMM yyyy", Locale.getDefault())
+    Column(modifier = modifier.fillMaxWidth(), verticalArrangement = Arrangement.spacedBy(6.dp)) {
+        purchaseDate?.let { raw ->
+            val formatted = runCatching { LocalDate.parse(raw).format(monthYearFormatter) }
+                .getOrDefault(raw)
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+            ) {
+                Text(
+                    text = stringResource(R.string.wardrobe_detail_purchased),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                Text(text = formatted, style = MaterialTheme.typography.bodyMedium)
+            }
+        }
+        purchaseLocation?.let { location ->
+            if (location.isNotBlank()) {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                ) {
+                    Text(
+                        text = stringResource(R.string.wardrobe_detail_from),
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                    Text(text = location, style = MaterialTheme.typography.bodyMedium)
+                }
+            }
+        }
     }
 }
 

--- a/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/ClothingDetailScreen.kt
+++ b/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/ClothingDetailScreen.kt
@@ -4,7 +4,6 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
@@ -64,6 +63,47 @@ fun ClothingDetailScreen(
 
     var activePicker by remember { mutableStateOf<AttributePicker?>(null) }
     var showDeleteDialog by remember { mutableStateOf(false) }
+    var showStatusDialog by remember { mutableStateOf(false) }
+
+    if (showStatusDialog) {
+        val currentStatus = (uiState as? ClothingDetailUiState.Success)?.item?.item?.status
+        AlertDialog(
+            onDismissRequest = { showStatusDialog = false },
+            title = { Text(stringResource(R.string.wardrobe_change_status)) },
+            text = {
+                Column {
+                    ClothingStatus.entries.forEach { status ->
+                        Row(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .clickable {
+                                    viewModel.updateStatus(status)
+                                    showStatusDialog = false
+                                }
+                                .padding(vertical = 12.dp),
+                            verticalAlignment = Alignment.CenterVertically,
+                            horizontalArrangement = Arrangement.spacedBy(12.dp),
+                        ) {
+                            RadioButton(
+                                selected = status == currentStatus,
+                                onClick = {
+                                    viewModel.updateStatus(status)
+                                    showStatusDialog = false
+                                },
+                            )
+                            Text(status.label, style = MaterialTheme.typography.bodyLarge)
+                        }
+                    }
+                }
+            },
+            confirmButton = {},
+            dismissButton = {
+                TextButton(onClick = { showStatusDialog = false }) {
+                    Text(stringResource(R.string.wardrobe_cancel))
+                }
+            },
+        )
+    }
 
     if (showDeleteDialog) {
         AlertDialog(
@@ -201,18 +241,12 @@ fun ClothingDetailScreen(
                                 }
                             }
 
-                            // Status Badge
-                            Surface(
-                                shape = CircleShape,
-                                color = MaterialTheme.colorScheme.secondaryContainer,
-                                contentColor = MaterialTheme.colorScheme.onSecondaryContainer
-                            ) {
-                                Text(
-                                    text = detail.item.status.label,
-                                    modifier = Modifier.padding(horizontal = 12.dp, vertical = 4.dp),
-                                    style = MaterialTheme.typography.labelLarge
-                                )
-                            }
+                            // Status Badge — tappable
+                            FilterChip(
+                                selected = true,
+                                onClick = { showStatusDialog = true },
+                                label = { Text(detail.item.status.label, style = MaterialTheme.typography.labelLarge) },
+                            )
                         }
 
                         Spacer(modifier = Modifier.height(8.dp))

--- a/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/ClothingDetailViewModel.kt
+++ b/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/ClothingDetailViewModel.kt
@@ -104,6 +104,17 @@ class ClothingDetailViewModel @Inject constructor(
         }
     }
 
+    /** Updates the lifecycle status of the current item. */
+    fun updateStatus(status: ClothingStatus) {
+        viewModelScope.launch {
+            clothingRepository.updateStatus(itemId, status).fold(
+                onLoading = {},
+                onSuccess = {},
+                onError = { handleActionError(it) }
+            )
+        }
+    }
+
     /** Toggles the wash status between [WashStatus.Clean] and [WashStatus.Dirty]. */
     fun toggleWashStatus() {
         viewModelScope.launch {

--- a/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/ClothingDetailViewModel.kt
+++ b/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/ClothingDetailViewModel.kt
@@ -89,6 +89,14 @@ class ClothingDetailViewModel @Inject constructor(
     /** One-shot error events emitted when a quick action (toggle, delete, update) fails. */
     val actionError: SharedFlow<UserMessage> = _actionError.asSharedFlow()
 
+    private val _logWearSuccess = MutableSharedFlow<Unit>(
+        replay = 0,
+        extraBufferCapacity = 1,
+        onBufferOverflow = BufferOverflow.DROP_OLDEST
+    )
+    /** Fires once after a successful [logWearToday] call — used to show a confirmation snackbar. */
+    val logWearSuccess: SharedFlow<Unit> = _logWearSuccess.asSharedFlow()
+
     /** Toggles the favorite status of the current item. */
     fun toggleFavorite() {
         viewModelScope.launch {
@@ -205,6 +213,21 @@ class ClothingDetailViewModel @Inject constructor(
             clothingRepository.updateItemPatterns(itemId, patternIds).fold(
                 onLoading = {},
                 onSuccess = {},
+                onError = { handleActionError(it) }
+            )
+        }
+    }
+
+    /**
+     * Logs this item as worn today without requiring a saved outfit.
+     * On success, emits on [logWearSuccess] so the UI can show a confirmation snackbar.
+     * On failure, emits on [actionError].
+     */
+    fun logWearToday() {
+        viewModelScope.launch {
+            logRepository.wearItemsToday(listOf(itemId)).fold(
+                onLoading = {},
+                onSuccess = { _logWearSuccess.tryEmit(Unit) },
                 onError = { handleActionError(it) }
             )
         }

--- a/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/ClothingFormScreen.kt
+++ b/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/ClothingFormScreen.kt
@@ -62,6 +62,7 @@ import coil.compose.AsyncImage
 import com.closet.core.ui.components.ResErrorSnackbarEffect
 import com.closet.core.data.model.BrandEntity
 import com.closet.core.data.model.CategoryEntity
+import com.closet.core.data.model.ClothingStatus
 import com.closet.core.data.model.ColorEntity
 import com.closet.core.data.model.SubcategoryEntity
 import java.time.LocalDate
@@ -167,6 +168,7 @@ fun ClothingFormScreen(
                 onDateChange = viewModel::onDateChange,
                 onLocationChange = viewModel::onLocationChange,
                 onNotesChange = viewModel::onNotesChange,
+                onStatusSelected = viewModel::onStatusSelected,
                 onImageClick = {
                     launcher.launch(PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.ImageOnly))
                 },
@@ -232,6 +234,7 @@ internal fun ClothingFormContent(
     onDateChange: (LocalDate?) -> Unit,
     onLocationChange: (String) -> Unit,
     onNotesChange: (String) -> Unit,
+    onStatusSelected: (ClothingStatus) -> Unit,
     onImageClick: () -> Unit,
     onRemoveBackground: () -> Unit,
     onRevertSegmentation: () -> Unit,
@@ -456,6 +459,19 @@ internal fun ClothingFormContent(
                 minLines = 3,
                 keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done)
             )
+        }
+
+        // Status Section (edit mode only — new items are always Active)
+        if (uiState.isEditMode) {
+            item {
+                DropdownSelector(
+                    selectedItem = uiState.status,
+                    items = ClothingStatus.entries,
+                    onItemSelect = { it?.let(onStatusSelected) },
+                    label = stringResource(R.string.wardrobe_field_status),
+                    itemLabel = { it.label },
+                )
+            }
         }
     }
 }

--- a/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/ClothingFormScreen.kt
+++ b/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/ClothingFormScreen.kt
@@ -169,6 +169,10 @@ fun ClothingFormScreen(
                 onLocationChange = viewModel::onLocationChange,
                 onNotesChange = viewModel::onNotesChange,
                 onStatusSelected = viewModel::onStatusSelected,
+                onSeasonToggle = viewModel::onSeasonToggle,
+                onOccasionToggle = viewModel::onOccasionToggle,
+                onMaterialToggle = viewModel::onMaterialToggle,
+                onPatternToggle = viewModel::onPatternToggle,
                 onImageClick = {
                     launcher.launch(PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.ImageOnly))
                 },
@@ -235,6 +239,10 @@ internal fun ClothingFormContent(
     onLocationChange: (String) -> Unit,
     onNotesChange: (String) -> Unit,
     onStatusSelected: (ClothingStatus) -> Unit,
+    onSeasonToggle: (Long) -> Unit,
+    onOccasionToggle: (Long) -> Unit,
+    onMaterialToggle: (Long) -> Unit,
+    onPatternToggle: (Long) -> Unit,
     onImageClick: () -> Unit,
     onRemoveBackground: () -> Unit,
     onRevertSegmentation: () -> Unit,
@@ -412,6 +420,42 @@ internal fun ClothingFormContent(
                     onColorToggle = onColorToggle
                 )
             }
+        }
+
+        item {
+            AttributeChipRow(
+                label = stringResource(R.string.wardrobe_seasons),
+                items = uiState.allSeasons.map { it.id to it.name },
+                selectedIds = uiState.selectedSeasonIds,
+                onToggle = onSeasonToggle,
+            )
+        }
+
+        item {
+            AttributeChipRow(
+                label = stringResource(R.string.wardrobe_occasions),
+                items = uiState.allOccasions.map { it.id to it.name },
+                selectedIds = uiState.selectedOccasionIds,
+                onToggle = onOccasionToggle,
+            )
+        }
+
+        item {
+            AttributeChipRow(
+                label = stringResource(R.string.wardrobe_materials),
+                items = uiState.allMaterials.map { it.id to it.name },
+                selectedIds = uiState.selectedMaterialIds,
+                onToggle = onMaterialToggle,
+            )
+        }
+
+        item {
+            AttributeChipRow(
+                label = stringResource(R.string.wardrobe_patterns),
+                items = uiState.allPatterns.map { it.id to it.name },
+                selectedIds = uiState.selectedPatternIds,
+                onToggle = onPatternToggle,
+            )
         }
 
         item { HorizontalDivider() }

--- a/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/ClothingFormViewModel.kt
+++ b/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/ClothingFormViewModel.kt
@@ -13,6 +13,10 @@ import com.closet.core.data.model.CategoryEntity
 import com.closet.core.data.model.ClothingItemEntity
 import com.closet.core.data.model.ClothingStatus
 import com.closet.core.data.model.ColorEntity
+import com.closet.core.data.model.MaterialEntity
+import com.closet.core.data.model.OccasionEntity
+import com.closet.core.data.model.PatternEntity
+import com.closet.core.data.model.SeasonEntity
 import com.closet.core.data.model.SizeSystemEntity
 import com.closet.core.data.model.SizeValueEntity
 import com.closet.core.data.model.SubcategoryEntity
@@ -86,6 +90,14 @@ data class ClothingFormUiState(
     val selectedSizeSystemId: Long? = null,
     val selectedSizeValueId: Long? = null,
     val status: ClothingStatus = ClothingStatus.Active,
+    val selectedSeasonIds: Set<Long> = emptySet(),
+    val selectedOccasionIds: Set<Long> = emptySet(),
+    val selectedMaterialIds: Set<Long> = emptySet(),
+    val selectedPatternIds: Set<Long> = emptySet(),
+    val allSeasons: List<SeasonEntity> = emptyList(),
+    val allOccasions: List<OccasionEntity> = emptyList(),
+    val allMaterials: List<MaterialEntity> = emptyList(),
+    val allPatterns: List<PatternEntity> = emptyList(),
 )
 
 private data class FormState(
@@ -114,6 +126,10 @@ private data class FormState(
     val selectedSizeSystemId: Long? = null,
     val selectedSizeValueId: Long? = null,
     val status: ClothingStatus = ClothingStatus.Active,
+    val selectedSeasonIds: Set<Long> = emptySet(),
+    val selectedOccasionIds: Set<Long> = emptySet(),
+    val selectedMaterialIds: Set<Long> = emptySet(),
+    val selectedPatternIds: Set<Long> = emptySet(),
 )
 
 /**
@@ -145,6 +161,10 @@ class ClothingFormViewModel @Inject constructor(
     private var originalImagePath: String? = null
     private var originalEntity: ClothingItemEntity? = null
     private var originalColors: List<ColorEntity> = emptyList()
+    private var originalSeasonIds: Set<Long> = emptySet()
+    private var originalOccasionIds: Set<Long> = emptySet()
+    private var originalMaterialIds: Set<Long> = emptySet()
+    private var originalPatternIds: Set<Long> = emptySet()
 
     private var sizeSystemUserOverridden = false
     private var captionJob: Job? = null
@@ -175,6 +195,18 @@ class ClothingFormViewModel @Inject constructor(
     val sizeSystems: StateFlow<List<SizeSystemEntity>> = lookupRepository.getSizeSystems()
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
 
+    val allSeasons: StateFlow<List<SeasonEntity>> = lookupRepository.getSeasons()
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
+
+    val allOccasions: StateFlow<List<OccasionEntity>> = lookupRepository.getOccasions()
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
+
+    val allMaterials: StateFlow<List<MaterialEntity>> = lookupRepository.getMaterials()
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
+
+    val allPatterns: StateFlow<List<PatternEntity>> = lookupRepository.getPatterns()
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
+
     @OptIn(ExperimentalCoroutinesApi::class)
     val sizeValues: StateFlow<List<SizeValueEntity>> = _form
         .map { it.selectedSizeSystemId }
@@ -193,7 +225,11 @@ class ClothingFormViewModel @Inject constructor(
         allColors,
         allBrands,
         sizeSystems,
-        sizeValues
+        sizeValues,
+        allSeasons,
+        allOccasions,
+        allMaterials,
+        allPatterns,
     ) { args: Array<Any?> ->
         val form = args[0] as FormState
         val cats = args[1] as List<CategoryEntity>
@@ -202,6 +238,14 @@ class ClothingFormViewModel @Inject constructor(
         val brands = args[4] as List<BrandEntity>
         val systems = args[5] as List<SizeSystemEntity>
         val values = args[6] as List<SizeValueEntity>
+        @Suppress("UNCHECKED_CAST")
+        val seasons = args[7] as List<SeasonEntity>
+        @Suppress("UNCHECKED_CAST")
+        val occasions = args[8] as List<OccasionEntity>
+        @Suppress("UNCHECKED_CAST")
+        val materials = args[9] as List<MaterialEntity>
+        @Suppress("UNCHECKED_CAST")
+        val patterns = args[10] as List<PatternEntity>
 
         ClothingFormUiState(
             isEditMode = isEditMode,
@@ -241,6 +285,14 @@ class ClothingFormViewModel @Inject constructor(
             selectedSizeSystemId = form.selectedSizeSystemId,
             selectedSizeValueId = form.selectedSizeValueId,
             status = form.status,
+            selectedSeasonIds = form.selectedSeasonIds,
+            selectedOccasionIds = form.selectedOccasionIds,
+            selectedMaterialIds = form.selectedMaterialIds,
+            selectedPatternIds = form.selectedPatternIds,
+            allSeasons = seasons,
+            allOccasions = occasions,
+            allMaterials = materials,
+            allPatterns = patterns,
         )
     }.stateIn(
         scope = viewModelScope,
@@ -287,7 +339,11 @@ class ClothingFormViewModel @Inject constructor(
                 form.imagePath != original.imagePath ||
                 colorsChanged ||
                 form.selectedSizeValueId != original.sizeValueId ||
-                form.status != original.status
+                form.status != original.status ||
+                form.selectedSeasonIds != originalSeasonIds ||
+                form.selectedOccasionIds != originalOccasionIds ||
+                form.selectedMaterialIds != originalMaterialIds ||
+                form.selectedPatternIds != originalPatternIds
     }
 
     private fun loadItemForEditing(id: Long) {
@@ -295,6 +351,7 @@ class ClothingFormViewModel @Inject constructor(
             _form.update { it.copy(isLoading = true) }
             try {
                 val entityResult = clothingRepository.getItemEntityById(id)
+                val detail = clothingRepository.getItemDetailOnce(id)
 
                 if (entityResult is DataResult.Success) {
                     val entity = entityResult.data
@@ -315,8 +372,12 @@ class ClothingFormViewModel @Inject constructor(
                             .find { it.id == entity.subcategoryId }
                     } else null
 
-                    val colors = clothingRepository.getItemColors(id).first()
+                    val colors = detail?.colors ?: emptyList()
                     originalColors = colors
+                    originalSeasonIds = detail?.seasons?.map { it.id }?.toSet() ?: emptySet()
+                    originalOccasionIds = detail?.occasions?.map { it.id }?.toSet() ?: emptySet()
+                    originalMaterialIds = detail?.materials?.map { it.id }?.toSet() ?: emptySet()
+                    originalPatternIds = detail?.patterns?.map { it.id }?.toSet() ?: emptySet()
 
                     var systemId: Long? = null
                     if (entity.sizeValueId != null) {
@@ -351,6 +412,10 @@ class ClothingFormViewModel @Inject constructor(
                         selectedSizeValueId = entity.sizeValueId,
                         imageCaption = entity.imageCaption,
                         status = entity.status,
+                        selectedSeasonIds = originalSeasonIds,
+                        selectedOccasionIds = originalOccasionIds,
+                        selectedMaterialIds = originalMaterialIds,
+                        selectedPatternIds = originalPatternIds,
                         isLoading = false
                     ) }
                 }
@@ -646,6 +711,24 @@ class ClothingFormViewModel @Inject constructor(
         }
     }
 
+    fun onSeasonToggle(id: Long) {
+        _form.update { it.copy(selectedSeasonIds = it.selectedSeasonIds.toggle(id)) }
+    }
+
+    fun onOccasionToggle(id: Long) {
+        _form.update { it.copy(selectedOccasionIds = it.selectedOccasionIds.toggle(id)) }
+    }
+
+    fun onMaterialToggle(id: Long) {
+        _form.update { it.copy(selectedMaterialIds = it.selectedMaterialIds.toggle(id)) }
+    }
+
+    fun onPatternToggle(id: Long) {
+        _form.update { it.copy(selectedPatternIds = it.selectedPatternIds.toggle(id)) }
+    }
+
+    private fun Set<Long>.toggle(id: Long): Set<Long> = if (id in this) this - id else this + id
+
     fun onStatusSelected(status: ClothingStatus) {
         _form.update { it.copy(status = status) }
     }
@@ -695,9 +778,23 @@ class ClothingFormViewModel @Inject constructor(
                 )
 
                 val result = if (isEditMode) {
-                    clothingRepository.updateItemWithColors(item, state.selectedColors)
+                    clothingRepository.updateItemWithAttributes(
+                        item,
+                        state.selectedColors,
+                        state.selectedSeasonIds.toList(),
+                        state.selectedOccasionIds.toList(),
+                        state.selectedMaterialIds.toList(),
+                        state.selectedPatternIds.toList(),
+                    )
                 } else {
-                    clothingRepository.insertItemWithColors(item, state.selectedColors)
+                    clothingRepository.insertItemWithAttributes(
+                        item,
+                        state.selectedColors,
+                        state.selectedSeasonIds.toList(),
+                        state.selectedOccasionIds.toList(),
+                        state.selectedMaterialIds.toList(),
+                        state.selectedPatternIds.toList(),
+                    )
                 }
 
                 if (result is DataResult.Success) {

--- a/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/ClothingFormViewModel.kt
+++ b/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/ClothingFormViewModel.kt
@@ -238,13 +238,9 @@ class ClothingFormViewModel @Inject constructor(
         val brands = args[4] as List<BrandEntity>
         val systems = args[5] as List<SizeSystemEntity>
         val values = args[6] as List<SizeValueEntity>
-        @Suppress("UNCHECKED_CAST")
         val seasons = args[7] as List<SeasonEntity>
-        @Suppress("UNCHECKED_CAST")
         val occasions = args[8] as List<OccasionEntity>
-        @Suppress("UNCHECKED_CAST")
         val materials = args[9] as List<MaterialEntity>
-        @Suppress("UNCHECKED_CAST")
         val patterns = args[10] as List<PatternEntity>
 
         ClothingFormUiState(

--- a/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/ClothingFormViewModel.kt
+++ b/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/ClothingFormViewModel.kt
@@ -351,7 +351,7 @@ class ClothingFormViewModel @Inject constructor(
             _form.update { it.copy(isLoading = true) }
             try {
                 val entityResult = clothingRepository.getItemEntityById(id)
-                val detail = clothingRepository.getItemDetailOnce(id)
+                val detail = (clothingRepository.getItemDetailOnce(id) as? DataResult.Success)?.data
 
                 if (entityResult is DataResult.Success) {
                     val entity = entityResult.data

--- a/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/ClothingFormViewModel.kt
+++ b/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/ClothingFormViewModel.kt
@@ -84,7 +84,8 @@ data class ClothingFormUiState(
     val sizeSystems: List<SizeSystemEntity> = emptyList(),
     val sizeValues: List<SizeValueEntity> = emptyList(),
     val selectedSizeSystemId: Long? = null,
-    val selectedSizeValueId: Long? = null
+    val selectedSizeValueId: Long? = null,
+    val status: ClothingStatus = ClothingStatus.Active,
 )
 
 private data class FormState(
@@ -111,7 +112,8 @@ private data class FormState(
     val isLoading: Boolean = false,
     val errorMessage: Int? = null,
     val selectedSizeSystemId: Long? = null,
-    val selectedSizeValueId: Long? = null
+    val selectedSizeValueId: Long? = null,
+    val status: ClothingStatus = ClothingStatus.Active,
 )
 
 /**
@@ -237,7 +239,8 @@ class ClothingFormViewModel @Inject constructor(
             sizeSystems = systems,
             sizeValues = values,
             selectedSizeSystemId = form.selectedSizeSystemId,
-            selectedSizeValueId = form.selectedSizeValueId
+            selectedSizeValueId = form.selectedSizeValueId,
+            status = form.status,
         )
     }.stateIn(
         scope = viewModelScope,
@@ -283,7 +286,8 @@ class ClothingFormViewModel @Inject constructor(
                 form.notes != (original.notes ?: "") ||
                 form.imagePath != original.imagePath ||
                 colorsChanged ||
-                form.selectedSizeValueId != original.sizeValueId
+                form.selectedSizeValueId != original.sizeValueId ||
+                form.status != original.status
     }
 
     private fun loadItemForEditing(id: Long) {
@@ -346,6 +350,7 @@ class ClothingFormViewModel @Inject constructor(
                         selectedSizeSystemId = systemId,
                         selectedSizeValueId = entity.sizeValueId,
                         imageCaption = entity.imageCaption,
+                        status = entity.status,
                         isLoading = false
                     ) }
                 }
@@ -641,6 +646,10 @@ class ClothingFormViewModel @Inject constructor(
         }
     }
 
+    fun onStatusSelected(status: ClothingStatus) {
+        _form.update { it.copy(status = status) }
+    }
+
     fun onSizeSystemSelected(systemId: Long?) {
         sizeSystemUserOverridden = true
         _form.update { it.copy(selectedSizeSystemId = systemId, selectedSizeValueId = null) }
@@ -674,7 +683,7 @@ class ClothingFormViewModel @Inject constructor(
                     imagePath = state.imagePath,
                     sizeValueId = state.selectedSizeValueId,
                     isFavorite = originalEntity?.isFavorite ?: 0,
-                    status = originalEntity?.status ?: ClothingStatus.Active,
+                    status = state.status,
                     washStatus = originalEntity?.washStatus ?: WashStatus.Clean,
                     // Use the caption generated this session if available. Fall back to the stored
                     // caption only when the image path hasn't changed (i.e. no new image was picked).

--- a/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/FormComponents.kt
+++ b/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/FormComponents.kt
@@ -49,6 +49,8 @@ import androidx.compose.ui.semantics.role
 import androidx.compose.ui.semantics.selected
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
 import com.closet.core.data.model.BrandEntity
 import com.closet.core.data.model.ColorEntity
 import com.closet.core.data.model.SizeSystemEntity
@@ -351,3 +353,36 @@ internal fun BrandAutocompleteField(
     }
 }
 
+// ─── AttributeChipRow ────────────────────────────────────────────────────────
+
+/**
+ * A wrapping row of [FilterChip]s for toggling membership in a named attribute set.
+ *
+ * @param label      Section title shown above the chips.
+ * @param items      All available options as (id, displayLabel) pairs.
+ * @param selectedIds The IDs currently selected.
+ * @param onToggle   Called with the ID of the chip that was tapped.
+ */
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+internal fun AttributeChipRow(
+    label: String,
+    items: List<Pair<Long, String>>,
+    selectedIds: Set<Long>,
+    onToggle: (Long) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    if (items.isEmpty()) return
+    Column(modifier = modifier, verticalArrangement = Arrangement.spacedBy(8.dp)) {
+        Text(text = label, style = MaterialTheme.typography.titleSmall)
+        FlowRow(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+            items.forEach { (id, name) ->
+                FilterChip(
+                    selected = id in selectedIds,
+                    onClick = { onToggle(id) },
+                    label = { Text(name) },
+                )
+            }
+        }
+    }
+}

--- a/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/FormPreviews.kt
+++ b/app-android/features/wardrobe/src/main/kotlin/com/closet/features/wardrobe/FormPreviews.kt
@@ -106,7 +106,12 @@ private fun ClothingFormContentEmptyPreview() {
                 onImageClick = {},
                 onRemoveBackground = {},
                 onRevertSegmentation = {},
-                onColorToggle = {}
+                onColorToggle = {},
+                onStatusSelected = {},
+                onSeasonToggle = {},
+                onOccasionToggle = {},
+                onMaterialToggle = {},
+                onPatternToggle = {},
             )
         }
     }
@@ -150,7 +155,12 @@ private fun ClothingFormContentFilledPreview() {
                 onImageClick = {},
                 onRemoveBackground = {},
                 onRevertSegmentation = {},
-                onColorToggle = {}
+                onColorToggle = {},
+                onStatusSelected = {},
+                onSeasonToggle = {},
+                onOccasionToggle = {},
+                onMaterialToggle = {},
+                onPatternToggle = {},
             )
         }
     }

--- a/app-android/features/wardrobe/src/main/res/values/strings.xml
+++ b/app-android/features/wardrobe/src/main/res/values/strings.xml
@@ -8,6 +8,7 @@
     <string name="wardrobe_empty_closet">Your closet is empty. Add some clothes!</string>
     <string name="wardrobe_all_items">All</string>
     <string name="wardrobe_filter_favorites">Favorites</string>
+    <string name="wardrobe_filter_show_archived">Show archived</string>
     <string name="wardrobe_filter_title">Filters</string>
     <string name="wardrobe_filter_clear_all">Clear all</string>
     <string name="wardrobe_filter_section_color">Color</string>

--- a/app-android/features/wardrobe/src/main/res/values/strings.xml
+++ b/app-android/features/wardrobe/src/main/res/values/strings.xml
@@ -15,7 +15,14 @@
     <string name="wardrobe_filter_section_season">Season</string>
     <string name="wardrobe_filter_section_occasion">Occasion</string>
     <string name="wardrobe_cd_open_filters">Open filters</string>
+    <string name="wardrobe_cd_sort">Sort items</string>
     <string name="wardrobe_cd_open_settings">Open settings</string>
+    <string name="wardrobe_sort_newest">Newest first</string>
+    <string name="wardrobe_sort_oldest">Oldest first</string>
+    <string name="wardrobe_sort_name_az">Name A→Z</string>
+    <string name="wardrobe_sort_name_za">Name Z→A</string>
+    <string name="wardrobe_sort_most_worn">Most worn</string>
+    <string name="wardrobe_sort_least_worn">Least worn</string>
     <string name="wardrobe_filter_empty_results">No items match your filters</string>
     <string name="wardrobe_filter_clear_filters">Clear filters</string>
 

--- a/app-android/features/wardrobe/src/main/res/values/strings.xml
+++ b/app-android/features/wardrobe/src/main/res/values/strings.xml
@@ -67,6 +67,8 @@
     <string name="wardrobe_field_none">None</string>
     <string name="wardrobe_field_size_system">Size System</string>
     <string name="wardrobe_field_size_value">Size</string>
+    <string name="wardrobe_field_status">Status</string>
+    <string name="wardrobe_change_status">Change Status</string>
     <string name="wardrobe_section_colors">Colors</string>
     <string name="wardrobe_discard_title">Discard Changes?</string>
     <string name="wardrobe_discard_message">You have unsaved changes. Are you sure you want to discard them?</string>

--- a/app-android/features/wardrobe/src/main/res/values/strings.xml
+++ b/app-android/features/wardrobe/src/main/res/values/strings.xml
@@ -110,6 +110,10 @@
     <string name="wardrobe_date_cancel">Cancel</string>
     <string name="wardrobe_date_clear">Clear</string>
 
+    <!-- Log wear action on clothing detail screen -->
+    <string name="wardrobe_log_wear">Log wear</string>
+    <string name="wardrobe_log_wear_success">Wear logged</string>
+
     <!-- Wear History -->
     <string name="wardrobe_wear_history">Wear history</string>
     <string name="wardrobe_wear_history_empty">Never worn yet</string>

--- a/app-android/features/wardrobe/src/main/res/values/strings.xml
+++ b/app-android/features/wardrobe/src/main/res/values/strings.xml
@@ -47,6 +47,8 @@
     <string name="wardrobe_uncategorized">Uncategorized</string>
     <string name="wardrobe_purchase_date">Purchase Date</string>
     <string name="wardrobe_purchase_location">Purchase Location</string>
+    <string name="wardrobe_detail_purchased">Purchased</string>
+    <string name="wardrobe_detail_from">From</string>
     <string name="wardrobe_notes">Notes</string>
     <string name="wardrobe_colors">Colors</string>
     <string name="wardrobe_materials">Materials</string>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Edit item status from detail screen and pick status via dialog.
  * Log wear directly from an item (success snackbar) and support ad-hoc single-item logs.
  * Wardrobe sorting (newest/oldest, name A→Z/Z→A, most/least worn) and "show archived" toggle with reveal action.
  * Purchase date/location shown on item details.
  * Multi-select attributes in add/edit forms (seasons, occasions, materials, patterns).
  * "Laundry Day" settings entry to bulk-mark items; outfit builder accepts preselected items.

* **Documentation**
  * Updated routing docs and added a UI/UX gaps roadmap.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->