### PR TITLE
Implement chat action intents feature (v0.7.0)

### DIFF
--- a/app-android/CHANGELOG.md
+++ b/app-android/CHANGELOG.md
@@ -10,6 +10,52 @@ Versions correspond to `versionName` in `app/build.gradle.kts`.
 
 ---
 
+## [0.7.0] — 2026-04-04
+
+Phase 3 of the chat enhancement roadmap: action intents. The model can now embed
+a suggested next action in its response, surfaced as a chip below the message bubble.
+Also includes bug fixes to the Phase 2 router and DAO query correctness.
+
+### Added
+- **`ChatAction`** sealed interface (`LogOutfit(itemIds)`, `OpenItem(itemId)`,
+  `OpenRecommendations`) in `core/data/ai/`. Actions are optional — the model only
+  emits one when intent is unambiguous.
+- **Action field on `ChatResponse`** — `WithItems` and `WithOutfit` both gain an
+  optional `action: ChatAction?` field; `WithStat` and `Text` are unaffected.
+- **`ActionChipRow`** composable in `ChatScreen` — a single `AssistChip` rendered
+  below the message bubble when an action is present. `LogOutfit` routes through
+  the existing log confirmation flow (`onNavigateToLog`), never logging directly.
+  `OpenItem` opens the item detail screen; `OpenRecommendations` opens the
+  recommendations screen.
+- **`ChatResponseParser` action parsing** — optional `"action"` object is parsed
+  from provider JSON with silent failure: a missing, malformed, or type-mismatched
+  action block returns `null` and never fails the parent response. `log_outfit` is
+  only accepted on `"outfit"` responses with 2–4 item IDs.
+- **System prompt updated** — `ChatPromptPrefix.SYSTEM_PROMPT` documents the
+  `action` field with one example per action type and rules instructing the model
+  to omit the field rather than guess.
+
+### Fixed
+- **`LogDao` historical snapshot** — `LOGS_BY_DATE_QUERY` and `getMostRecentLog`
+  now join `outfit_log_items` (snapshot) instead of live `outfits`/`outfit_items`;
+  outfit renames and composition changes no longer retroactively rewrite historical
+  log display.
+- **`ChatRouter` language-ID fail-closed** — `isEnglish()` now returns `false` on
+  ML Kit failure instead of `true`; unresolvable language checks fall through to
+  RAG rather than risking a misrouted stat answer on non-English input.
+- **`ChatRouter` FOSS flavor split** — `ChatRouter` moved to flavor source sets;
+  full flavor retains ML Kit language ID and pattern routing; FOSS stub always
+  returns `Unrouted` so `kotlinx-coroutines-play-services` and `mlkit.language.id`
+  (both GMS-transitive) are excluded from the FOSS build.
+- **`matchesWornOn` false positives** — bare `"wore on"` substring replaced with
+  `WORE_ON_INTERROGATIVE_PATTERN` (`\bwhat\b.{0,15}\bi\b\s*\bwore on\b`);
+  incidental uses like "top I wore on Tuesday" no longer trigger the worn-on route.
+- **`getItemsNotWornSince` boundary** — DAO predicate changed from `>=` to `>`
+  so items last worn exactly N days ago correctly appear in "not worn in N days"
+  results.
+
+---
+
 ## [0.6.0] — 2026-04-04
 
 Phase 2 of the chat enhancement roadmap: intent routing for stat queries.
@@ -407,7 +453,8 @@ Phase 1 of the RAG pipeline (semantic descriptions + image captions).
 - Two product flavors: `full` (GMS / Play Services) and `foss` (no GMS,
   F-Droid target).
 
-[Unreleased]: https://github.com/Masked-Kunsiquat/closet/compare/v0.6.0...HEAD
+[Unreleased]: https://github.com/Masked-Kunsiquat/closet/compare/v0.7.0...HEAD
+[0.7.0]: https://github.com/Masked-Kunsiquat/closet/compare/v0.6.0...v0.7.0
 [0.6.0]: https://github.com/Masked-Kunsiquat/closet/compare/v0.5.0...v0.6.0
 [0.5.0]: https://github.com/Masked-Kunsiquat/closet/compare/v0.4.0...v0.5.0
 [0.4.0]: https://github.com/Masked-Kunsiquat/closet/compare/v0.3.0...v0.4.0

--- a/app-android/app/build.gradle.kts
+++ b/app-android/app/build.gradle.kts
@@ -37,8 +37,8 @@ android {
         applicationId = "com.closet"
         minSdk = libs.versions.minSdk.get().toInt()
         targetSdk = libs.versions.targetSdk.get().toInt()
-        versionCode = 8
-        versionName = "0.6.0"
+        versionCode = 9
+        versionName = "0.7.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {

--- a/app-android/core/data/src/main/kotlin/com/closet/core/data/ai/ChatAiProvider.kt
+++ b/app-android/core/data/src/main/kotlin/com/closet/core/data/ai/ChatAiProvider.kt
@@ -38,6 +38,24 @@ interface ChatAiProvider {
     ): Result<ChatResponse>
 }
 
+/**
+ * Optional next action embedded in a [ChatResponse].
+ *
+ * Surfaced as a chip row below the message — one tap triggers the action without leaving chat.
+ * The model only suggests an action when the intent is unambiguous; the parser rejects
+ * malformed or type-mismatched actions silently (falls back to no action).
+ */
+sealed interface ChatAction {
+    /** Log [itemIds] as a wear — routes through the existing log confirmation flow. */
+    data class LogOutfit(val itemIds: List<Long>) : ChatAction
+
+    /** Navigate to the detail screen for [itemId]. */
+    data class OpenItem(val itemId: Long) : ChatAction
+
+    /** Navigate to the recommendations screen. */
+    data object OpenRecommendations : ChatAction
+}
+
 /** Structured response returned by every [ChatAiProvider] implementation. */
 sealed interface ChatResponse {
     /** Plain conversational answer — no specific items to surface in the UI. */
@@ -46,15 +64,27 @@ sealed interface ChatResponse {
     /**
      * Answer references a set of specific wardrobe items (e.g. "haven't worn lately").
      * [itemIds] are resolved DB item IDs from the context block — always from the wardrobe.
+     * [action] is an optional next action the model suggests (e.g. [ChatAction.OpenItem]).
      */
-    data class WithItems(val text: String, val itemIds: List<Long>) : ChatResponse
+    data class WithItems(
+        val text: String,
+        val itemIds: List<Long>,
+        val action: ChatAction? = null,
+    ) : ChatResponse
 
     /**
      * Answer is an outfit suggestion.
      * [itemIds] are the 2–4 items forming the outfit.
      * [reason] is the AI's one-sentence rationale.
+     * [action] is an optional next action (e.g. [ChatAction.LogOutfit] — only accepted when
+     * [itemIds] has 2–4 entries, matching the outfit).
      */
-    data class WithOutfit(val text: String, val itemIds: List<Long>, val reason: String) : ChatResponse
+    data class WithOutfit(
+        val text: String,
+        val itemIds: List<Long>,
+        val reason: String,
+        val action: ChatAction? = null,
+    ) : ChatResponse
 
     /**
      * Answer is a direct data stat returned by [com.closet.features.chat.ChatRouter]

--- a/app-android/core/data/src/main/kotlin/com/closet/core/data/ai/ChatAiProvider.kt
+++ b/app-android/core/data/src/main/kotlin/com/closet/core/data/ai/ChatAiProvider.kt
@@ -46,7 +46,13 @@ interface ChatAiProvider {
  * malformed or type-mismatched actions silently (falls back to no action).
  */
 sealed interface ChatAction {
-    /** Log [itemIds] as a wear — routes through the existing log confirmation flow. */
+    /**
+     * Log [itemIds] as a wear — routes through the existing log confirmation flow.
+     *
+     * [itemIds] must contain between 2 and 4 entries (inclusive); the parser enforces
+     * this constraint and returns null for any action block that violates it. Callers
+     * constructing [LogOutfit] directly should ensure the same invariant.
+     */
     data class LogOutfit(val itemIds: List<Long>) : ChatAction
 
     /** Navigate to the detail screen for [itemId]. */

--- a/app-android/core/data/src/main/kotlin/com/closet/core/data/ai/ChatPromptPrefix.kt
+++ b/app-android/core/data/src/main/kotlin/com/closet/core/data/ai/ChatPromptPrefix.kt
@@ -32,5 +32,23 @@ object ChatPromptPrefix {
         - For "outfit": item_ids should be 2–4 items forming a complete outfit.
         - For "items": item_ids should be IDs directly relevant to the question.
         - Keep "text" concise and conversational (1–3 sentences).
+
+        Optional action field:
+        You may append an "action" object to suggest a single follow-up action when the intent
+        is completely unambiguous. Omit it when unsure — a missing action is always safe.
+
+        Log an outfit as worn today (only valid on "outfit" responses; item_ids must match the outfit):
+        {"type":"outfit","text":"...","item_ids":[1,2],"reason":"...","action":{"type":"log_outfit","item_ids":[1,2]}}
+
+        Open a specific item (use when the answer is about exactly one item):
+        {"type":"items","text":"...","item_ids":[42],"action":{"type":"open_item","item_id":42}}
+
+        Open the recommendations screen (use when the user is asking for outfit ideas generally):
+        {"type":"text","text":"...","action":{"type":"open_recommendations"}}
+
+        Action rules:
+        - Never suggest "log_outfit" unless the response is an outfit suggestion the user explicitly asked to wear.
+        - Never invent item_ids in the action that are not already in the response's item_ids.
+        - Omit the action field entirely rather than guessing.
     """.trimIndent()
 }

--- a/app-android/core/data/src/main/kotlin/com/closet/core/data/ai/ChatResponseParser.kt
+++ b/app-android/core/data/src/main/kotlin/com/closet/core/data/ai/ChatResponseParser.kt
@@ -1,6 +1,7 @@
 package com.closet.core.data.ai
 
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
@@ -12,8 +13,12 @@ import kotlinx.serialization.json.longOrNull
  *
  * Expected shape:
  * ```json
- * { "type": "text"|"items"|"outfit", "text": "...", "item_ids": [...], "reason": "..." }
+ * { "type": "text"|"items"|"outfit", "text": "...", "item_ids": [...], "reason": "...",
+ *   "action": { "type": "log_outfit"|"open_item"|"open_recommendations", ... } }
  * ```
+ *
+ * The `action` field is optional. Malformed or type-mismatched action objects are silently
+ * dropped (fall back to no action) so action parse failures never fail the whole response.
  *
  * Unknown `type` values fall back to [ChatResponse.Text] so new response types added
  * server-side degrade gracefully rather than crashing.
@@ -44,7 +49,7 @@ object ChatResponseParser {
                 if (ids.isEmpty()) throw IllegalArgumentException(
                     "'item_ids' is empty in chat response (type='items')"
                 )
-                ChatResponse.WithItems(text, ids)
+                ChatResponse.WithItems(text, ids, parseAction(obj, parentType = "items"))
             }
             "outfit" -> {
                 val idsElement = obj["item_ids"]
@@ -60,10 +65,41 @@ object ChatResponseParser {
                 if (reason.isNullOrBlank()) throw IllegalArgumentException(
                     "'reason' is missing or blank in outfit response"
                 )
-                ChatResponse.WithOutfit(text, ids, reason)
+                ChatResponse.WithOutfit(text, ids, reason, parseAction(obj, parentType = "outfit"))
             }
             else -> ChatResponse.Text(text)   // "text" + unknown types
         }
+    }
+
+    /**
+     * Parses the optional `"action"` object from [obj], returning null on any problem.
+     *
+     * [parentType] gates which action types are accepted:
+     * - `"log_outfit"` is only valid when [parentType] is `"outfit"` and the item count is 2–4.
+     * - `"open_item"` and `"open_recommendations"` are accepted for any parent type.
+     *
+     * All exceptions are swallowed so a bad action block never fails the parent response.
+     */
+    private fun parseAction(obj: JsonObject, parentType: String): ChatAction? = try {
+        val actionObj = obj["action"]?.jsonObject ?: return null
+        when (val actionType = actionObj["type"]?.jsonPrimitive?.content) {
+            "log_outfit" -> {
+                if (parentType != "outfit") return null
+                val ids = actionObj["item_ids"]?.jsonArray
+                    ?.mapNotNull { it.jsonPrimitive.longOrNull }
+                    ?: return null
+                if (ids.size !in 2..4) return null
+                ChatAction.LogOutfit(ids)
+            }
+            "open_item" -> {
+                val itemId = actionObj["item_id"]?.jsonPrimitive?.longOrNull ?: return null
+                ChatAction.OpenItem(itemId)
+            }
+            "open_recommendations" -> ChatAction.OpenRecommendations
+            else -> null.also { /* unknown action type — ignore */ }
+        }
+    } catch (_: Exception) {
+        null
     }
 
     /**

--- a/app-android/core/data/src/main/kotlin/com/closet/core/data/ai/ChatResponseParser.kt
+++ b/app-android/core/data/src/main/kotlin/com/closet/core/data/ai/ChatResponseParser.kt
@@ -49,7 +49,7 @@ object ChatResponseParser {
                 if (ids.isEmpty()) throw IllegalArgumentException(
                     "'item_ids' is empty in chat response (type='items')"
                 )
-                ChatResponse.WithItems(text, ids, parseAction(obj, parentType = "items"))
+                ChatResponse.WithItems(text, ids, parseAction(obj, parentType = "items", parentIds = ids))
             }
             "outfit" -> {
                 val idsElement = obj["item_ids"]
@@ -65,7 +65,7 @@ object ChatResponseParser {
                 if (reason.isNullOrBlank()) throw IllegalArgumentException(
                     "'reason' is missing or blank in outfit response"
                 )
-                ChatResponse.WithOutfit(text, ids, reason, parseAction(obj, parentType = "outfit"))
+                ChatResponse.WithOutfit(text, ids, reason, parseAction(obj, parentType = "outfit", parentIds = ids))
             }
             else -> ChatResponse.Text(text)   // "text" + unknown types
         }
@@ -78,21 +78,29 @@ object ChatResponseParser {
      * - `"log_outfit"` is only valid when [parentType] is `"outfit"` and the item count is 2–4.
      * - `"open_item"` and `"open_recommendations"` are accepted for any parent type.
      *
+     * [parentIds] is the list of item IDs from the parent response. Action IDs are validated
+     * against it: every ID in a `log_outfit` or `open_item` action must appear in [parentIds]
+     * and be a positive Long. Any mismatch returns null so the parent response still succeeds.
+     *
      * All exceptions are swallowed so a bad action block never fails the parent response.
      */
-    private fun parseAction(obj: JsonObject, parentType: String): ChatAction? = try {
+    private fun parseAction(obj: JsonObject, parentType: String, parentIds: List<Long>): ChatAction? = try {
         val actionObj = obj["action"]?.jsonObject ?: return null
-        when (val actionType = actionObj["type"]?.jsonPrimitive?.content) {
+        when (actionObj["type"]?.jsonPrimitive?.content) {
             "log_outfit" -> {
                 if (parentType != "outfit") return null
-                val ids = actionObj["item_ids"]?.jsonArray
-                    ?.mapNotNull { it.jsonPrimitive.longOrNull }
-                    ?: return null
+                val idsArray = actionObj["item_ids"]?.jsonArray ?: return null
+                val ids = idsArray.map {
+                    it.jsonPrimitive.longOrNull?.takeIf { id -> id > 0 } ?: return null
+                }
                 if (ids.size !in 2..4) return null
+                if (!parentIds.containsAll(ids)) return null
                 ChatAction.LogOutfit(ids)
             }
             "open_item" -> {
-                val itemId = actionObj["item_id"]?.jsonPrimitive?.longOrNull ?: return null
+                val itemId = actionObj["item_id"]?.jsonPrimitive?.longOrNull
+                    ?.takeIf { it > 0 } ?: return null
+                if (itemId !in parentIds) return null
                 ChatAction.OpenItem(itemId)
             }
             "open_recommendations" -> ChatAction.OpenRecommendations

--- a/app-android/docs/roadmaps/chat-enhance-roadmap.md
+++ b/app-android/docs/roadmaps/chat-enhance-roadmap.md
@@ -87,16 +87,16 @@ The model can embed a suggested next action in its response. The UI surfaces it 
 
 ### New response fields
 
-- [ ] Add optional `action: ChatAction?` field to `ChatResponse.WithOutfit` and `ChatResponse.WithItems`
+- [x] Add optional `action: ChatAction?` field to `ChatResponse.WithOutfit` and `ChatResponse.WithItems`
   - `ChatAction` sealed class: `LogOutfit(itemIds)`, `OpenItem(itemId)`, `OpenRecommendations`
   - Keep it as an optional field, not a new response type — actions always accompany content
-- [ ] Update `ChatResponseParser` to parse an optional `"action"` object: `{"type":"log_outfit","item_ids":[…]}`
-- [ ] Update `ChatPromptPrefix.SYSTEM_PROMPT` to describe the optional `action` field with examples; make it clear the model should only suggest it when the intent is unambiguous
+- [x] Update `ChatResponseParser` to parse an optional `"action"` object: `{"type":"log_outfit","item_ids":[…]}`
+- [x] Update `ChatPromptPrefix.SYSTEM_PROMPT` to describe the optional `action` field with examples; make it clear the model should only suggest it when the intent is unambiguous
 
 ### ViewModel
 
-- [ ] Map `ChatAction` through `ChatMessage` to the UI — actions are stored on the message, not triggered automatically
-- [ ] No new ViewModel functions needed — existing `onNavigateToLog`, `onNavigateToItem`, `onNavigateToRecommendations` lambdas cover all three action types
+- [x] Map `ChatAction` through `ChatMessage` to the UI — actions are stored on the message, not triggered automatically
+- [x] No new ViewModel functions needed — existing `onNavigateToLog`, `onNavigateToItem`, `onNavigateToRecommendations` lambdas cover all three action types
 
 ### Screen
 

--- a/app-android/docs/roadmaps/chat-enhance-roadmap.md
+++ b/app-android/docs/roadmaps/chat-enhance-roadmap.md
@@ -100,8 +100,8 @@ The model can embed a suggested next action in its response. The UI surfaces it 
 
 ### Screen
 
-- [ ] Add `ActionChipRow` composable below `AssistantBubbleWithItems` and `AssistantBubbleWithOutfit` when an action is present
-- [ ] Tapping the chip calls the appropriate existing navigation lambda — no new navigation wiring needed beyond what's already in `ChatScreen`'s parameter list
+- [x] Add `ActionChipRow` composable below `AssistantBubbleWithItems` and `AssistantBubbleWithOutfit` when an action is present
+- [x] Tapping the chip calls the appropriate existing navigation lambda — no new navigation wiring needed beyond what's already in `ChatScreen`'s parameter list
 
 ### Pitfalls
 

--- a/app-android/docs/roadmaps/chat-test-roadmap.md
+++ b/app-android/docs/roadmaps/chat-test-roadmap.md
@@ -1,0 +1,200 @@
+# Chat Enhancement — Test Coverage Roadmap
+
+Tests for the completed phases of `chat-enhance-roadmap.md` (Phases 1–3).  
+Target: **0.7.1**. No new Gradle dependencies required — MockK, Turbine, and `coroutines-test` are already in `libs.versions.toml`.
+
+---
+
+## Files to create
+
+```
+features/chat/src/test/kotlin/com/closet/features/chat/
+    ChatResponseParserTest.kt
+    RegexDateParserTest.kt
+    ChatViewModelTest.kt
+    ChatRouterPatternTest.kt
+```
+
+---
+
+## 1 — `ChatResponseParserTest`
+
+Pure logic, no Android or GMS dependencies. Highest value per line of test code.
+
+### JSON extraction (`extractJson`)
+
+- [ ] Plain `{…}` — returned as-is
+- [ ] Markdown-fenced ` ```json\n{…}\n``` ` — inner block extracted
+- [ ] Markdown fence without `json` tag — inner block extracted
+- [ ] Prose with embedded `{…}` — outermost braces extracted
+- [ ] No `{…}` found — original string returned (parse failure surfaced by caller)
+
+### `text` type
+
+- [ ] Valid `{"type":"text","text":"hello"}` → `ChatResponse.Text("hello")`
+- [ ] Missing `text` field → `Result.failure`
+- [ ] Missing `type` field → `Result.failure`
+
+### `items` type
+
+- [ ] Valid with `item_ids` → `ChatResponse.WithItems` with correct IDs
+- [ ] Missing `item_ids` → `Result.failure`
+- [ ] Empty `item_ids` → `Result.failure`
+- [ ] Non-long entry in `item_ids` → `Result.failure`
+
+### `outfit` type
+
+- [ ] Valid with 2–4 IDs and `reason` → `ChatResponse.WithOutfit`
+- [ ] 1 ID → `Result.failure` (too few)
+- [ ] 5 IDs → `Result.failure` (too many)
+- [ ] Missing `reason` → `Result.failure`
+- [ ] Blank `reason` → `Result.failure`
+- [ ] Missing `item_ids` → `Result.failure`
+
+### Unknown type
+
+- [ ] `{"type":"unknown","text":"hi"}` → `ChatResponse.Text("hi")` (graceful fallback)
+- [ ] Future type `"widget"` with valid `text` → `ChatResponse.Text`
+
+### Action parsing — `log_outfit`
+
+- [ ] Accepted on `outfit` parent with 2–4 IDs → `ChatAction.LogOutfit`
+- [ ] Rejected on `items` parent → `action = null`, parent response still succeeds
+- [ ] 1 ID → `action = null`
+- [ ] 5 IDs → `action = null`
+- [ ] Missing `item_ids` in action block → `action = null`
+
+### Action parsing — `open_item`
+
+- [ ] Valid `item_id` → `ChatAction.OpenItem(id)`
+- [ ] Missing `item_id` → `action = null`
+- [ ] `item_id` is a string, not a number → `action = null`
+
+### Action parsing — `open_recommendations`
+
+- [ ] `{"type":"open_recommendations"}` → `ChatAction.OpenRecommendations`
+- [ ] Accepted on both `items` and `outfit` parent types
+
+### Action parsing — error isolation
+
+- [ ] Unknown action type → `action = null`, parent response still succeeds
+- [ ] Malformed action block (invalid JSON fragment) → `action = null`, parent still succeeds
+- [ ] Missing `action` field entirely → `action = null`
+
+---
+
+## 2 — `RegexDateParserTest`
+
+`regexParseDate()` is an `internal fun` in `RegexDateParser.kt` — no mocking needed.
+
+### ISO dates
+
+- [ ] `"2026-04-04"` → `"2026-04-04"`
+- [ ] ISO date embedded in a sentence → extracted correctly
+- [ ] Malformed ISO-looking string `"2026-13-01"` → `null` (invalid date)
+
+### Month Day patterns
+
+- [ ] `"April 4"` → `"2026-04-04"` (current year assumed)
+- [ ] `"April 4th"` → `"2026-04-04"` (ordinal suffix stripped)
+- [ ] `"Apr 4"` → `"2026-04-04"` (abbreviated month)
+- [ ] `"april 4, 2025"` → `"2025-04-04"` (explicit year used)
+- [ ] All 12 full month names → correct month number
+- [ ] All abbreviated month names → correct month number
+- [ ] `"April 31"` → `null` (invalid day for month)
+
+### Unhandled patterns (must return `null`)
+
+- [ ] `"yesterday"`
+- [ ] `"last Monday"`
+- [ ] `"3 days ago"`
+- [ ] Blank string
+- [ ] Garbage input `"wear count"`
+
+---
+
+## 3 — `ChatViewModelTest`
+
+Follows the `StatsViewModelTest` pattern: MockK + Turbine + `UnconfinedTestDispatcher`.
+
+Fake `ChatRepository` with a `mockk` that returns configurable `Result<ChatResponse>`.  
+Fake `ClothingDao.getItemDetailsByIds()` returning empty list (no image lookups needed).  
+Fake `StorageRepository` and `EmbeddingIndex` as no-ops.
+
+### Message flow
+
+- [ ] `sendMessage()` with blank input → no state change, no repository call
+- [ ] `sendMessage()` while `isLoading = true` → no-op (second call ignored)
+- [ ] Successful response → `Thinking` placeholder replaced by assistant message; `isLoading = false`
+- [ ] Failed response → `Thinking` replaced by `ChatMessage.Assistant.Error`; `isLoading = false`
+- [ ] Failed response → `isLoading = false` (loading not stuck)
+
+### History — Phase 1
+
+- [ ] Successful `Text` response → `history` gains 2 turns (user + assistant)
+- [ ] Failed response → `history` unchanged
+- [ ] After 3 successful exchanges → history has 6 turns
+- [ ] After 4th successful exchange → history still 6 turns (oldest pair dropped)
+- [ ] History snapshot taken before launch (in-flight message not in snapshot)
+
+### History — Phase 2 stat responses
+
+- [ ] `WithStat` response → `history` **not** updated
+- [ ] Follow-up after a stat → history still reflects only non-stat turns
+
+### `clearChat()`
+
+- [ ] `messages` list reset to empty
+- [ ] `history` reset (subsequent send passes empty history to repository)
+- [ ] `inputText` cleared
+
+### `toAssistantMessage()` mapping
+
+- [ ] `ChatResponse.Text` → `ChatMessage.Assistant.Text`
+- [ ] `ChatResponse.WithItems` with action → `ChatMessage.Assistant.WithItems` with action preserved
+- [ ] `ChatResponse.WithOutfit` with action → `ChatMessage.Assistant.WithOutfit` with action preserved
+- [ ] `ChatResponse.WithStat` → `ChatMessage.Assistant.WithStat`
+
+---
+
+## 4 — `ChatRouterPatternTest`
+
+The full-flavor `ChatRouter` calls `LanguageIdentification.getClient()` at construction time, which requires GMS. Two layers to test without instrumented setup:
+
+**Layer A — FOSS stub**: trivial but worth having as a smoke test.
+
+- [ ] FOSS `ChatRouter.route(anyString)` always returns `Unrouted`
+
+**Layer B — Regex/pattern helpers** (full flavor): the companion `val` patterns are accessible directly. Test them without constructing `ChatRouter`.
+
+### `ITEM_NAME_PATTERN`
+
+- [ ] `"how many times have i worn my grey blazer"` → captures `"grey blazer"`
+- [ ] `"how many times worn my black jeans?"` → captures `"black jeans"`
+- [ ] `"wear count for the white shirt"` → captures `"white shirt"`
+- [ ] Query with no item name → no match
+
+### `DAYS_PATTERN`
+
+- [ ] `"30 days"` → count 30, unit days → 30
+- [ ] `"2 weeks"` → count 2, unit weeks → 14
+- [ ] `"1 week"` → 7
+- [ ] `"lately"` → no match (falls back to `DEFAULT_UNWORN_DAYS`)
+
+### `WORE_ON_INTERROGATIVE_PATTERN`
+
+- [ ] `"what did i wore on tuesday"` → matches
+- [ ] `"what goes with what i wore on tuesday"` — gap between `what` and `i` is > 15 chars → no match (false-positive guard)
+
+### Pattern priority (never-worn before not-worn-since)
+
+- [ ] `"what have i never worn"` matches `matchesNeverWorn`, not `matchesNotWornSince`
+  - Verify by checking only `matchesNeverWorn` returns true and `matchesNotWornSince` returns false for this input
+
+---
+
+## Pitfalls
+
+- **`LanguageIdentification.getClient()` in `ChatRouter` constructor** — do not instantiate full-flavor `ChatRouter` in unit tests. Test patterns via companion vals and test routing behaviour through `ChatRepository` with a mocked router instead.
+- **`embeddingIndex.size`** — `ChatViewModel` reads this at construction; stub it to return `> 0` to put the UI into the ready state by default.
+- **History is `private`** — assert indirectly: after a known number of sends, check the `history` list passed to the mock repository on the next `sendMessage()` call via `verify { repo.query(any(), capture(slot)) }`.

--- a/app-android/features/chat/src/main/kotlin/com/closet/features/chat/ChatScreen.kt
+++ b/app-android/features/chat/src/main/kotlin/com/closet/features/chat/ChatScreen.kt
@@ -71,6 +71,7 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import coil.compose.AsyncImage
+import com.closet.core.data.ai.ChatAction
 import com.closet.core.ui.theme.ClosetTheme
 import com.closet.features.chat.R
 import com.closet.features.chat.model.ChatItemSummary
@@ -340,6 +341,9 @@ private fun MessageList(
                     text = msg.text,
                     items = msg.items,
                     onItemTapped = onNavigateToItem,
+                    action = msg.action,
+                    onNavigateToLog = onNavigateToLog,
+                    onNavigateToRecommendations = onNavigateToRecommendations,
                 )
                 is ChatMessage.Assistant.WithOutfit -> AssistantBubbleWithOutfit(
                     text = msg.text,
@@ -348,6 +352,8 @@ private fun MessageList(
                     onItemTapped = onNavigateToItem,
                     onLogIt = onNavigateToLog?.let { cb -> { cb(msg.items.map { it.id }) } },
                     onAlternatives = onNavigateToRecommendations,
+                    action = msg.action,
+                    onNavigateToLog = onNavigateToLog,
                 )
                 is ChatMessage.Assistant.WithStat -> StatBubble(
                     text = msg.text,
@@ -428,6 +434,9 @@ private fun AssistantBubbleWithItems(
     text: String,
     items: List<ChatItemSummary>,
     onItemTapped: (Long) -> Unit,
+    action: ChatAction? = null,
+    onNavigateToLog: ((List<Long>) -> Unit)? = null,
+    onNavigateToRecommendations: () -> Unit = {},
 ) {
     Column(
         modifier = Modifier.fillMaxWidth(),
@@ -441,6 +450,14 @@ private fun AssistantBubbleWithItems(
             items(items) { item ->
                 ItemChip(item = item, onTap = { onItemTapped(item.id) })
             }
+        }
+        if (action != null) {
+            ActionChipRow(
+                action = action,
+                onNavigateToLog = onNavigateToLog,
+                onNavigateToItem = onItemTapped,
+                onNavigateToRecommendations = onNavigateToRecommendations,
+            )
         }
     }
 }
@@ -497,6 +514,8 @@ private fun AssistantBubbleWithOutfit(
     onItemTapped: (Long) -> Unit,
     onLogIt: (() -> Unit)?,
     onAlternatives: () -> Unit,
+    action: ChatAction? = null,
+    onNavigateToLog: ((List<Long>) -> Unit)? = null,
 ) {
     Column(
         modifier = Modifier.fillMaxWidth(),
@@ -510,6 +529,14 @@ private fun AssistantBubbleWithOutfit(
             onLogIt = onLogIt,
             onAlternatives = onAlternatives,
         )
+        if (action != null) {
+            ActionChipRow(
+                action = action,
+                onNavigateToLog = onNavigateToLog,
+                onNavigateToItem = onItemTapped,
+                onNavigateToRecommendations = onAlternatives,
+            )
+        }
     }
 }
 
@@ -658,6 +685,52 @@ private fun OutfitImageCell(
                 tint = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.38f),
             )
         }
+    }
+}
+
+// ─── Action chip row ──────────────────────────────────────────────────────────
+
+/**
+ * A single [AssistChip] surfacing the model's suggested next action.
+ * Rendered below the message bubble — one tap triggers the action without leaving chat.
+ * Tapping [ChatAction.LogOutfit] routes through the existing log confirmation flow via [onNavigateToLog].
+ */
+@Composable
+private fun ActionChipRow(
+    action: ChatAction,
+    onNavigateToLog: ((List<Long>) -> Unit)?,
+    onNavigateToItem: (Long) -> Unit,
+    onNavigateToRecommendations: () -> Unit,
+) {
+    val (label, icon, onClick) = when (action) {
+        is ChatAction.LogOutfit -> Triple(
+            stringResource(R.string.chat_action_chip_log_outfit),
+            Icons.Default.Checkroom,
+            { onNavigateToLog?.invoke(action.itemIds) },
+        )
+        is ChatAction.OpenItem -> Triple(
+            stringResource(R.string.chat_action_chip_view_item),
+            Icons.Default.Checkroom,
+            { onNavigateToItem(action.itemId) },
+        )
+        is ChatAction.OpenRecommendations -> Triple(
+            stringResource(R.string.chat_action_chip_explore_outfits),
+            Icons.Default.AutoAwesome,
+            onNavigateToRecommendations,
+        )
+    }
+    Row {
+        AssistChip(
+            onClick = onClick,
+            label = { Text(label, style = MaterialTheme.typography.labelMedium) },
+            leadingIcon = {
+                Icon(
+                    imageVector = icon,
+                    contentDescription = null,
+                    modifier = Modifier.size(16.dp),
+                )
+            },
+        )
     }
 }
 

--- a/app-android/features/chat/src/main/kotlin/com/closet/features/chat/ChatScreen.kt
+++ b/app-android/features/chat/src/main/kotlin/com/closet/features/chat/ChatScreen.kt
@@ -706,7 +706,7 @@ private fun ActionChipRow(
         is ChatAction.LogOutfit -> Triple(
             stringResource(R.string.chat_action_chip_log_outfit),
             Icons.Default.Checkroom,
-            { onNavigateToLog?.invoke(action.itemIds) },
+            { onNavigateToLog?.invoke(action.itemIds) ?: Unit },
         )
         is ChatAction.OpenItem -> Triple(
             stringResource(R.string.chat_action_chip_view_item),

--- a/app-android/features/chat/src/main/kotlin/com/closet/features/chat/ChatViewModel.kt
+++ b/app-android/features/chat/src/main/kotlin/com/closet/features/chat/ChatViewModel.kt
@@ -110,8 +110,8 @@ class ChatViewModel @Inject constructor(
 
     private suspend fun ChatResponse.toAssistantMessage(): ChatMessage.Assistant = when (this) {
         is ChatResponse.Text -> ChatMessage.Assistant.Text(text)
-        is ChatResponse.WithItems -> ChatMessage.Assistant.WithItems(text, lookupItems(itemIds))
-        is ChatResponse.WithOutfit -> ChatMessage.Assistant.WithOutfit(text, lookupItems(itemIds), reason)
+        is ChatResponse.WithItems -> ChatMessage.Assistant.WithItems(text, lookupItems(itemIds), action)
+        is ChatResponse.WithOutfit -> ChatMessage.Assistant.WithOutfit(text, lookupItems(itemIds), reason, action)
         is ChatResponse.WithStat -> ChatMessage.Assistant.WithStat(text, label, value, lookupItems(itemIds))
     }
 

--- a/app-android/features/chat/src/main/kotlin/com/closet/features/chat/model/ChatMessage.kt
+++ b/app-android/features/chat/src/main/kotlin/com/closet/features/chat/model/ChatMessage.kt
@@ -1,16 +1,22 @@
 package com.closet.features.chat.model
 
+import com.closet.core.data.ai.ChatAction
 import java.io.File
 
 sealed interface ChatMessage {
     data class User(val text: String) : ChatMessage
     sealed interface Assistant : ChatMessage {
         data class Text(val text: String) : Assistant
-        data class WithItems(val text: String, val items: List<ChatItemSummary>) : Assistant
+        data class WithItems(
+            val text: String,
+            val items: List<ChatItemSummary>,
+            val action: ChatAction? = null,
+        ) : Assistant
         data class WithOutfit(
             val text: String,
             val items: List<ChatItemSummary>,
             val reason: String,
+            val action: ChatAction? = null,
         ) : Assistant
         data class WithStat(
             val text: String,

--- a/app-android/features/chat/src/main/res/values/strings.xml
+++ b/app-android/features/chat/src/main/res/values/strings.xml
@@ -26,6 +26,11 @@
     <string name="chat_action_log_it">Log it</string>
     <string name="chat_action_alternatives">Alternatives \u2192</string>
 
+    <!-- Action intent chips -->
+    <string name="chat_action_chip_log_outfit">Log outfit</string>
+    <string name="chat_action_chip_view_item">View item</string>
+    <string name="chat_action_chip_explore_outfits">Explore outfits</string>
+
     <!-- Clear chat dialog -->
     <string name="chat_clear_dialog_title">Start new chat?</string>
     <string name="chat_clear_dialog_message">This will clear the current conversation. This can\'t be undone.</string>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Assistant messages can include action chips for logging outfits, viewing items, or exploring recommendations.

* **Bug Fixes**
  * Improved query accuracy, intent matching, and routing fallbacks for more reliable recommendations; corrected “not worn in N days” behavior.

* **Documentation**
  * Updated changelog and chat roadmaps with Phase 3 action intents and test coverage plans.

* **Release**
  * App version bumped to 0.7.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->