### PR TITLE
Add ChatRouter intent-routing layer for stat queries

### DIFF
--- a/app-android/CHANGELOG.md
+++ b/app-android/CHANGELOG.md
@@ -39,6 +39,23 @@ touching the RAG pipeline — faster, zero token cost, fully offline.
 - **Routed responses skip history** — `WithStat` answers are data facts, not
   conversational turns; they don't pollute the rolling history so follow-up
   questions continue to reach RAG naturally.
+- **ML Kit Language ID router guard** — `com.google.mlkit:language-id` (bundled,
+  ~900 KB, no Play Services required) gates the router on English-only input.
+  Non-English queries and low-confidence detections (< 0.7) skip pattern matching
+  and fall through to RAG. Works on both `full` and `foss` flavors.
+- **ML Kit Entity Extraction date parser** (`full` flavor) — `ChatDateParser` uses
+  the English entity extraction model (~5.6 MB, downloaded via Play Services on
+  first use) to handle natural date expressions ("yesterday", "last Monday",
+  "3 days ago") that the regex parser cannot handle; FOSS flavor uses regex only.
+  `setReferenceTime` is passed on every call so relative expressions resolve
+  correctly against the current moment.
+- **Extended router — 8 patterns total** — five additional intents beyond the
+  original three:
+  - "What have I never worn?" → `getItemsNeverWorn()`
+  - "What's in my laundry?" / "What needs washing?" → `getItemsNeedingWash()`
+  - "What did I wear last?" → `getMostRecentLog()`
+  - "How many items do I own?" → `getItemCount()`
+  - "What's my most worn item?" → `getMostWornItem()`
 
 ---
 

--- a/app-android/CHANGELOG.md
+++ b/app-android/CHANGELOG.md
@@ -10,6 +10,38 @@ Versions correspond to `versionName` in `app/build.gradle.kts`.
 
 ---
 
+## [0.6.0] — 2026-04-04
+
+Phase 2 of the chat enhancement roadmap: intent routing for stat queries.
+Common data questions are answered directly from DAO queries without
+touching the RAG pipeline — faster, zero token cost, fully offline.
+
+### Added
+- **`ChatRouter`** — pre-LLM intent router in `features/chat/`. Intercepts
+  three query patterns before the encoder or AI provider is invoked:
+  1. "How many times have I worn [item]?" → `ClothingDao.getWearCountByName()`
+  2. "What haven't I worn in [N] days?" → `ClothingDao.getItemsNotWornSince()`
+  3. "What did I wear on [date]?" → `LogDao.getLogsForDateOnce()`
+  Unrecognised or ambiguous patterns return `Unrouted` and fall through to RAG.
+- **ML Kit Language ID router guard** — `com.google.mlkit:language-id` (bundled,
+  ~900 KB, no Play Services required) gates the router on English-only input.
+  Non-English queries and low-confidence detections (< 0.7) skip pattern matching
+  and fall through to RAG. Works on both `full` and `foss` flavors.
+- **`ChatResponse.WithStat`** — new response subtype for routed data answers;
+  carries `label` (e.g. "Wear count"), `value` (e.g. "5 times"), and optional
+  `itemIds` for the item rail.
+- **`StatBubble`** — new composable in `ChatScreen`; renders a compact card
+  with a label/value row and an optional `ItemChip` rail for referenced items.
+- **New DAO queries** — `ClothingDao.getWearCountByName()` (fuzzy `LIKE`,
+  shortest-name-first), `ClothingDao.getItemsNotWornSince()` (`NOT EXISTS`
+  subquery via `outfit_log_items`), `LogDao.getLogsForDateOnce()` (one-shot
+  `suspend` variant of the existing `Flow`-based `getLogsByDate`).
+- **Routed responses skip history** — `WithStat` answers are data facts, not
+  conversational turns; they don't pollute the rolling history so follow-up
+  questions continue to reach RAG naturally.
+
+---
+
 ## [0.5.0] — 2026-04-04
 
 Phase 1 of the chat enhancement roadmap: multi-turn conversation history,
@@ -358,7 +390,8 @@ Phase 1 of the RAG pipeline (semantic descriptions + image captions).
 - Two product flavors: `full` (GMS / Play Services) and `foss` (no GMS,
   F-Droid target).
 
-[Unreleased]: https://github.com/Masked-Kunsiquat/closet/compare/v0.5.0...HEAD
+[Unreleased]: https://github.com/Masked-Kunsiquat/closet/compare/v0.6.0...HEAD
+[0.6.0]: https://github.com/Masked-Kunsiquat/closet/compare/v0.5.0...v0.6.0
 [0.5.0]: https://github.com/Masked-Kunsiquat/closet/compare/v0.4.0...v0.5.0
 [0.4.0]: https://github.com/Masked-Kunsiquat/closet/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/Masked-Kunsiquat/closet/compare/v0.2.0...v0.3.0

--- a/app-android/app/build.gradle.kts
+++ b/app-android/app/build.gradle.kts
@@ -37,8 +37,8 @@ android {
         applicationId = "com.closet"
         minSdk = libs.versions.minSdk.get().toInt()
         targetSdk = libs.versions.targetSdk.get().toInt()
-        versionCode = 7
-        versionName = "0.5.0"
+        versionCode = 8
+        versionName = "0.6.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {

--- a/app-android/core/data/src/main/kotlin/com/closet/core/data/ai/ChatAiProvider.kt
+++ b/app-android/core/data/src/main/kotlin/com/closet/core/data/ai/ChatAiProvider.kt
@@ -55,4 +55,19 @@ sealed interface ChatResponse {
      * [reason] is the AI's one-sentence rationale.
      */
     data class WithOutfit(val text: String, val itemIds: List<Long>, val reason: String) : ChatResponse
+
+    /**
+     * Answer is a direct data stat returned by [com.closet.features.chat.ChatRouter]
+     * without going through the RAG + provider pipeline.
+     *
+     * [label] is the stat name (e.g. "Wear count").
+     * [value] is the formatted result (e.g. "14 times").
+     * [itemIds] are the relevant item IDs (empty for aggregate stats).
+     */
+    data class WithStat(
+        val text: String,
+        val label: String,
+        val value: String,
+        val itemIds: List<Long> = emptyList(),
+    ) : ChatResponse
 }

--- a/app-android/core/data/src/main/kotlin/com/closet/core/data/dao/ClothingDao.kt
+++ b/app-android/core/data/src/main/kotlin/com/closet/core/data/dao/ClothingDao.kt
@@ -278,6 +278,53 @@ interface ClothingDao {
     // ── Chat router queries ───────────────────────────────────────────────────
 
     /**
+     * Returns the total count of clothing items. Used by [com.closet.features.chat.ChatRouter]
+     * for "how many items do I own?" queries.
+     */
+    @Query("SELECT COUNT(*) FROM clothing_items")
+    suspend fun getItemCount(): Int
+
+    /**
+     * Returns all items that have never been worn (no entry in [outfit_log_items] at all).
+     * Used by [com.closet.features.chat.ChatRouter] for "what have I never worn?" queries.
+     */
+    @Query("""
+        SELECT ci.id, ci.name, ci.image_path
+        FROM clothing_items ci
+        WHERE NOT EXISTS (
+            SELECT 1
+            FROM outfit_log_items oli
+            WHERE oli.clothing_item_id = ci.id
+        )
+        ORDER BY ci.name ASC
+    """)
+    suspend fun getItemsNeverWorn(): List<NotWornItem>
+
+    /**
+     * Returns all items currently marked as dirty (wash_status = 'Dirty').
+     * Used by [com.closet.features.chat.ChatRouter] for "what's in my laundry?" queries.
+     */
+    @Query("""
+        SELECT ci.id, ci.name, ci.image_path
+        FROM clothing_items ci
+        WHERE ci.wash_status = 'Dirty'
+        ORDER BY ci.name ASC
+    """)
+    suspend fun getItemsNeedingWash(): List<NotWornItem>
+
+    /**
+     * Returns the single most-worn item across all time, or null if nothing has been worn.
+     * Used by [com.closet.features.chat.ChatRouter] for "what's my most worn item?" queries.
+     */
+    @Query("""
+        SELECT ci.id, ci.name, ci.image_path, $WEAR_COUNT_SUBQUERY
+        FROM clothing_items ci
+        ORDER BY wear_count DESC
+        LIMIT 1
+    """)
+    suspend fun getMostWornItem(): WearCountResult?
+
+    /**
      * Returns the single closest item whose name matches [query] (case-insensitive LIKE),
      * along with its wear count. Returns null if no item matches.
      * Used by [com.closet.features.chat.ChatRouter] for wear-count pattern queries.

--- a/app-android/core/data/src/main/kotlin/com/closet/core/data/dao/ClothingDao.kt
+++ b/app-android/core/data/src/main/kotlin/com/closet/core/data/dao/ClothingDao.kt
@@ -339,9 +339,11 @@ interface ClothingDao {
     suspend fun getWearCountByName(query: String): WearCountResult?
 
     /**
-     * Returns all items that have not been worn on or after [cutoffDate] (YYYY-MM-DD).
-     * An item counts as worn if it appears in [outfit_log_items] linked to a log on or
-     * after [cutoffDate]. Items with no wear history at all are included.
+     * Returns all items that have not been worn after [cutoffDate] (YYYY-MM-DD, exclusive).
+     * An item counts as worn if it appears in [outfit_log_items] linked to a log strictly
+     * after [cutoffDate]. Items worn exactly on [cutoffDate] are treated as "not worn in N days"
+     * (boundary is exclusive so the label matches — "30 days" includes day-30 items).
+     * Items with no wear history at all are also included.
      * Used by [com.closet.features.chat.ChatRouter] for "haven't worn in N days" queries.
      */
     @Query("""
@@ -352,7 +354,7 @@ interface ClothingDao {
             FROM outfit_logs ol
             JOIN outfit_log_items oli ON oli.outfit_log_id = ol.id
             WHERE oli.clothing_item_id = ci.id
-            AND ol.date >= :cutoffDate
+            AND ol.date > :cutoffDate
         )
         ORDER BY ci.name ASC
     """)

--- a/app-android/core/data/src/main/kotlin/com/closet/core/data/dao/ClothingDao.kt
+++ b/app-android/core/data/src/main/kotlin/com/closet/core/data/dao/ClothingDao.kt
@@ -274,4 +274,55 @@ interface ClothingDao {
     /** Returns all non-null image paths; used by [ImageCompressionWorker] to build its work queue. */
     @Query("SELECT image_path FROM clothing_items WHERE image_path IS NOT NULL")
     suspend fun getAllImagePaths(): List<String>
+
+    // ── Chat router queries ───────────────────────────────────────────────────
+
+    /**
+     * Returns the single closest item whose name matches [query] (case-insensitive LIKE),
+     * along with its wear count. Returns null if no item matches.
+     * Used by [com.closet.features.chat.ChatRouter] for wear-count pattern queries.
+     */
+    @Query("""
+        SELECT ci.id, ci.name, ci.image_path, $WEAR_COUNT_SUBQUERY
+        FROM clothing_items ci
+        WHERE ci.name LIKE '%' || :query || '%'
+        ORDER BY length(ci.name) ASC
+        LIMIT 1
+    """)
+    suspend fun getWearCountByName(query: String): WearCountResult?
+
+    /**
+     * Returns all items that have not been worn on or after [cutoffDate] (YYYY-MM-DD).
+     * An item counts as worn if it appears in [outfit_log_items] linked to a log on or
+     * after [cutoffDate]. Items with no wear history at all are included.
+     * Used by [com.closet.features.chat.ChatRouter] for "haven't worn in N days" queries.
+     */
+    @Query("""
+        SELECT ci.id, ci.name, ci.image_path
+        FROM clothing_items ci
+        WHERE NOT EXISTS (
+            SELECT 1
+            FROM outfit_logs ol
+            JOIN outfit_log_items oli ON oli.outfit_log_id = ol.id
+            WHERE oli.clothing_item_id = ci.id
+            AND ol.date >= :cutoffDate
+        )
+        ORDER BY ci.name ASC
+    """)
+    suspend fun getItemsNotWornSince(cutoffDate: String): List<NotWornItem>
 }
+
+/** Result of a wear-count lookup by item name — used by the [com.closet.features.chat.ChatRouter]. */
+data class WearCountResult(
+    val id: Long,
+    val name: String,
+    @ColumnInfo(name = "image_path") val imagePath: String?,
+    @ColumnInfo(name = "wear_count") val wearCount: Int,
+)
+
+/** A clothing item with no recent wear — returned by [ClothingDao.getItemsNotWornSince]. */
+data class NotWornItem(
+    val id: Long,
+    val name: String,
+    @ColumnInfo(name = "image_path") val imagePath: String?,
+)

--- a/app-android/core/data/src/main/kotlin/com/closet/core/data/dao/LogDao.kt
+++ b/app-android/core/data/src/main/kotlin/com/closet/core/data/dao/LogDao.kt
@@ -36,6 +36,29 @@ interface LogDao {
     fun getLogsByDate(date: String): Flow<List<OutfitLogWithMeta>>
 
     /**
+     * One-shot variant of [getLogsByDate] for use in the chat router where a [Flow] is not needed.
+     * @param date The date string (YYYY-MM-DD).
+     */
+    @Query("""
+        SELECT
+            ol.*,
+            o.name AS outfit_name,
+            COUNT(oi.clothing_item_id) AS item_count,
+            (SELECT ci.image_path
+             FROM outfit_items oi2
+             JOIN clothing_items ci ON ci.id = oi2.clothing_item_id
+             WHERE oi2.outfit_id = ol.outfit_id AND ci.image_path IS NOT NULL
+             LIMIT 1) AS cover_image
+        FROM outfit_logs ol
+        LEFT JOIN outfits o     ON o.id  = ol.outfit_id
+        LEFT JOIN outfit_items oi ON oi.outfit_id = ol.outfit_id
+        WHERE ol.date = :date
+        GROUP BY ol.id
+        ORDER BY ol.is_ootd DESC, ol.created_at ASC
+    """)
+    suspend fun getLogsForDateOnce(date: String): List<OutfitLogWithMeta>
+
+    /**
      * Returns the row ID of an existing log for [outfitId] on [date], or null if none exists.
      * Used by [LogRepository.wearOutfitToday] to keep wear logging idempotent.
      */

--- a/app-android/core/data/src/main/kotlin/com/closet/core/data/dao/LogDao.kt
+++ b/app-android/core/data/src/main/kotlin/com/closet/core/data/dao/LogDao.kt
@@ -11,12 +11,9 @@ import kotlinx.coroutines.flow.Flow
 @Dao
 interface LogDao {
 
-    /**
-     * Retrieves all outfit logs for a specific date, including metadata like outfit name and item count.
-     * @param date The date string (YYYY-MM-DD).
-     * @return A [Flow] emitting a list of [OutfitLogWithMeta].
-     */
-    @Query("""
+    companion object {
+        // Shared by getLogsByDate (Flow) and getLogsForDateOnce (suspend) — maintain SQL in one place.
+        const val LOGS_BY_DATE_QUERY = """
         SELECT
             ol.*,
             o.name AS outfit_name,
@@ -32,7 +29,15 @@ interface LogDao {
         WHERE ol.date = :date
         GROUP BY ol.id
         ORDER BY ol.is_ootd DESC, ol.created_at ASC
-    """)
+    """
+    }
+
+    /**
+     * Retrieves all outfit logs for a specific date, including metadata like outfit name and item count.
+     * @param date The date string (YYYY-MM-DD).
+     * @return A [Flow] emitting a list of [OutfitLogWithMeta].
+     */
+    @Query(LOGS_BY_DATE_QUERY)
     fun getLogsByDate(date: String): Flow<List<OutfitLogWithMeta>>
 
     /**
@@ -62,23 +67,7 @@ interface LogDao {
      * One-shot variant of [getLogsByDate] for use in the chat router where a [Flow] is not needed.
      * @param date The date string (YYYY-MM-DD).
      */
-    @Query("""
-        SELECT
-            ol.*,
-            o.name AS outfit_name,
-            COUNT(oi.clothing_item_id) AS item_count,
-            (SELECT ci.image_path
-             FROM outfit_items oi2
-             JOIN clothing_items ci ON ci.id = oi2.clothing_item_id
-             WHERE oi2.outfit_id = ol.outfit_id AND ci.image_path IS NOT NULL
-             LIMIT 1) AS cover_image
-        FROM outfit_logs ol
-        LEFT JOIN outfits o     ON o.id  = ol.outfit_id
-        LEFT JOIN outfit_items oi ON oi.outfit_id = ol.outfit_id
-        WHERE ol.date = :date
-        GROUP BY ol.id
-        ORDER BY ol.is_ootd DESC, ol.created_at ASC
-    """)
+    @Query(LOGS_BY_DATE_QUERY)
     suspend fun getLogsForDateOnce(date: String): List<OutfitLogWithMeta>
 
     /**

--- a/app-android/core/data/src/main/kotlin/com/closet/core/data/dao/LogDao.kt
+++ b/app-android/core/data/src/main/kotlin/com/closet/core/data/dao/LogDao.kt
@@ -13,19 +13,20 @@ interface LogDao {
 
     companion object {
         // Shared by getLogsByDate (Flow) and getLogsForDateOnce (suspend) — maintain SQL in one place.
+        // Reads outfit_name, item_count, and cover_image from the outfit_log_items snapshot table
+        // so that outfit renames and composition edits do not retroactively alter historical logs.
         const val LOGS_BY_DATE_QUERY = """
         SELECT
             ol.*,
-            o.name AS outfit_name,
-            COUNT(oi.clothing_item_id) AS item_count,
+            MAX(oli.outfit_name) AS outfit_name,
+            COUNT(oli.clothing_item_id) AS item_count,
             (SELECT ci.image_path
-             FROM outfit_items oi2
-             JOIN clothing_items ci ON ci.id = oi2.clothing_item_id
-             WHERE oi2.outfit_id = ol.outfit_id AND ci.image_path IS NOT NULL
+             FROM outfit_log_items oli2
+             JOIN clothing_items ci ON ci.id = oli2.clothing_item_id
+             WHERE oli2.outfit_log_id = ol.id AND ci.image_path IS NOT NULL
              LIMIT 1) AS cover_image
         FROM outfit_logs ol
-        LEFT JOIN outfits o     ON o.id  = ol.outfit_id
-        LEFT JOIN outfit_items oi ON oi.outfit_id = ol.outfit_id
+        LEFT JOIN outfit_log_items oli ON oli.outfit_log_id = ol.id
         WHERE ol.date = :date
         GROUP BY ol.id
         ORDER BY ol.is_ootd DESC, ol.created_at ASC
@@ -42,21 +43,22 @@ interface LogDao {
 
     /**
      * Returns the single most recent outfit log entry, or null if nothing has been logged.
+     * Reads from the [outfit_log_items] snapshot so the outfit name reflects what was logged,
+     * not the current live name.
      * Used by [com.closet.features.chat.ChatRouter] for "what did I wear last?" queries.
      */
     @Query("""
         SELECT
             ol.*,
-            o.name AS outfit_name,
-            COUNT(oi.clothing_item_id) AS item_count,
+            MAX(oli.outfit_name) AS outfit_name,
+            COUNT(oli.clothing_item_id) AS item_count,
             (SELECT ci.image_path
-             FROM outfit_items oi2
-             JOIN clothing_items ci ON ci.id = oi2.clothing_item_id
-             WHERE oi2.outfit_id = ol.outfit_id AND ci.image_path IS NOT NULL
+             FROM outfit_log_items oli2
+             JOIN clothing_items ci ON ci.id = oli2.clothing_item_id
+             WHERE oli2.outfit_log_id = ol.id AND ci.image_path IS NOT NULL
              LIMIT 1) AS cover_image
         FROM outfit_logs ol
-        LEFT JOIN outfits o      ON o.id  = ol.outfit_id
-        LEFT JOIN outfit_items oi ON oi.outfit_id = ol.outfit_id
+        LEFT JOIN outfit_log_items oli ON oli.outfit_log_id = ol.id
         GROUP BY ol.id
         ORDER BY ol.date DESC, ol.created_at DESC
         LIMIT 1

--- a/app-android/core/data/src/main/kotlin/com/closet/core/data/dao/LogDao.kt
+++ b/app-android/core/data/src/main/kotlin/com/closet/core/data/dao/LogDao.kt
@@ -36,6 +36,29 @@ interface LogDao {
     fun getLogsByDate(date: String): Flow<List<OutfitLogWithMeta>>
 
     /**
+     * Returns the single most recent outfit log entry, or null if nothing has been logged.
+     * Used by [com.closet.features.chat.ChatRouter] for "what did I wear last?" queries.
+     */
+    @Query("""
+        SELECT
+            ol.*,
+            o.name AS outfit_name,
+            COUNT(oi.clothing_item_id) AS item_count,
+            (SELECT ci.image_path
+             FROM outfit_items oi2
+             JOIN clothing_items ci ON ci.id = oi2.clothing_item_id
+             WHERE oi2.outfit_id = ol.outfit_id AND ci.image_path IS NOT NULL
+             LIMIT 1) AS cover_image
+        FROM outfit_logs ol
+        LEFT JOIN outfits o      ON o.id  = ol.outfit_id
+        LEFT JOIN outfit_items oi ON oi.outfit_id = ol.outfit_id
+        GROUP BY ol.id
+        ORDER BY ol.date DESC, ol.created_at DESC
+        LIMIT 1
+    """)
+    suspend fun getMostRecentLog(): OutfitLogWithMeta?
+
+    /**
      * One-shot variant of [getLogsByDate] for use in the chat router where a [Flow] is not needed.
      * @param date The date string (YYYY-MM-DD).
      */

--- a/app-android/docs/roadmaps/chat-enhance-roadmap.md
+++ b/app-android/docs/roadmaps/chat-enhance-roadmap.md
@@ -52,7 +52,9 @@ Start with exactly these three patterns — don't grow this list speculatively:
 
 - [x] Add `ChatRouter` class in `features/chat/` — takes the raw user message, returns `RouterResult` (either `Routed(response)` or `Unrouted`)
 - [x] Add any missing DAO queries needed (wear count by fuzzy name, items not worn since date, logs for date)
-- [x] `ChatRouter` does **pattern matching only** — no ML, no embeddings. Regex or `contains` on lowercased input. If the pattern doesn't match confidently, return `Unrouted` and fall through to RAG
+- [x] `ChatRouter` does **pattern matching** via regex/`contains` on lowercased input. If the pattern doesn't match confidently, return `Unrouted` and fall through to RAG.
+  - **Full flavor**: `ChatRouter` is guarded by ML Kit Language Identification (confidence ≥ 0.7); non-English or low-confidence input bypasses all routing and goes straight to RAG. Date parsing uses ML Kit Entity Extraction as a first pass with regex fallback. Both are Play-Services-backed and scoped to `fullImplementation`.
+  - **FOSS flavor**: `ChatRouter` is a no-op stub that always returns `Unrouted` — no GMS dependencies, all queries fall through to RAG.
 
 ### Repository
 
@@ -169,17 +171,11 @@ The regex date parser in `ChatRouter` intentionally handles only unambiguous pat
 - ~1.5 MB model download via Play Services on first use.
 - Drop-in replacement for the date-parsing branch inside `ChatRouter` — no changes needed to the DAO queries or the rest of the router.
 
-### Phase 2 — ML Kit Language Identification as a router guard
+### ~~Phase 2 — ML Kit Language Identification as a router guard~~ (shipped)
 
-The `ChatRouter` pattern-matching is written for English. A non-English query that partially overlaps an English pattern (e.g. a French query containing "worn") could trigger a false-positive match and return wrong data. [ML Kit Language ID](https://developers.google.com/ml-kit/language/identification) can gate the router: if the detected language is not English with sufficient confidence, skip pattern matching entirely and fall through to RAG.
+~~The `ChatRouter` pattern-matching is written for English. A non-English query that partially overlaps an English pattern (e.g. a French query containing "worn") could trigger a false-positive match and return wrong data. [ML Kit Language ID](https://developers.google.com/ml-kit/language/identification) can gate the router: if the detected language is not English with sufficient confidence, skip pattern matching entirely and fall through to RAG.~~
 
-**When to consider it:** if the app ships to non-English locales or if user testing surfaces false-positive router matches on multilingual input.
-
-**Implementation notes:**
-- Uses `com.google.mlkit:language-id` — on-device, no network call, ~900 KB model bundled at install time.
-- Works on all devices and API levels; no GMS or AICore requirement. Can be added to both `full` and `foss` flavors.
-- One call site: a single `languageIdentifier.identifyLanguage(message)` check at the top of `ChatRouter.route()` before any regex is evaluated.
-- Threshold suggestion: only proceed with routing if the top language tag is `"en"` with confidence ≥ 0.7; everything else is `Unrouted`.
+**Shipped in full flavor.** `ChatRouter` (full flavor) calls `languageIdentifier.identifyLanguage()` at the top of `route()` with a 0.7 confidence threshold. Non-English or low-confidence input returns `Unrouted` immediately. On ML Kit failure the router also returns `Unrouted` (fail-closed). The FOSS-flavor `ChatRouter` stub skips language ID entirely and always returns `Unrouted`. `mlkit.language.id` and `kotlinx.coroutines.play.services` are both scoped to `fullImplementation`.
 
 ### Phase 2 — Additional router intents
 

--- a/app-android/docs/roadmaps/chat-enhance-roadmap.md
+++ b/app-android/docs/roadmaps/chat-enhance-roadmap.md
@@ -183,7 +183,9 @@ The `ChatRouter` pattern-matching is written for English. A non-English query th
 
 ### Phase 2 — Additional router intents
 
-The three shipped patterns are intentionally minimal. These are the strongest candidates for future expansion, ordered by confidence of intent and query simplicity. **Do not add speculatively** — add a pattern only when user feedback confirms it's a common miss.
+~~The three shipped patterns are intentionally minimal. These are the strongest candidates for future expansion~~ — all five additional patterns below have been implemented alongside the original three.
+
+**Shipped (8 patterns total):**
 
 | Query pattern | DAO / query | Notes |
 |---|---|---|

--- a/app-android/docs/roadmaps/chat-enhance-roadmap.md
+++ b/app-android/docs/roadmaps/chat-enhance-roadmap.md
@@ -63,13 +63,13 @@ Start with exactly these three patterns — don't grow this list speculatively:
 - [x] Add `ChatResponse.WithStat(text: String, label: String, value: String, itemIds: List<Long>)` to `ChatAiProvider.kt`
   - `label`: e.g. "Wear count", `value`: e.g. "14 times"
   - `itemIds`: empty list if the stat is aggregate, populated if it refers to specific items
-- [ ] Add `ChatMessage.Assistant.WithStat` mirror in `ChatMessage.kt`
-- [ ] Add `StatBubble` composable in `ChatScreen.kt` — compact card with label/value pair and optional item rail
+- [x] Add `ChatMessage.Assistant.WithStat` mirror in `ChatMessage.kt`
+- [x] Add `StatBubble` composable in `ChatScreen.kt` — compact card with label/value pair and optional item rail
 
 ### ViewModel
 
-- [ ] Map `ChatResponse.WithStat` → `ChatMessage.Assistant.WithStat` in `ChatViewModel.toAssistantMessage()`
-- [ ] Routed responses do **not** update `history` — they are data answers, not conversational turns; follow-ups on them fall through to RAG naturally
+- [x] Map `ChatResponse.WithStat` → `ChatMessage.Assistant.WithStat` in `ChatViewModel.toAssistantMessage()`
+- [x] Routed responses do **not** update `history` — they are data answers, not conversational turns; follow-ups on them fall through to RAG naturally
 
 ### Pitfalls
 

--- a/app-android/docs/roadmaps/chat-enhance-roadmap.md
+++ b/app-android/docs/roadmaps/chat-enhance-roadmap.md
@@ -50,9 +50,9 @@ Start with exactly these three patterns — don't grow this list speculatively:
 
 ### Data layer
 
-- [ ] Add `ChatRouter` class in `features/chat/` — takes the raw user message, returns `RouterResult` (either `Routed(response)` or `Unrouted`)
-- [ ] Add any missing DAO queries needed (wear count by fuzzy name, items not worn since date, logs for date)
-- [ ] `ChatRouter` does **pattern matching only** — no ML, no embeddings. Regex or `contains` on lowercased input. If the pattern doesn't match confidently, return `Unrouted` and fall through to RAG
+- [x] Add `ChatRouter` class in `features/chat/` — takes the raw user message, returns `RouterResult` (either `Routed(response)` or `Unrouted`)
+- [x] Add any missing DAO queries needed (wear count by fuzzy name, items not worn since date, logs for date)
+- [x] `ChatRouter` does **pattern matching only** — no ML, no embeddings. Regex or `contains` on lowercased input. If the pattern doesn't match confidently, return `Unrouted` and fall through to RAG
 
 ### Repository
 
@@ -60,7 +60,7 @@ Start with exactly these three patterns — don't grow this list speculatively:
 
 ### New response type — stat card
 
-- [ ] Add `ChatResponse.WithStat(text: String, label: String, value: String, itemIds: List<Long>)` to `ChatAiProvider.kt`
+- [x] Add `ChatResponse.WithStat(text: String, label: String, value: String, itemIds: List<Long>)` to `ChatAiProvider.kt`
   - `label`: e.g. "Wear count", `value`: e.g. "14 times"
   - `itemIds`: empty list if the stat is aggregate, populated if it refers to specific items
 - [ ] Add `ChatMessage.Assistant.WithStat` mirror in `ChatMessage.kt`

--- a/app-android/docs/roadmaps/chat-enhance-roadmap.md
+++ b/app-android/docs/roadmaps/chat-enhance-roadmap.md
@@ -56,7 +56,7 @@ Start with exactly these three patterns — don't grow this list speculatively:
 
 ### Repository
 
-- [ ] `ChatRepository.query()` checks `ChatRouter` first; on `Routed` result, package it into a `ChatResponse` and return early without calling the encoder or provider
+- [x] `ChatRepository.query()` checks `ChatRouter` first; on `Routed` result, package it into a `ChatResponse` and return early without calling the encoder or provider
 
 ### New response type — stat card
 

--- a/app-android/docs/roadmaps/chat-enhance-roadmap.md
+++ b/app-android/docs/roadmaps/chat-enhance-roadmap.md
@@ -180,3 +180,19 @@ The `ChatRouter` pattern-matching is written for English. A non-English query th
 - Works on all devices and API levels; no GMS or AICore requirement. Can be added to both `full` and `foss` flavors.
 - One call site: a single `languageIdentifier.identifyLanguage(message)` check at the top of `ChatRouter.route()` before any regex is evaluated.
 - Threshold suggestion: only proceed with routing if the top language tag is `"en"` with confidence ≥ 0.7; everything else is `Unrouted`.
+
+### Phase 2 — Additional router intents
+
+The three shipped patterns are intentionally minimal. These are the strongest candidates for future expansion, ordered by confidence of intent and query simplicity. **Do not add speculatively** — add a pattern only when user feedback confirms it's a common miss.
+
+| Query pattern | DAO / query | Notes |
+|---|---|---|
+| "What have I never worn?" | `WHERE wear_count = 0` | Zero ambiguity; reuses the `outfit_log_items` join pattern already in `getItemsNotWornSince` |
+| "What's in my laundry?" / "What needs washing?" | `WHERE wash_status = 'dirty'` | Direct, actionable; wash status is an existing field |
+| "What was my last outfit?" / "What did I wear last?" | `SELECT * FROM outfit_logs ORDER BY date DESC LIMIT 1` | Simple and unambiguous |
+| "How many items do I own?" / "How big is my wardrobe?" | `SELECT COUNT(*) FROM clothing_items` | Instant; zero AI value-add |
+| "What's my most worn item?" | `StatsDao` already has the ranked query | One-liner; `StatItem` result type already exists |
+
+**Patterns to avoid routing:**
+- "What [category] do I have?" — category name matching is fuzzy; RAG handles it better and won't silently return incomplete results if the user's term doesn't exactly match a subcategory name.
+- Any pattern where a confident-looking match could return a subset of the correct answer — a wrong routed response is worse than a slower RAG response.

--- a/app-android/features/chat/build.gradle.kts
+++ b/app-android/features/chat/build.gradle.kts
@@ -77,6 +77,10 @@ dependencies {
     // MLKit GenAI Prompt API — Gemini Nano on-device inference (full flavor only; foss uses stub)
     "fullImplementation"(libs.mlkit.genai.prompt)
 
+    // MLKit Entity Extraction — model downloaded via Play Services on first use (~5.6 MB).
+    // Full flavor only; FOSS uses the regex-only ChatDateParser stub.
+    "fullImplementation"(libs.mlkit.entity.extraction)
+
     // MLKit Language Identification — bundled on-device model, no Play Services required.
     // Used by ChatRouter to gate English-only pattern matching.
     implementation(libs.mlkit.language.id)

--- a/app-android/features/chat/build.gradle.kts
+++ b/app-android/features/chat/build.gradle.kts
@@ -81,10 +81,11 @@ dependencies {
     // Full flavor only; FOSS uses the regex-only ChatDateParser stub.
     "fullImplementation"(libs.mlkit.entity.extraction)
 
-    // MLKit Language Identification — bundled on-device model, no Play Services required.
-    // Used by ChatRouter to gate English-only pattern matching.
-    implementation(libs.mlkit.language.id)
-    implementation(libs.kotlinx.coroutines.play.services)
+    // MLKit Language Identification — used by ChatRouter (full flavor only; FOSS stub skips it).
+    "fullImplementation"(libs.mlkit.language.id)
+    // kotlinx coroutines Task.await() extension — depends on play-services-tasks transiently;
+    // full flavor only so the FOSS build stays GMS-free.
+    "fullImplementation"(libs.kotlinx.coroutines.play.services)
 
     // Logging
     implementation(libs.timber)

--- a/app-android/features/chat/build.gradle.kts
+++ b/app-android/features/chat/build.gradle.kts
@@ -77,6 +77,11 @@ dependencies {
     // MLKit GenAI Prompt API — Gemini Nano on-device inference (full flavor only; foss uses stub)
     "fullImplementation"(libs.mlkit.genai.prompt)
 
+    // MLKit Language Identification — bundled on-device model, no Play Services required.
+    // Used by ChatRouter to gate English-only pattern matching.
+    implementation(libs.mlkit.language.id)
+    implementation(libs.kotlinx.coroutines.play.services)
+
     // Logging
     implementation(libs.timber)
 }

--- a/app-android/features/chat/src/foss/kotlin/com/closet/features/chat/ChatDateParser.kt
+++ b/app-android/features/chat/src/foss/kotlin/com/closet/features/chat/ChatDateParser.kt
@@ -1,0 +1,13 @@
+package com.closet.features.chat
+
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * FOSS-flavor [ChatDateParser]: regex-only date parsing via [regexParseDate].
+ * ML Kit Entity Extraction is not available in the FOSS build (requires Play Services).
+ */
+@Singleton
+class ChatDateParser @Inject constructor() {
+    suspend fun parseDate(text: String): String? = regexParseDate(text)
+}

--- a/app-android/features/chat/src/foss/kotlin/com/closet/features/chat/ChatRouter.kt
+++ b/app-android/features/chat/src/foss/kotlin/com/closet/features/chat/ChatRouter.kt
@@ -1,0 +1,24 @@
+package com.closet.features.chat
+
+import com.closet.core.data.ai.ChatResponse
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * FOSS-flavor [ChatRouter]: no-op stub — always returns [RouterResult.Unrouted].
+ *
+ * ML Kit Language Identification and [kotlinx.coroutines.tasks.await] both pull in
+ * GMS transitive dependencies, so routing is disabled in the FOSS build. All queries
+ * fall through to the RAG + provider pipeline as usual.
+ */
+@Singleton
+class ChatRouter @Inject constructor() {
+
+    sealed interface RouterResult {
+        data class Routed(val response: ChatResponse) : RouterResult
+        data object Unrouted : RouterResult
+    }
+
+    @Suppress("RedundantSuspendModifier")
+    suspend fun route(message: String): RouterResult = RouterResult.Unrouted
+}

--- a/app-android/features/chat/src/full/kotlin/com/closet/features/chat/ChatDateParser.kt
+++ b/app-android/features/chat/src/full/kotlin/com/closet/features/chat/ChatDateParser.kt
@@ -1,0 +1,75 @@
+package com.closet.features.chat
+
+import com.google.mlkit.nl.entityextraction.DateTimeEntity
+import com.google.mlkit.nl.entityextraction.Entity
+import com.google.mlkit.nl.entityextraction.EntityExtraction
+import com.google.mlkit.nl.entityextraction.EntityExtractionParams
+import com.google.mlkit.nl.entityextraction.EntityExtractorOptions
+import kotlinx.coroutines.tasks.await
+import timber.log.Timber
+import java.time.Instant
+import java.time.ZoneOffset
+import java.time.format.DateTimeFormatter
+import java.util.Locale
+import java.util.TimeZone
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Full-flavor [ChatDateParser]: uses ML Kit Entity Extraction to handle the full range of
+ * natural date expressions ("yesterday", "last Monday", "3 days ago") that the regex parser
+ * cannot handle. Falls back to [regexParseDate] if the model is unavailable or returns no result.
+ *
+ * The English model (~5.6 MB) is downloaded via Play Services on first use. The download is
+ * triggered lazily in [init] so it's typically ready by the time the user first queries a date.
+ */
+@Singleton
+class ChatDateParser @Inject constructor() {
+
+    private val extractor = EntityExtraction.getClient(
+        EntityExtractorOptions.Builder(EntityExtractorOptions.ENGLISH).build()
+    )
+
+    init {
+        // Trigger model download in the background so it's ready on first query.
+        extractor.downloadModelIfNeeded()
+            .addOnFailureListener { e ->
+                Timber.w(e, "ChatDateParser: entity extraction model download failed")
+            }
+    }
+
+    /**
+     * Parses a date from [text], returning an ISO date string (`YYYY-MM-DD`) or `null`.
+     *
+     * Tries ML Kit Entity Extraction first with a reference time of "now" so relative
+     * expressions resolve correctly. Falls back to [regexParseDate] if ML Kit returns no
+     * date entity or the model is not yet available.
+     */
+    suspend fun parseDate(text: String): String? = try {
+        val params = EntityExtractionParams.Builder(text)
+            .setEntityTypesFilter(setOf(Entity.TYPE_DATE_TIME))
+            .setPreferredLocale(Locale.US)
+            .setReferenceTime(System.currentTimeMillis())
+            .setReferenceTimeZone(TimeZone.getDefault())
+            .build()
+
+        val annotations = extractor.annotate(params).await()
+
+        annotations
+            .flatMap { it.entities }
+            .filterIsInstance<DateTimeEntity>()
+            .filter { it.dateTimeGranularity >= DateTimeEntity.GRANULARITY_DAY }
+            .firstOrNull()
+            ?.let { entity ->
+                Instant.ofEpochMilli(entity.timestampMillis)
+                    .atZone(ZoneOffset.UTC)
+                    .toLocalDate()
+                    .format(DateTimeFormatter.ISO_LOCAL_DATE)
+            }
+            ?: regexParseDate(text) // model returned nothing — regex fallback
+    } catch (e: Exception) {
+        if (e is kotlinx.coroutines.CancellationException) throw e
+        Timber.w(e, "ChatDateParser: ML Kit annotation failed, falling back to regex")
+        regexParseDate(text)
+    }
+}

--- a/app-android/features/chat/src/full/kotlin/com/closet/features/chat/ChatRouter.kt
+++ b/app-android/features/chat/src/full/kotlin/com/closet/features/chat/ChatRouter.kt
@@ -78,16 +78,15 @@ class ChatRouter @Inject constructor(
 
     /**
      * Returns true if ML Kit identifies [text] as English with confidence ≥ [LANGUAGE_CONFIDENCE_THRESHOLD].
-     * On any identification failure, logs the error and returns true so the router still runs —
-     * a false negative (routing a non-English query) is less harmful than silently dropping
-     * all routing for the session.
+     * On any identification failure, logs the error and returns false (Unrouted) so the query
+     * falls through to RAG rather than risking a misrouted stat answer on non-English input.
      */
     private suspend fun isEnglish(text: String): Boolean = try {
         languageIdentifier.identifyLanguage(text).await() == "en"
     } catch (e: Exception) {
         if (e is kotlinx.coroutines.CancellationException) throw e
-        Timber.w(e, "ChatRouter: language identification failed, proceeding with routing")
-        true
+        Timber.w(e, "ChatRouter: language identification failed, falling through to RAG")
+        false
     }
 
     // ── Pattern matching ──────────────────────────────────────────────────────

--- a/app-android/features/chat/src/full/kotlin/com/closet/features/chat/ChatRouter.kt
+++ b/app-android/features/chat/src/full/kotlin/com/closet/features/chat/ChatRouter.kt
@@ -14,7 +14,8 @@ import javax.inject.Inject
 import javax.inject.Singleton
 
 /**
- * Pre-LLM intent router for the chat feature.
+ * Full-flavor [ChatRouter]: uses ML Kit Language Identification to gate English-only
+ * pattern matching, then routes stat queries directly from DAO results.
  *
  * Intercepts user messages that have unambiguous, data-only answers and returns
  * them directly from DAO queries without going through the RAG + provider pipeline.
@@ -103,7 +104,7 @@ class ChatRouter @Inject constructor(
     private fun matchesWornOn(lower: String): Boolean =
         "what did i wear on" in lower ||
         "what was i wearing on" in lower ||
-        "wore on" in lower
+        WORE_ON_INTERROGATIVE_PATTERN.containsMatchIn(lower)
 
     private fun matchesNeverWorn(lower: String): Boolean =
         "never worn" in lower ||
@@ -159,6 +160,9 @@ class ChatRouter @Inject constructor(
 
     private suspend fun routeNotWornSince(lower: String): RouterResult {
         val days = extractDays(lower) ?: DEFAULT_UNWORN_DAYS
+        // Use strict "> cutoffDate" semantics: an item last worn exactly `days` days ago
+        // should appear in the results ("haven't worn in 30 days" includes day-30 boundary).
+        // The DAO predicate is now "ol.date > :cutoffDate" (exclusive), so cutoffDate = today - days.
         val cutoffDate = LocalDate.now().minusDays(days.toLong()).toString()
         val items = clothingDao.getItemsNotWornSince(cutoffDate)
 
@@ -335,5 +339,9 @@ class ChatRouter @Inject constructor(
         )
 
         private val DAYS_PATTERN = Regex("""(\d+)\s*(days?|weeks?)""")
+
+        // Matches "what ... i wore on" with at most ~15 chars between "what" and "i" so that
+        // incidental uses like "what goes with what I wore on Tuesday?" don't trigger routing.
+        private val WORE_ON_INTERROGATIVE_PATTERN = Regex("""\bwhat\b.{0,15}\bi\b\s*\bwore on\b""")
     }
 }

--- a/app-android/features/chat/src/main/kotlin/com/closet/features/chat/ChatRepository.kt
+++ b/app-android/features/chat/src/main/kotlin/com/closet/features/chat/ChatRepository.kt
@@ -13,10 +13,15 @@ import javax.inject.Singleton
 
 /**
  * Orchestrates the full RAG query pipeline:
- * encode query → retrieve top-K items → build context block → call AI provider.
+ * route → (if unrouted) encode query → retrieve top-K items → build context block → call AI provider.
+ *
+ * [ChatRouter] is checked first. On a [ChatRouter.RouterResult.Routed] result the response is
+ * returned immediately — the encoder, index, and provider are never touched. This keeps routed
+ * responses zero-token-cost and fully offline.
  */
 @Singleton
 class ChatRepository @Inject constructor(
+    private val router: ChatRouter,
     private val encoder: EmbeddingEncoder,
     private val index: EmbeddingIndex,
     private val clothingDao: ClothingDao,
@@ -27,6 +32,12 @@ class ChatRepository @Inject constructor(
         history: List<ConversationTurn> = emptyList(),
     ): Result<ChatResponse> {
         return try {
+            // Router check — short-circuits the RAG pipeline for stat queries.
+            when (val routed = router.route(userMessage)) {
+                is ChatRouter.RouterResult.Routed -> return Result.success(routed.response)
+                is ChatRouter.RouterResult.Unrouted -> Unit
+            }
+
             val queryVec = encoder.encode(userMessage).getOrElse {
                 if (it is CancellationException) throw it
                 return Result.failure(it)

--- a/app-android/features/chat/src/main/kotlin/com/closet/features/chat/ChatRepository.kt
+++ b/app-android/features/chat/src/main/kotlin/com/closet/features/chat/ChatRepository.kt
@@ -18,6 +18,8 @@ import javax.inject.Singleton
  * [ChatRouter] is checked first. On a [ChatRouter.RouterResult.Routed] result the response is
  * returned immediately — the encoder, index, and provider are never touched. This keeps routed
  * responses zero-token-cost and fully offline.
+ *
+ * In the FOSS flavor [ChatRouter] is a no-op stub, so all queries go through the full pipeline.
  */
 @Singleton
 class ChatRepository @Inject constructor(

--- a/app-android/features/chat/src/main/kotlin/com/closet/features/chat/ChatRouter.kt
+++ b/app-android/features/chat/src/main/kotlin/com/closet/features/chat/ChatRouter.kt
@@ -1,0 +1,232 @@
+package com.closet.features.chat
+
+import com.closet.core.data.ai.ChatResponse
+import com.closet.core.data.dao.ClothingDao
+import com.closet.core.data.dao.LogDao
+import timber.log.Timber
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
+import java.time.format.DateTimeParseException
+import java.util.Locale
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Pre-LLM intent router for the chat feature.
+ *
+ * Intercepts user messages that have unambiguous, data-only answers and returns
+ * them directly from DAO queries without going through the RAG + provider pipeline.
+ * Faster, zero token cost, works fully offline.
+ *
+ * Three patterns are handled (per the Phase 2 spec — don't expand speculatively):
+ * 1. "How many times have I worn [item]?" → [ClothingDao.getWearCountByName]
+ * 2. "What haven't I worn in [N] days?"   → [ClothingDao.getItemsNotWornSince]
+ * 3. "What did I wear on [date]?"         → [LogDao.getLogsForDateOnce]
+ *
+ * If a pattern doesn't match confidently, or the DAO returns an ambiguous result,
+ * [RouterResult.Unrouted] is returned and the caller falls through to RAG.
+ */
+@Singleton
+class ChatRouter @Inject constructor(
+    private val clothingDao: ClothingDao,
+    private val logDao: LogDao,
+) {
+
+    sealed interface RouterResult {
+        data class Routed(val response: ChatResponse) : RouterResult
+        data object Unrouted : RouterResult
+    }
+
+    suspend fun route(message: String): RouterResult {
+        val lower = message.lowercase(Locale.ENGLISH).trim()
+
+        return when {
+            matchesWearCount(lower)   -> routeWearCount(lower)
+            matchesNotWornSince(lower) -> routeNotWornSince(lower)
+            matchesWornOn(lower)      -> routeWornOn(lower)
+            else                      -> RouterResult.Unrouted
+        }
+    }
+
+    // ── Pattern matching ──────────────────────────────────────────────────────
+
+    private fun matchesWearCount(lower: String): Boolean =
+        ("how many times" in lower || "wear count" in lower) &&
+        ("worn" in lower || "wear" in lower)
+
+    private fun matchesNotWornSince(lower: String): Boolean =
+        ("haven't worn" in lower || "havent worn" in lower ||
+         "not worn" in lower || "unworn" in lower) &&
+        (DAYS_PATTERN.containsMatchIn(lower) || "lately" in lower || "recently" in lower)
+
+    private fun matchesWornOn(lower: String): Boolean =
+        "what did i wear on" in lower ||
+        "what was i wearing on" in lower ||
+        "wore on" in lower
+
+    // ── Routing handlers ─────────────────────────────────────────────────────
+
+    private suspend fun routeWearCount(lower: String): RouterResult {
+        val itemName = extractItemName(lower) ?: run {
+            Timber.d("ChatRouter: wear-count pattern matched but item name not extractable")
+            return RouterResult.Unrouted
+        }
+        val result = clothingDao.getWearCountByName(itemName) ?: run {
+            Timber.d("ChatRouter: no item matched name query '%s'", itemName)
+            return RouterResult.Unrouted
+        }
+        val timesLabel = if (result.wearCount == 1) "time" else "times"
+        return RouterResult.Routed(
+            ChatResponse.WithStat(
+                text = "You've worn your ${result.name} ${result.wearCount} $timesLabel.",
+                label = "Wear count",
+                value = "${result.wearCount} $timesLabel",
+                itemIds = listOf(result.id),
+            )
+        )
+    }
+
+    private suspend fun routeNotWornSince(lower: String): RouterResult {
+        val days = extractDays(lower) ?: DEFAULT_UNWORN_DAYS
+        val cutoffDate = LocalDate.now().minusDays(days.toLong()).toString()
+        val items = clothingDao.getItemsNotWornSince(cutoffDate)
+
+        val itemsLabel = if (items.size == 1) "item" else "items"
+        val text = if (items.isEmpty()) {
+            "You've worn everything in the last $days days — nice work!"
+        } else {
+            "You have ${items.size} $itemsLabel you haven't worn in the last $days days."
+        }
+        return RouterResult.Routed(
+            ChatResponse.WithStat(
+                text = text,
+                label = "Unworn for $days+ days",
+                value = "${items.size} $itemsLabel",
+                itemIds = items.map { it.id },
+            )
+        )
+    }
+
+    private suspend fun routeWornOn(lower: String): RouterResult {
+        val date = extractDate(lower) ?: run {
+            Timber.d("ChatRouter: worn-on pattern matched but date not parseable")
+            return RouterResult.Unrouted
+        }
+        val logs = logDao.getLogsForDateOnce(date)
+        val displayDate = formatDisplayDate(date)
+
+        val text = when {
+            logs.isEmpty() -> "No outfit was logged for $displayDate."
+            else -> {
+                val names = logs.mapNotNull { it.outfitName }.distinct()
+                if (names.isEmpty()) "You logged a wear on $displayDate."
+                else "On $displayDate you wore: ${names.joinToString(", ")}."
+            }
+        }
+        val outfitsLabel = if (logs.size == 1) "outfit" else "outfits"
+        return RouterResult.Routed(
+            ChatResponse.WithStat(
+                text = text,
+                label = "Worn on $displayDate",
+                value = if (logs.isEmpty()) "Nothing logged" else "${logs.size} $outfitsLabel",
+                itemIds = emptyList(),
+            )
+        )
+    }
+
+    // ── Extraction helpers ────────────────────────────────────────────────────
+
+    /**
+     * Extracts an item name from a wear-count query.
+     * Matches patterns like "how many times have i worn my grey blazer?" → "grey blazer".
+     * Returns null if no name can be confidently extracted.
+     */
+    private fun extractItemName(lower: String): String? {
+        val match = ITEM_NAME_PATTERN.find(lower) ?: return null
+        return match.groupValues[1].trim().removeSuffix("?").trim().takeIf { it.isNotBlank() }
+    }
+
+    /**
+     * Extracts a day count from a not-worn-since query.
+     * Matches "30 days", "2 weeks" (converted to days). Returns null for "lately"/"recently".
+     */
+    private fun extractDays(lower: String): Int? {
+        val match = DAYS_PATTERN.find(lower) ?: return null
+        val count = match.groupValues[1].toIntOrNull() ?: return null
+        val unit = match.groupValues[2]
+        return if ("week" in unit) count * 7 else count
+    }
+
+    /**
+     * Extracts and parses a date string from a worn-on query.
+     *
+     * Only handles unambiguous formats:
+     * - ISO: `2026-04-04`
+     * - Month Day: `April 4`, `April 4th`, `Apr 4`
+     * - Month Day Year: `April 4, 2026`
+     *
+     * Returns an ISO date string (YYYY-MM-DD) or null if unparseable.
+     */
+    private fun extractDate(lower: String): String? {
+        // ISO date
+        ISO_DATE_PATTERN.find(lower)?.value?.let { return it }
+
+        // "Month Day" or "Month Day, Year"
+        val monthMatch = MONTH_DAY_PATTERN.find(lower) ?: return null
+        val monthStr = monthMatch.groupValues[1]
+        val dayStr = monthMatch.groupValues[2].replace(Regex("st|nd|rd|th"), "")
+        val yearStr = monthMatch.groupValues[3].trim().trimStart(',').trim()
+
+        val year = yearStr.toIntOrNull() ?: LocalDate.now().year
+        val monthNum = MONTH_NAMES[monthStr.lowercase(Locale.ENGLISH)] ?: return null
+
+        return try {
+            LocalDate.of(year, monthNum, dayStr.toInt()).format(DateTimeFormatter.ISO_LOCAL_DATE)
+        } catch (e: DateTimeParseException) {
+            null
+        } catch (e: Exception) {
+            null
+        }
+    }
+
+    private fun formatDisplayDate(isoDate: String): String = try {
+        LocalDate.parse(isoDate).format(DateTimeFormatter.ofPattern("MMMM d, yyyy", Locale.ENGLISH))
+    } catch (e: Exception) {
+        isoDate
+    }
+
+    // ── Constants ─────────────────────────────────────────────────────────────
+
+    companion object {
+        private const val DEFAULT_UNWORN_DAYS = 30
+
+        private val ITEM_NAME_PATTERN = Regex(
+            """(?:how many times (?:have i |did i |i've )?worn|worn) (?:my |the )?(.+?)(?:\?|$)"""
+        )
+
+        private val DAYS_PATTERN = Regex("""(\d+)\s*(days?|weeks?)""")
+
+        private val ISO_DATE_PATTERN = Regex("""\d{4}-\d{2}-\d{2}""")
+
+        private val MONTH_DAY_PATTERN = Regex(
+            """(january|february|march|april|may|june|july|august|september|october|november|december|""" +
+            """jan|feb|mar|apr|jun|jul|aug|sep|oct|nov|dec)\.?\s+(\d{1,2}(?:st|nd|rd|th)?),?\s*(\d{4})?""",
+            RegexOption.IGNORE_CASE
+        )
+
+        private val MONTH_NAMES = mapOf(
+            "january" to 1, "jan" to 1,
+            "february" to 2, "feb" to 2,
+            "march" to 3, "mar" to 3,
+            "april" to 4, "apr" to 4,
+            "may" to 5,
+            "june" to 6, "jun" to 6,
+            "july" to 7, "jul" to 7,
+            "august" to 8, "aug" to 8,
+            "september" to 9, "sep" to 9,
+            "october" to 10, "oct" to 10,
+            "november" to 11, "nov" to 11,
+            "december" to 12, "dec" to 12,
+        )
+    }
+}

--- a/app-android/features/chat/src/main/kotlin/com/closet/features/chat/ChatRouter.kt
+++ b/app-android/features/chat/src/main/kotlin/com/closet/features/chat/ChatRouter.kt
@@ -20,10 +20,15 @@ import javax.inject.Singleton
  * them directly from DAO queries without going through the RAG + provider pipeline.
  * Faster, zero token cost, works fully offline.
  *
- * Three patterns are handled (per the Phase 2 spec — don't expand speculatively):
+ * Eight patterns are handled:
  * 1. "How many times have I worn [item]?" → [ClothingDao.getWearCountByName]
  * 2. "What haven't I worn in [N] days?"   → [ClothingDao.getItemsNotWornSince]
  * 3. "What did I wear on [date]?"         → [LogDao.getLogsForDateOnce]
+ * 4. "What have I never worn?"            → [ClothingDao.getItemsNeverWorn]
+ * 5. "What's in my laundry?"             → [ClothingDao.getItemsNeedingWash]
+ * 6. "What did I wear last?"             → [LogDao.getMostRecentLog]
+ * 7. "How many items do I own?"          → [ClothingDao.getItemCount]
+ * 8. "What's my most worn item?"         → [ClothingDao.getMostWornItem]
  *
  * If a pattern doesn't match confidently, or the DAO returns an ambiguous result,
  * [RouterResult.Unrouted] is returned and the caller falls through to RAG.
@@ -57,9 +62,15 @@ class ChatRouter @Inject constructor(
         val lower = message.lowercase(Locale.ENGLISH).trim()
 
         return when {
+            // Order matters: neverWorn before notWornSince (both contain "worn")
+            matchesNeverWorn(lower)    -> routeNeverWorn()
             matchesWearCount(lower)    -> routeWearCount(lower)
             matchesNotWornSince(lower) -> routeNotWornSince(lower)
             matchesWornOn(lower)       -> routeWornOn(lower)
+            matchesNeedsWash(lower)    -> routeNeedsWash()
+            matchesLastOutfit(lower)   -> routeLastOutfit()
+            matchesItemCount(lower)    -> routeItemCount()
+            matchesMostWorn(lower)     -> routeMostWorn()
             else                       -> RouterResult.Unrouted
         }
     }
@@ -93,6 +104,36 @@ class ChatRouter @Inject constructor(
         "what did i wear on" in lower ||
         "what was i wearing on" in lower ||
         "wore on" in lower
+
+    private fun matchesNeverWorn(lower: String): Boolean =
+        "never worn" in lower ||
+        "never been worn" in lower ||
+        ("never" in lower && "wear" in lower)
+
+    private fun matchesNeedsWash(lower: String): Boolean =
+        "laundry" in lower ||
+        "needs washing" in lower ||
+        "needs to be washed" in lower ||
+        "need to wash" in lower ||
+        ("dirty" in lower && ("clothes" in lower || "items" in lower || "what" in lower))
+
+    private fun matchesLastOutfit(lower: String): Boolean =
+        "what did i wear last" in lower ||
+        "what was i wearing last" in lower ||
+        "last outfit" in lower ||
+        "wore last" in lower ||
+        "most recent outfit" in lower
+
+    private fun matchesItemCount(lower: String): Boolean =
+        ("how many" in lower && ("items" in lower || "clothes" in lower || "pieces" in lower)) ||
+        "how big is my wardrobe" in lower ||
+        "size of my wardrobe" in lower
+
+    private fun matchesMostWorn(lower: String): Boolean =
+        "most worn" in lower ||
+        "wear the most" in lower ||
+        "what do i wear most" in lower ||
+        "most frequently worn" in lower
 
     // ── Routing handlers ─────────────────────────────────────────────────────
 
@@ -160,6 +201,96 @@ class ChatRouter @Inject constructor(
                 label = "Worn on $displayDate",
                 value = if (logs.isEmpty()) "Nothing logged" else "${logs.size} $outfitsLabel",
                 itemIds = emptyList(),
+            )
+        )
+    }
+
+    private suspend fun routeNeverWorn(): RouterResult {
+        val items = clothingDao.getItemsNeverWorn()
+        val itemsLabel = if (items.size == 1) "item" else "items"
+        val text = if (items.isEmpty()) {
+            "You've worn everything in your wardrobe — impressive!"
+        } else {
+            "You have ${items.size} $itemsLabel you've never worn."
+        }
+        return RouterResult.Routed(
+            ChatResponse.WithStat(
+                text = text,
+                label = "Never worn",
+                value = "${items.size} $itemsLabel",
+                itemIds = items.map { it.id },
+            )
+        )
+    }
+
+    private suspend fun routeNeedsWash(): RouterResult {
+        val items = clothingDao.getItemsNeedingWash()
+        val itemsLabel = if (items.size == 1) "item" else "items"
+        val text = if (items.isEmpty()) {
+            "Your laundry is all clear — nothing needs washing."
+        } else {
+            "You have ${items.size} $itemsLabel in your laundry."
+        }
+        return RouterResult.Routed(
+            ChatResponse.WithStat(
+                text = text,
+                label = "Needs washing",
+                value = "${items.size} $itemsLabel",
+                itemIds = items.map { it.id },
+            )
+        )
+    }
+
+    private suspend fun routeLastOutfit(): RouterResult {
+        val log = logDao.getMostRecentLog() ?: return RouterResult.Routed(
+            ChatResponse.WithStat(
+                text = "You haven't logged any outfits yet.",
+                label = "Last worn",
+                value = "Nothing logged",
+            )
+        )
+        val displayDate = formatDisplayDate(log.date)
+        val text = if (log.outfitName != null) {
+            "Your last logged outfit was ${log.outfitName} on $displayDate."
+        } else {
+            "Your last logged wear was on $displayDate."
+        }
+        return RouterResult.Routed(
+            ChatResponse.WithStat(
+                text = text,
+                label = "Last worn",
+                value = displayDate,
+            )
+        )
+    }
+
+    private suspend fun routeItemCount(): RouterResult {
+        val count = clothingDao.getItemCount()
+        val itemsLabel = if (count == 1) "item" else "items"
+        return RouterResult.Routed(
+            ChatResponse.WithStat(
+                text = "You have $count $itemsLabel in your wardrobe.",
+                label = "Wardrobe size",
+                value = "$count $itemsLabel",
+            )
+        )
+    }
+
+    private suspend fun routeMostWorn(): RouterResult {
+        val result = clothingDao.getMostWornItem() ?: return RouterResult.Routed(
+            ChatResponse.WithStat(
+                text = "You haven't logged any wears yet.",
+                label = "Most worn",
+                value = "Nothing logged",
+            )
+        )
+        val timesLabel = if (result.wearCount == 1) "time" else "times"
+        return RouterResult.Routed(
+            ChatResponse.WithStat(
+                text = "Your most worn item is the ${result.name}, worn ${result.wearCount} $timesLabel.",
+                label = "Most worn",
+                value = "${result.wearCount} $timesLabel",
+                itemIds = listOf(result.id),
             )
         )
     }

--- a/app-android/features/chat/src/main/kotlin/com/closet/features/chat/ChatRouter.kt
+++ b/app-android/features/chat/src/main/kotlin/com/closet/features/chat/ChatRouter.kt
@@ -3,6 +3,9 @@ package com.closet.features.chat
 import com.closet.core.data.ai.ChatResponse
 import com.closet.core.data.dao.ClothingDao
 import com.closet.core.data.dao.LogDao
+import com.google.mlkit.nl.languageid.LanguageIdentification
+import com.google.mlkit.nl.languageid.LanguageIdentificationOptions
+import kotlinx.coroutines.tasks.await
 import timber.log.Timber
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
@@ -37,15 +40,42 @@ class ChatRouter @Inject constructor(
         data object Unrouted : RouterResult
     }
 
+    // Language identifier configured with a 0.7 confidence threshold.
+    // Returns "und" (undetermined) when confidence < threshold — treated as non-English.
+    private val languageIdentifier = LanguageIdentification.getClient(
+        LanguageIdentificationOptions.Builder()
+            .setConfidenceThreshold(LANGUAGE_CONFIDENCE_THRESHOLD)
+            .build()
+    )
+
     suspend fun route(message: String): RouterResult {
+        // Language guard: only route if the message is confidently English.
+        // Non-English or low-confidence input falls through to RAG, which handles
+        // multilingual prompts naturally via the provider.
+        if (!isEnglish(message)) return RouterResult.Unrouted
+
         val lower = message.lowercase(Locale.ENGLISH).trim()
 
         return when {
-            matchesWearCount(lower)   -> routeWearCount(lower)
+            matchesWearCount(lower)    -> routeWearCount(lower)
             matchesNotWornSince(lower) -> routeNotWornSince(lower)
-            matchesWornOn(lower)      -> routeWornOn(lower)
-            else                      -> RouterResult.Unrouted
+            matchesWornOn(lower)       -> routeWornOn(lower)
+            else                       -> RouterResult.Unrouted
         }
+    }
+
+    /**
+     * Returns true if ML Kit identifies [text] as English with confidence ≥ [LANGUAGE_CONFIDENCE_THRESHOLD].
+     * On any identification failure, logs the error and returns true so the router still runs —
+     * a false negative (routing a non-English query) is less harmful than silently dropping
+     * all routing for the session.
+     */
+    private suspend fun isEnglish(text: String): Boolean = try {
+        languageIdentifier.identifyLanguage(text).await() == "en"
+    } catch (e: Exception) {
+        if (e is kotlinx.coroutines.CancellationException) throw e
+        Timber.w(e, "ChatRouter: language identification failed, proceeding with routing")
+        true
     }
 
     // ── Pattern matching ──────────────────────────────────────────────────────
@@ -199,6 +229,7 @@ class ChatRouter @Inject constructor(
 
     companion object {
         private const val DEFAULT_UNWORN_DAYS = 30
+        private const val LANGUAGE_CONFIDENCE_THRESHOLD = 0.7f
 
         private val ITEM_NAME_PATTERN = Regex(
             """(?:how many times (?:have i |did i |i've )?worn|worn) (?:my |the )?(.+?)(?:\?|$)"""

--- a/app-android/features/chat/src/main/kotlin/com/closet/features/chat/ChatRouter.kt
+++ b/app-android/features/chat/src/main/kotlin/com/closet/features/chat/ChatRouter.kt
@@ -9,7 +9,6 @@ import kotlinx.coroutines.tasks.await
 import timber.log.Timber
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
-import java.time.format.DateTimeParseException
 import java.util.Locale
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -33,6 +32,7 @@ import javax.inject.Singleton
 class ChatRouter @Inject constructor(
     private val clothingDao: ClothingDao,
     private val logDao: LogDao,
+    private val dateParser: ChatDateParser,
 ) {
 
     sealed interface RouterResult {
@@ -138,7 +138,7 @@ class ChatRouter @Inject constructor(
     }
 
     private suspend fun routeWornOn(lower: String): RouterResult {
-        val date = extractDate(lower) ?: run {
+        val date = dateParser.parseDate(lower) ?: run {
             Timber.d("ChatRouter: worn-on pattern matched but date not parseable")
             return RouterResult.Unrouted
         }
@@ -187,38 +187,6 @@ class ChatRouter @Inject constructor(
         return if ("week" in unit) count * 7 else count
     }
 
-    /**
-     * Extracts and parses a date string from a worn-on query.
-     *
-     * Only handles unambiguous formats:
-     * - ISO: `2026-04-04`
-     * - Month Day: `April 4`, `April 4th`, `Apr 4`
-     * - Month Day Year: `April 4, 2026`
-     *
-     * Returns an ISO date string (YYYY-MM-DD) or null if unparseable.
-     */
-    private fun extractDate(lower: String): String? {
-        // ISO date
-        ISO_DATE_PATTERN.find(lower)?.value?.let { return it }
-
-        // "Month Day" or "Month Day, Year"
-        val monthMatch = MONTH_DAY_PATTERN.find(lower) ?: return null
-        val monthStr = monthMatch.groupValues[1]
-        val dayStr = monthMatch.groupValues[2].replace(Regex("st|nd|rd|th"), "")
-        val yearStr = monthMatch.groupValues[3].trim().trimStart(',').trim()
-
-        val year = yearStr.toIntOrNull() ?: LocalDate.now().year
-        val monthNum = MONTH_NAMES[monthStr.lowercase(Locale.ENGLISH)] ?: return null
-
-        return try {
-            LocalDate.of(year, monthNum, dayStr.toInt()).format(DateTimeFormatter.ISO_LOCAL_DATE)
-        } catch (e: DateTimeParseException) {
-            null
-        } catch (e: Exception) {
-            null
-        }
-    }
-
     private fun formatDisplayDate(isoDate: String): String = try {
         LocalDate.parse(isoDate).format(DateTimeFormatter.ofPattern("MMMM d, yyyy", Locale.ENGLISH))
     } catch (e: Exception) {
@@ -236,28 +204,5 @@ class ChatRouter @Inject constructor(
         )
 
         private val DAYS_PATTERN = Regex("""(\d+)\s*(days?|weeks?)""")
-
-        private val ISO_DATE_PATTERN = Regex("""\d{4}-\d{2}-\d{2}""")
-
-        private val MONTH_DAY_PATTERN = Regex(
-            """(january|february|march|april|may|june|july|august|september|october|november|december|""" +
-            """jan|feb|mar|apr|jun|jul|aug|sep|oct|nov|dec)\.?\s+(\d{1,2}(?:st|nd|rd|th)?),?\s*(\d{4})?""",
-            RegexOption.IGNORE_CASE
-        )
-
-        private val MONTH_NAMES = mapOf(
-            "january" to 1, "jan" to 1,
-            "february" to 2, "feb" to 2,
-            "march" to 3, "mar" to 3,
-            "april" to 4, "apr" to 4,
-            "may" to 5,
-            "june" to 6, "jun" to 6,
-            "july" to 7, "jul" to 7,
-            "august" to 8, "aug" to 8,
-            "september" to 9, "sep" to 9,
-            "october" to 10, "oct" to 10,
-            "november" to 11, "nov" to 11,
-            "december" to 12, "dec" to 12,
-        )
     }
 }

--- a/app-android/features/chat/src/main/kotlin/com/closet/features/chat/ChatScreen.kt
+++ b/app-android/features/chat/src/main/kotlin/com/closet/features/chat/ChatScreen.kt
@@ -349,6 +349,13 @@ private fun MessageList(
                     onLogIt = onNavigateToLog?.let { cb -> { cb(msg.items.map { it.id }) } },
                     onAlternatives = onNavigateToRecommendations,
                 )
+                is ChatMessage.Assistant.WithStat -> StatBubble(
+                    text = msg.text,
+                    label = msg.label,
+                    value = msg.value,
+                    items = msg.items,
+                    onItemTapped = onNavigateToItem,
+                )
                 is ChatMessage.Assistant.Thinking -> ThinkingBubble()
                 is ChatMessage.Assistant.Error -> ErrorBubble(msg.text)
             }
@@ -650,6 +657,65 @@ private fun OutfitImageCell(
                 modifier = Modifier.size(48.dp),
                 tint = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.38f),
             )
+        }
+    }
+}
+
+// ─── Bubble: stat card ────────────────────────────────────────────────────────
+
+@Composable
+private fun StatBubble(
+    text: String,
+    label: String,
+    value: String,
+    items: List<ChatItemSummary>,
+    onItemTapped: (Long) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier.fillMaxWidth(),
+        verticalArrangement = Arrangement.spacedBy(6.dp),
+    ) {
+        AssistantBubble(text)
+        Card(
+            modifier = Modifier.fillMaxWidth(0.92f),
+            colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant),
+            elevation = CardDefaults.cardElevation(defaultElevation = 2.dp),
+        ) {
+            Column(
+                modifier = Modifier.padding(horizontal = 16.dp, vertical = 12.dp),
+                verticalArrangement = Arrangement.spacedBy(10.dp),
+            ) {
+                // Label / value row
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Text(
+                        text = label,
+                        style = MaterialTheme.typography.labelMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                    Text(
+                        text = value,
+                        style = MaterialTheme.typography.titleMedium,
+                        color = MaterialTheme.colorScheme.primary,
+                    )
+                }
+                // Optional item rail — only shown when items are present
+                if (items.isNotEmpty()) {
+                    HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant)
+                    LazyRow(
+                        horizontalArrangement = Arrangement.spacedBy(10.dp),
+                        contentPadding = PaddingValues(vertical = 2.dp),
+                    ) {
+                        items(items) { item ->
+                            ItemChip(item = item, onTap = { onItemTapped(item.id) })
+                        }
+                    }
+                }
+            }
         }
     }
 }

--- a/app-android/features/chat/src/main/kotlin/com/closet/features/chat/ChatViewModel.kt
+++ b/app-android/features/chat/src/main/kotlin/com/closet/features/chat/ChatViewModel.kt
@@ -71,11 +71,14 @@ class ChatViewModel @Inject constructor(
                 onSuccess = { response ->
                     val message = response.toAssistantMessage()
 
-                    // Commit to history only on success — failed attempts must not pollute context.
-                    history.add(ConversationTurn(ConversationTurn.Role.User, text))
-                    history.add(ConversationTurn(ConversationTurn.Role.Assistant, response.conversationText))
-                    // Cap at 6 turns (3 exchanges) — drop oldest first.
-                    while (history.size > 6) history.removeAt(0)
+                    // Routed stat responses are data answers — they don't belong in conversational
+                    // history. Follow-up questions on them fall through to RAG naturally.
+                    if (response !is ChatResponse.WithStat) {
+                        history.add(ConversationTurn(ConversationTurn.Role.User, text))
+                        history.add(ConversationTurn(ConversationTurn.Role.Assistant, response.conversationText))
+                        // Cap at 6 turns (3 exchanges) — drop oldest first.
+                        while (history.size > 6) history.removeAt(0)
+                    }
 
                     _uiState.update { state ->
                         state.copy(
@@ -109,6 +112,7 @@ class ChatViewModel @Inject constructor(
         is ChatResponse.Text -> ChatMessage.Assistant.Text(text)
         is ChatResponse.WithItems -> ChatMessage.Assistant.WithItems(text, lookupItems(itemIds))
         is ChatResponse.WithOutfit -> ChatMessage.Assistant.WithOutfit(text, lookupItems(itemIds), reason)
+        is ChatResponse.WithStat -> ChatMessage.Assistant.WithStat(text, label, value, lookupItems(itemIds))
     }
 
     /** The conversational text of any [ChatResponse], stored as the assistant's history turn. */
@@ -117,6 +121,7 @@ class ChatViewModel @Inject constructor(
             is ChatResponse.Text -> text
             is ChatResponse.WithItems -> text
             is ChatResponse.WithOutfit -> text
+            is ChatResponse.WithStat -> text
         }
 
     private suspend fun lookupItems(ids: List<Long>): List<ChatItemSummary> = try {

--- a/app-android/features/chat/src/main/kotlin/com/closet/features/chat/RegexDateParser.kt
+++ b/app-android/features/chat/src/main/kotlin/com/closet/features/chat/RegexDateParser.kt
@@ -1,0 +1,66 @@
+package com.closet.features.chat
+
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
+import java.util.Locale
+
+/**
+ * Regex-based date extraction shared between the full and FOSS [ChatDateParser] implementations.
+ *
+ * Only handles unambiguous, explicit date formats:
+ * - ISO:          `2026-04-04`
+ * - Month Day:    `April 4`, `April 4th`, `Apr 4`
+ * - Month + Year: `April 4, 2026`
+ *
+ * Relative expressions ("yesterday", "last Monday") are intentionally not handled here —
+ * those are the ML Kit Entity Extraction upgrade path in the full flavor.
+ *
+ * @return An ISO date string (`YYYY-MM-DD`) or `null` if no date can be parsed.
+ */
+internal fun regexParseDate(text: String): String? {
+    val lower = text.lowercase(Locale.ENGLISH)
+
+    // ISO date — fast path.
+    ISO_DATE_PATTERN.find(lower)?.value?.let { return it }
+
+    // "Month Day" or "Month Day, Year"
+    val match = MONTH_DAY_PATTERN.find(lower) ?: return null
+    val monthStr  = match.groupValues[1]
+    val dayStr    = match.groupValues[2].replace(ORDINAL_SUFFIX, "")
+    val yearStr   = match.groupValues[3].trim().trimStart(',').trim()
+
+    val year     = yearStr.toIntOrNull() ?: LocalDate.now().year
+    val monthNum = MONTH_NAMES[monthStr.lowercase(Locale.ENGLISH)] ?: return null
+
+    return try {
+        LocalDate.of(year, monthNum, dayStr.toInt())
+            .format(DateTimeFormatter.ISO_LOCAL_DATE)
+    } catch (e: Exception) {
+        null
+    }
+}
+
+private val ISO_DATE_PATTERN = Regex("""\d{4}-\d{2}-\d{2}""")
+
+private val MONTH_DAY_PATTERN = Regex(
+    """(january|february|march|april|may|june|july|august|september|october|november|december|""" +
+    """jan|feb|mar|apr|jun|jul|aug|sep|oct|nov|dec)\.?\s+(\d{1,2}(?:st|nd|rd|th)?),?\s*(\d{4})?""",
+    RegexOption.IGNORE_CASE
+)
+
+private val ORDINAL_SUFFIX = Regex("""st|nd|rd|th""")
+
+private val MONTH_NAMES = mapOf(
+    "january" to 1, "jan" to 1,
+    "february" to 2, "feb" to 2,
+    "march" to 3, "mar" to 3,
+    "april" to 4, "apr" to 4,
+    "may" to 5,
+    "june" to 6, "jun" to 6,
+    "july" to 7, "jul" to 7,
+    "august" to 8, "aug" to 8,
+    "september" to 9, "sep" to 9,
+    "october" to 10, "oct" to 10,
+    "november" to 11, "nov" to 11,
+    "december" to 12, "dec" to 12,
+)

--- a/app-android/features/chat/src/main/kotlin/com/closet/features/chat/model/ChatMessage.kt
+++ b/app-android/features/chat/src/main/kotlin/com/closet/features/chat/model/ChatMessage.kt
@@ -12,6 +12,12 @@ sealed interface ChatMessage {
             val items: List<ChatItemSummary>,
             val reason: String,
         ) : Assistant
+        data class WithStat(
+            val text: String,
+            val label: String,
+            val value: String,
+            val items: List<ChatItemSummary>,
+        ) : Assistant
         data object Thinking : Assistant
         data class Error(val text: String) : Assistant
     }

--- a/app-android/gradle/libs.versions.toml
+++ b/app-android/gradle/libs.versions.toml
@@ -32,6 +32,7 @@ mlkitGenaiPrompt = "1.0.0-beta1"
 mlkitGenaiImageDescription = "1.0.0-beta1"
 mlkitSubjectSegmentation = "16.0.0-beta1" # beta accepted; no stable release exists for this API
 mlkitLanguageId = "17.0.6"
+mlkitEntityExtraction = "16.0.0-beta6"
 kotlinxCoroutinesPlayServices = "1.10.2"
 work = "2.10.0"
 hiltWork = "1.2.0"
@@ -83,6 +84,7 @@ mlkit-genai-prompt = { group = "com.google.mlkit", name = "genai-prompt", versio
 mlkit-genai-image-description = { group = "com.google.mlkit", name = "genai-image-description", version.ref = "mlkitGenaiImageDescription" }
 mlkit-subject-segmentation = { group = "com.google.android.gms", name = "play-services-mlkit-subject-segmentation", version.ref = "mlkitSubjectSegmentation" }
 mlkit-language-id = { group = "com.google.mlkit", name = "language-id", version.ref = "mlkitLanguageId" }
+mlkit-entity-extraction = { group = "com.google.mlkit", name = "entity-extraction", version.ref = "mlkitEntityExtraction" }
 kotlinx-coroutines-play-services = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-play-services", version.ref = "kotlinxCoroutinesPlayServices" }
 androidx-work-runtime-ktx = { group = "androidx.work", name = "work-runtime-ktx", version.ref = "work" }
 androidx-hilt-work = { group = "androidx.hilt", name = "hilt-work", version.ref = "hiltWork" }

--- a/app-android/gradle/libs.versions.toml
+++ b/app-android/gradle/libs.versions.toml
@@ -31,6 +31,7 @@ ktor = "3.1.3"
 mlkitGenaiPrompt = "1.0.0-beta1"
 mlkitGenaiImageDescription = "1.0.0-beta1"
 mlkitSubjectSegmentation = "16.0.0-beta1" # beta accepted; no stable release exists for this API
+mlkitLanguageId = "17.0.6"
 kotlinxCoroutinesPlayServices = "1.10.2"
 work = "2.10.0"
 hiltWork = "1.2.0"
@@ -81,6 +82,7 @@ ktor-client-logging = { group = "io.ktor", name = "ktor-client-logging", version
 mlkit-genai-prompt = { group = "com.google.mlkit", name = "genai-prompt", version.ref = "mlkitGenaiPrompt" }
 mlkit-genai-image-description = { group = "com.google.mlkit", name = "genai-image-description", version.ref = "mlkitGenaiImageDescription" }
 mlkit-subject-segmentation = { group = "com.google.android.gms", name = "play-services-mlkit-subject-segmentation", version.ref = "mlkitSubjectSegmentation" }
+mlkit-language-id = { group = "com.google.mlkit", name = "language-id", version.ref = "mlkitLanguageId" }
 kotlinx-coroutines-play-services = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-play-services", version.ref = "kotlinxCoroutinesPlayServices" }
 androidx-work-runtime-ktx = { group = "androidx.work", name = "work-runtime-ktx", version.ref = "work" }
 androidx-hilt-work = { group = "androidx.hilt", name = "hilt-work", version.ref = "hiltWork" }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Intelligent chat routing for clothing stat queries (wear counts, items not worn, laundry needs, last outfit, totals)
  * Stat result cards with label/value display and optional item previews
  * Improved natural-language date parsing for time-based queries
  * Routed stat answers do not append to rolling chat history (follow-ups still use the normal assistant pipeline)

* **Chores**
  * App version bumped to 0.6.0
  * Added language detection and entity extraction support
<!-- end of auto-generated comment: release notes by coderabbit.ai -->