### PR TITLE
Bump version to 0.5.0 and update changelog and roadmap for Phase 1

### DIFF
--- a/app-android/CHANGELOG.md
+++ b/app-android/CHANGELOG.md
@@ -10,6 +10,40 @@ Versions correspond to `versionName` in `app/build.gradle.kts`.
 
 ---
 
+## [0.5.0] — 2026-04-04
+
+Phase 1 of the chat enhancement roadmap: multi-turn conversation history,
+a "New chat" action, and a hardened JSON parsing pipeline for AI responses.
+
+### Added
+- **Multi-turn conversation history** — `ChatViewModel` maintains a rolling
+  6-turn (3-exchange) history; each successful response appends user + assistant
+  turns, failed attempts never pollute context. History is never persisted — it
+  lives only for the duration of the session.
+- **History threading through providers** — `ChatAiProvider.chat()` now accepts
+  `history: List<ConversationTurn>`; `AnthropicChatProvider`, `OpenAiChatProvider`,
+  and `GeminiChatProvider` map it to their respective message-array formats.
+  `NanoChatProvider` flattens the last 1 exchange (2 turns) as a text prefix inside
+  the single-string prompt to stay within Nano's character budget.
+- **Context block sent once** — `ChatRepository` injects the wardrobe context block
+  only in the system preamble; subsequent history turns never re-include it, keeping
+  token cost flat across multi-turn sessions.
+- **"New chat" action** — top bar edit icon clears conversation history and message
+  list; guarded by an `AlertDialog` confirmation so accidental taps don't lose context.
+- **`ConversationTurn`** value class in `core/data/ai/` with a provider-agnostic
+  `Role` enum (`User` / `Assistant`).
+
+### Fixed
+- **Gemini prose responses** — added `"generationConfig":{"responseMimeType":"application/json"}`
+  to every Gemini request so the API enforces JSON output at the model level, preventing
+  the provider from returning plain text that crashes the parser.
+- **`ChatResponseParser` fallback** — parser now strips markdown code fences and
+  extracts the outermost `{…}` block from surrounding prose before attempting to
+  parse, so a stray non-JSON response degrades gracefully rather than throwing
+  `JsonDecodingException`.
+
+---
+
 ## [0.4.0] — 2026-04-04
 
 Phase 4 of the image pipeline: automatic compression of incoming photos, segmented
@@ -324,7 +358,8 @@ Phase 1 of the RAG pipeline (semantic descriptions + image captions).
 - Two product flavors: `full` (GMS / Play Services) and `foss` (no GMS,
   F-Droid target).
 
-[Unreleased]: https://github.com/Masked-Kunsiquat/closet/compare/v0.4.0...HEAD
+[Unreleased]: https://github.com/Masked-Kunsiquat/closet/compare/v0.5.0...HEAD
+[0.5.0]: https://github.com/Masked-Kunsiquat/closet/compare/v0.4.0...v0.5.0
 [0.4.0]: https://github.com/Masked-Kunsiquat/closet/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/Masked-Kunsiquat/closet/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/Masked-Kunsiquat/closet/compare/v0.1.2...v0.2.0

--- a/app-android/app/build.gradle.kts
+++ b/app-android/app/build.gradle.kts
@@ -37,8 +37,8 @@ android {
         applicationId = "com.closet"
         minSdk = libs.versions.minSdk.get().toInt()
         targetSdk = libs.versions.targetSdk.get().toInt()
-        versionCode = 6
-        versionName = "0.4.0"
+        versionCode = 7
+        versionName = "0.5.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {

--- a/app-android/docs/roadmaps/chat-enhance-roadmap.md
+++ b/app-android/docs/roadmaps/chat-enhance-roadmap.md
@@ -168,3 +168,15 @@ The regex date parser in `ChatRouter` intentionally handles only unambiguous pat
 - Scope to the `full` flavor only; FOSS falls back to the existing strict regex path.
 - ~1.5 MB model download via Play Services on first use.
 - Drop-in replacement for the date-parsing branch inside `ChatRouter` — no changes needed to the DAO queries or the rest of the router.
+
+### Phase 2 — ML Kit Language Identification as a router guard
+
+The `ChatRouter` pattern-matching is written for English. A non-English query that partially overlaps an English pattern (e.g. a French query containing "worn") could trigger a false-positive match and return wrong data. [ML Kit Language ID](https://developers.google.com/ml-kit/language/identification) can gate the router: if the detected language is not English with sufficient confidence, skip pattern matching entirely and fall through to RAG.
+
+**When to consider it:** if the app ships to non-English locales or if user testing surfaces false-positive router matches on multilingual input.
+
+**Implementation notes:**
+- Uses `com.google.mlkit:language-id` — on-device, no network call, ~900 KB model bundled at install time.
+- Works on all devices and API levels; no GMS or AICore requirement. Can be added to both `full` and `foss` flavors.
+- One call site: a single `languageIdentifier.identifyLanguage(message)` check at the top of `ChatRouter.route()` before any regex is evaluated.
+- Threshold suggestion: only proceed with routing if the top language tag is `"en"` with confidence ≥ 0.7; everything else is `Unrouted`.


### PR DESCRIPTION
Version bump 0.4.0 → 0.5.0 (versionCode 6 → 7) to mark completion of Phase 1 chat enhancements (multi-turn history, new chat action, Gemini JSON fix, parser fallback). Roadmap updated with ML Kit Language ID as a future Phase 2 router guard.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Multi-turn conversation history: Chat now maintains context across multiple exchanges within a session.
  * "New chat" button in top bar to reset conversations with confirmation protection.

* **Bug Fixes**
  * Improved chat response parsing robustness.
  * Fixed Gemini API response formatting for consistent JSON output.

* **Documentation**
  * Updated roadmap with Phase 2 planned enhancements for chat routing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->